### PR TITLE
Configure and test conda build

### DIFF
--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -1,0 +1,11 @@
+name: conda-pgm-env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - wheel
+  - setuptools
+  - boost-cpp
+  - eigen
+  - numpy

--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -9,3 +9,5 @@ dependencies:
   - boost-cpp
   - eigen
   - numpy
+  - pytest
+  - pytest-cov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,7 +219,7 @@ jobs:
           pytest
 
 
-  publish:
+  publish-wheels:
     needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,11 +217,11 @@ jobs:
           conda info
           conda list
       
-      - name: Build and test
-        run: |
-          python -m pip install . -vv --no-build-isolation --no-deps
-          pytest
+      - name: Build
+        run: python -m pip install . -vv --no-build-isolation --no-deps   
 
+      - name: Test
+        run: pytest
 
   publish-wheels:
     needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,8 +124,6 @@ jobs:
   
   set-python-version-build-sdist:
     runs-on: ubuntu-latest
-    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos]
-
     steps:
       - uses: actions/checkout@v3
 
@@ -194,7 +192,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish-wheels:
-    needs: build-and-test-python
+    needs: needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,8 +193,13 @@ jobs:
 
 
   build-and-test-conda:
-    name: Build and test in Conda Linux
-    runs-on: ubuntu-latest
+    name: Build and test in Conda
+  
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+  
     defaults:
       run:
         shell: bash -el {0}
@@ -211,7 +216,6 @@ jobs:
         run: |
           conda info
           conda list
-          printenv | sort
       
       - name: Build and test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,8 +191,36 @@ jobs:
           name: wheelhouse
           path: ./wheelhouse/*.whl
 
-  publish-wheels:
-    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python]
+
+  build-and-test-conda:
+    name: Build and test in Conda Linux
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: conda-pgm-env
+          environment-file: .github/conda_pgm_env.yml
+          auto-activate-base: false
+      
+      - name: List conda
+        run: |
+          conda info
+          conda list
+          printenv | sort
+      
+      - name: Build and test
+        run: |
+          python -m pip install . -vv --no-build-isolation --no-deps
+          pytest
+
+
+  publish:
+    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish-wheels:
-    needs: needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python]
+    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,11 @@ doc = [
 ]
 
 [project.urls]
-Home-page = "https://github.com/PowerGridModel/power-grid-model"
+Home-page = "https://lfenergy.org/projects/power-grid-model/"
+GitHub = "https://github.com/PowerGridModel/power-grid-model"
 Documentation = "https://power-grid-model.readthedocs.io/en/stable/"
+Mailing-list = "https://lists.lfenergy.org/g/powergridmodel"
+Discussion = "https://github.com/orgs/PowerGridModel/discussions"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from sysconfig import get_paths
 from typing import List
 
 # noinspection PyPackageRequirements
-from pybuild_header_dependency import HeaderResolver
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
@@ -24,6 +23,43 @@ elif platform.system() in ["Linux", "Darwin"]:
     if_win = False
 else:
     raise SystemError("Only Windows, Linux, or MacOS is supported!")
+
+
+def get_header_include() -> List[str]:
+    """
+    Get header files from pybuild_header_dependency, if it is installed
+
+    Returns:
+        either empty list or a list of header path
+    """
+    try:
+        from pybuild_header_dependency import HeaderResolver
+
+        resolver = HeaderResolver({"eigen": None, "boost": None})
+        return [str(resolver.get_include())]
+    except ImportError:
+        return []
+
+
+def get_conda_include() -> List[str]:
+    """
+    Get conda include path, if we are inside conda environment
+
+    Returns:
+        either empty list or a list of header paths
+    """
+    if "CONDA_PREFIX" in os.environ:
+        conda_path = os.environ["CONDA_PREFIX"]
+        if if_win:
+            # windows has Library folder prefix
+            return [
+                os.path.join(conda_path, "Library", "include"),
+                os.path.join(conda_path, "Library", "include", "eigen3"),
+            ]
+        else:
+            return [os.path.join(conda_path, "include"), os.path.join(conda_path, "include", "eigen3")]
+    else:
+        return []
 
 
 # custom class for ctypes
@@ -89,16 +125,16 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
 
     """
     # fetch dependent headers
-    resolver = HeaderResolver({"eigen": None, "boost": None})
     pgm = Path("power_grid_model")
     pgm_c = Path("power_grid_model_c")
 
     # include-folders
     include_dirs = [
-        str(resolver.get_include()),
         str(pkg_dir / pgm_c / pgm / "include"),  # The include-folder of the library
         str(pkg_dir / pgm_c / pgm_c / "include"),  # The include-folder of the C API self
     ]
+    include_dirs += get_header_include()
+    include_dirs += get_conda_include()
     # compiler and link flag
     cflags: List[str] = []
     lflags: List[str] = []
@@ -129,11 +165,7 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     if if_win:
         # flag for C++20
         cflags += ["/std:c++20"]
-        include_dirs += [str(env_base_path / "Library" / "include")]
-        library_dirs += [str(env_base_path / "Library" / "lib")]
     else:
-        include_dirs += [str(env_base_path / "include"), get_paths()["platinclude"], get_paths()["include"]]
-        library_dirs += [str(env_base_path / "lib")]
         # flags for Linux and Mac
         cflags += [
             "-std=c++20",


### PR DESCRIPTION
# Purpose

This PR configures the build process for conda environment and adds relevant tests in the CI.

This is needed if we want to publish PGM into conda.

# Approach

`conda-build` does not use `pip` build isolations. `conda-forge` requires that all the build dependencies have to be installed from `conda-forge`. To satisfy this, `setup.py` is adjusted to either add include folder from `CONDA_PREFIX`, or use the `pip` package to fetch the header files.
