### PR TITLE
Add Musllinux support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,11 @@ build-frontend = "build"
 build-verbosity = 1
 test-extras = ["dev"]
 test-command = "pytest {package}/tests"
-# we do not support PyPy, musllinux
-skip = ["pp*", "*musllinux*"]
+# we do not support 
+#    PyPy
+#    musllinux when python < 3.9
+#    musllinux in aarch64
+skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ skip = ["pp*", "*musllinux*"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
-# force auditwheel to use manylinux_2_24 to support Amazon Linux 2
-environment = { CC="gcc", CXX="g++", AUDITWHEEL_PLAT="manylinux_2_24_$(uname -m)" }
+# force auditwheel to use manylinux_2_24 to support Amazon Linux 2 when building in manylinux_2_28
+environment = { CC="gcc", CXX="g++", AUDITWHEEL_PLAT="${AUDITWHEEL_PLAT//2_28/2_24}" }
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ archs = ["x86_64", "aarch64"]
 environment = { CC="gcc", CXX="g++", AUDITWHEEL_PLAT="${AUDITWHEEL_PLAT//2_28/2_24}" }
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_1"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
This PR adds `musllinux` support for `x86_64`. This is now possible because `numpy` supports `musllinux` from version `1.25`.