### PR TITLE
Add DOI citation badge

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -71,4 +71,3 @@ jobs:
             git status --porcelain --untracked-files=no
             exit 1
           fi
-     

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+name: Validate citation
+
+on:
+  # run pipeline on push event of main or release branch, or when CITATIONS path has changed
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - CITATION.cff
+
+  workflow_dispatch:
+
+jobs:
+  validate-citations:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Validate CITATION.cff
+      uses: dieghernan/cff-validator@v2.3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -29,6 +29,7 @@ build:
       # download support
       - wget -P docs/release_and_support https://github.com/PowerGridModel/.github/raw/main/RELEASE.md
       - wget -P docs/release_and_support https://github.com/PowerGridModel/.github/raw/main/SUPPORT.md
+      - wget -P docs/release_and_support https://github.com/PowerGridModel/.github/raw/main/CITATION.md
       # download contribution
       - wget -P docs/contribution https://github.com/PowerGridModel/.github/raw/main/GOVERNANCE.md
       - wget -P docs/contribution https://github.com/PowerGridModel/.github/raw/main/CONTRIBUTING.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+cff-version: 1.2.0
+message: "If you are using Power Grid Model in your research work, please consider citing our library as below."
+
+title: "PowerGridModel/power-grid-model"
+url: "https://github.com/PowerGridModel/power-grid-model"
+doi: "10.5281/zenodo.8054429"
+license: "MPL-2.0"
+authors:
+  - family-names: "Xiang"
+    given-names: "Yu"
+    email: "Tony.Xiang@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Salemink"
+    given-names: "Peter"
+    email: "Peter.Salemink@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Bharambe"
+    given-names: "Nitish"
+    email: "Nitish.Bharambe@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Govers"
+    given-names: "Martinus"
+    email: "Martijn.Govers@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Bogaard"
+    name-particle: "van den"
+    given-names: "Jonas"
+    email: "Jonas.van.den.Bogaard@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Stoeller"
+    given-names: "Bram"
+  - family-names: "Jagutis"
+    given-names: "Laurynas"
+    email: "Laurynas.Jagutis@Alliander.com"
+    affiliation: "Alliander"
+  - family-names: "Wang"
+    given-names: "Chenguang"
+    email: "Chenguang.Wang@Alliander.com"
+    affiliation: "Alliander"
+  - name: "Contributors from the LF Energy project Power Grid Model"
+contact:
+  - name: "LF Energy project Power Grid Model"
+    email: "powergridmodel+help@lists.lfenergy.org"
+
+references:
+  - title: "Power grid model: A high-performance distribution grid calculation library"
+    authors:
+      - family-names: "Xiang"
+        given-names: "Yu"
+        email: Tony.Xiang@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Salemink"
+        given-names: "Peter"
+        email: Peter.Salemink@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Stoeller"
+        given-names: "Bram"
+      - family-names: "Bharambe"
+        given-names: "Nitish"
+        email: Nitish.Bharambe@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Westering"
+        name-particle: "van"
+        given-names: "Werner"
+    conference:
+      name: "CIRED 2023 - The 27th International Conference and Exhibition on Electricity Distribution"
+    type: conference-paper
+    year: 2023
+    volume: 2023
+    pages: "1-5"
+
+  - title: "PowerGridModel/power-grid-model-io"
+    repository-code: "https://github.com/PowerGridModel/power-grid-model-io"
+    doi: "10.5281/zenodo.8059257"
+    type: software-code
+    authors:
+      - family-names: "Xiang"
+        given-names: "Yu"
+        email: Tony.Xiang@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Salemink"
+        given-names: "Peter"
+        email: Peter.Salemink@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Bharambe"
+        given-names: "Nitish"
+        email: Nitish.Bharambe@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Govers"
+        given-names: "Martinus"
+        email: "Martijn.Govers@Alliander.com"
+        affiliation: "Alliander"
+      - family-names: "Bogaard"
+        name-particle: "van den"
+        given-names: "Jonas"
+        email: Jonas.van.den.Bogaard@Alliander.com
+        affiliation: "Alliander"
+      - family-names: "Stoeller"
+        given-names: "Bram"
+      - family-names: "Jagutis"
+        given-names: "Laurynas"
+        email: "Laurynas.Jagutis@Alliander.com"
+        affiliation: "Alliander"
+      - family-names: "Wang"
+        given-names: "Chenguang"
+        email: "Chenguang.Wang@Alliander.com"
+        affiliation: "Alliander"
+      - name: "Contributors from the LF Energy project Power Grid Model"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,6 +76,7 @@ references:
   - title: "PowerGridModel/power-grid-model-io"
     repository-code: "https://github.com/PowerGridModel/power-grid-model-io"
     doi: "10.5281/zenodo.8059257"
+    license: "MPL-2.0"
     type: software-code
     authors:
       - family-names: "Xiang"

--- a/README.md
+++ b/README.md
@@ -84,14 +84,13 @@ Visit [Contribute](https://github.com/PowerGridModel/power-grid-model/contribute
 
 If you are using Power Grid Model in your research work, please consider citing our library using the following references.
 
-### Power Grid Model source code
-
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8054429.svg)](https://zenodo.org/record/8054429)
 
 ```bibtex
 @software{Xiang_PowerGridModel_power-grid-model,
-  author = {Xiang, Yu and Salemink, Peter and Bharambe, Nitish and Jagutis, Laurynas and Wang, Chenguang and van den Bogaard, Jonas and Govers, Martinus and Stoeller, Bram and {Contributors from the LF Energy project Power Grid Model}},
+  author = {Xiang, Yu and Salemink, Peter and Bharambe, Nitish and Govers, Martinus and van den Bogaard, Jonas and Stoeller, Bram and Jagutis, Laurynas and Wang, Chenguang and {Contributors from the LF Energy project Power Grid Model}},
   doi = {10.5281/zenodo.8054429},
+  license = {MPL-2.0},
   title = {{PowerGridModel/power-grid-model}},
   url = {https://github.com/PowerGridModel/power-grid-model}
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ SPDX-License-Identifier: MPL-2.0
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=PowerGridModel_power-grid-model&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=PowerGridModel_power-grid-model)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=PowerGridModel_power-grid-model&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=PowerGridModel_power-grid-model)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8054429.svg)](https://zenodo.org/record/8054429)
+
 [![](https://github.com/PowerGridModel/.github/blob/main/artwork/svg/color.svg)](#)
 
 # Power Grid Model
@@ -77,6 +79,32 @@ Please read [CODE_OF_CONDUCT](https://github.com/PowerGridModel/.github/blob/mai
 for submitting pull requests to us.
 
 Visit [Contribute](https://github.com/PowerGridModel/power-grid-model/contribute) for a list of good first issues in this repo.
+
+## Citations
+
+If you are using Power Grid Model in your research work, please consider citing our library using the following references.
+
+### Power Grid Model source code
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8054429.svg)](https://zenodo.org/record/8054429)
+
+```bibtex
+@software{Xiang_PowerGridModel_power-grid-model,
+  author = {Xiang, Yu and Salemink, Peter and Bharambe, Nitish and Jagutis, Laurynas and Wang, Chenguang and van den Bogaard, Jonas and Govers, Martinus and Stoeller, Bram and {Contributors from the LF Energy project Power Grid Model}},
+  doi = {10.5281/zenodo.8054429},
+  title = {{PowerGridModel/power-grid-model}},
+  url = {https://github.com/PowerGridModel/power-grid-model}
+}
+@inproceedings{Xiang2023,
+  author = {Xiang, Yu and Salemink, Peter and Stoeller, Bram and Bharambe, Nitish and van Westering, Werner},
+  booktitle = {CIRED 2023 - The 27th International Conference and Exhibition on Electricity Distribution},
+  title = {Power grid model: A high-performance distribution grid calculation library},
+  year = {2023},
+  volume={2023},
+  number = {},
+  pages={1-5}
+}
+```
 
 ## Contact
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,10 @@ conda install -c conda-forge power-grid-model
 
 To install the library from source, refer to the [Build Guide](advanced_documentation/build-guide.md).
 
+## Citations
+
+If you are using Power Grid Model in your research work, please consider citing our library using the references in [Citation](release_and_support/CITATION.md)
+
 # Contents
 
 Detailed contents of the documentation are structured as follows.
@@ -97,4 +101,5 @@ contribution/GOVERNANCE.md
 :maxdepth: 2
 release_and_support/RELEASE.md
 release_and_support/SUPPORT.md
+release_and_support/CITATION.md
 ```


### PR DESCRIPTION
Add DOI citation to latest version in https://zenodo.org/account/settings/github/repository/PowerGridModel/power-grid-model# (example: https://zenodo.org/record/8054430 )

The `CITATION.cff` also adds a button to the github repo:

![image](https://github.com/PowerGridModel/power-grid-model/assets/15234327/40fdbdff-6006-4faa-a459-3c7ca378eb86)

Example bibtex generated from the `Citation` part:

```bibtex
@software{Power_Grid_Model_and_Xiang_power-grid-model,
author = {{Power Grid Model} and Xiang, Yu and Salemink, Peter and Bharambe, Nitish and Jagutis, Laurynas and Wang, Chenguang and van den Bogaard, Jonas and Govers, Martinus and Stoeller, Bram and Datta, Sattama and Baaijen, Thijs},
doi = {10.5281/zenodo.8054429},
title = {{power-grid-model}},
url = {https://github.com/PowerGridModel/power-grid-model}
}
```

Example APA generated by that button

```md
Power Grid Model, Xiang, Y., Salemink, P., Bharambe, N., Jagutis, L., Wang, C., van den Bogaard, J., Govers, M., Stoeller, B., Datta, S., & Baaijen, T. power-grid-model [Computer software]. https://doi.org/10.5281/zenodo.8054429
```