### PR TITLE
IDE presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -151,6 +151,42 @@
       "hidden": true
     },
     {
+      "name": "clang-release",
+      "inherits": [
+        "release",
+        "unix-base"
+      ]
+    },
+    {
+      "name": "clang-debug",
+      "inherits": [
+        "release",
+        "unix-base"
+      ]
+    },
+    {
+      "name": "gcc-base",
+      "environment": {
+        "COMPILER_CXX_FLAGS": "$env{COMPILER_C_FLAGS} -Wno-maybe-uninitialized"
+      },
+      "inherits": "unix-base",
+      "hidden": true
+    },
+    {
+      "name": "gcc-release",
+      "inherits": [
+        "release",
+        "gcc-base"
+      ]
+    },
+    {
+      "name": "gcc-debug",
+      "inherits": [
+        "debug",
+        "gcc-base"
+      ]
+    },
+    {
       "name": "ci-unix-release",
       "inherits": [
         "release",

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -42,17 +42,22 @@ You need a C++ compiler with C++20 support. Below is a list of tested compilers:
 **Linux**
 
 * gcc >= 10.0
-* clang >= 13.0
+  * Version 10.0 tested using the version in the `manylinux2014` container.
+  * Version 11.x tested in CI
+* Clang >= 14.0
+  * Version 14.x tested in CI
 
 You can define the environment variable `CXX` to for example `clang++` to specify the C++ compiler.
 
 **Windows**
 
-* MSVC >= 16.2 (Visual Studio 2019, IDE or build tools)
+* MSVC >= 17.5
+  * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 
 **macOS**
 
-* clang >= 13.0
+* Clang >= 14.0
+  * Latest release tested in CI
 
 ### Build System for CMake Project
 


### PR DESCRIPTION
* Disable coverage and sanitizer for IDE on Linux
  * this prevents the annoying false positive `profiling: /path/to/xyz.cpp.gcda: cannot merge previous run count: corrupt object tag` and `profiling: /path/to/xyz.cpp.gcda: cannot merge previous GCDA file: mismatched number of counters` warning messages from happening (see https://stackoverflow.com/questions/59259069/what-does-the-gcc-warning-coverage-mismatch-mean )
  * Introduces `clang-release`, `clang-debug`, `gcc-release` and `gcc-debug` presets (as opposed to `ci-*`)
* Update documentation on supported vs tested compiler versions