### PR TITLE
Fix read the docs equations

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,5 @@
+@import 'theme.css';    /* for the Read the Docs theme */
+
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/_static/css/custom.css.license
+++ b/docs/_static/css/custom.css.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+
+SPDX-License-Identifier: MPL-2.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,3 +107,6 @@ html_extra_path = ["google6d726d2d56f95e32.html"]
 # config doxygen for C API
 breathe_projects = {"power_grid_model_c": "./doxygen/build/xml/"}
 breathe_default_project = "power_grid_model_c"
+
+# Override theme CSS with style adjustments of our own
+html_style = "css/custom.css"


### PR DESCRIPTION
In the read the docs documentation, the equations exceed the line length. This should fix that