### PR TITLE
bump isort pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: reuse
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black


### PR DESCRIPTION
Enforce [newer `isort` version](https://github.com/PyCQA/isort/releases/tag/5.12.0) that [fixes compatibility](https://github.com/PyCQA/isort/pull/2078) with a backwards incompatible change in `poetry` (its packager).

Only new contributors that use `pre-commit` appear to be affected (due to caching of old `poetry` versions)