### PR TITLE
Bugfix/fix clang cl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,9 +94,10 @@ jobs:
     strategy:
       matrix:
         build-option: [ debug, release ]
+        compiler: [msvc, clang-cl]
 
     env:
-      PRESET: msvc-${{ matrix.build-option }}
+      PRESET: ${{ matrix.compiler }}-${{ matrix.build-option }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           # build
           cmake --build --preset ${{ env.PRESET }} --verbose -j 1
           # test
-          ctest --test-dir . --output-on-failure
+          ctest --test-dir cpp_build\${{ env.PRESET }} --output-on-failure
           # install
           cmake --build --preset ${{ env.PRESET }} --verbose -j 1 --target install
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -110,11 +110,21 @@
       "hidden": true
     },
     {
-      "name": "clang-tidy-base",
+      "name": "clang-tidy-windows-base",
+      "cacheVariables": {
+        "CMAKE_C_CLANG_TIDY": "clang-tidy.exe;--extra-arg=/EHsc",
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy.exe;--extra-arg=/EHsc"
+      },
+      "inherits": "windows-base",
+      "hidden": true
+    },
+    {
+      "name": "clang-tidy-unix-base",
       "cacheVariables": {
         "CMAKE_C_CLANG_TIDY": "$env{CLANG_TIDY}",
         "CMAKE_CXX_CLANG_TIDY": "$env{CLANG_TIDY}"
       },
+      "inherits": "unix-base",
       "hidden": true
     },
     {
@@ -150,13 +160,6 @@
       ]
     },
     {
-      "name": "clang-release",
-      "inherits": [
-        "release",
-        "unix-sanitizer"
-      ]
-    },
-    {
       "name": "clang-debug",
       "inherits": [
         "debug",
@@ -164,19 +167,40 @@
       ]
     },
     {
-      "name": "clang-tidy-release",
+      "name": "clang-release",
       "inherits": [
         "release",
-        "clang-tidy-base",
-        "unix-base"
+        "unix-sanitizer"
       ]
     },
     {
       "name": "clang-tidy-debug",
       "inherits": [
         "debug",
-        "clang-tidy-base",
-        "unix-base"
+        "clang-tidy-unix-base"
+      ]
+    },
+    {
+      "name": "clang-tidy-release",
+      "inherits": [
+        "release",
+        "clang-tidy-unix-base"
+      ]
+    },
+    {
+      "name": "clang-tidy-windows-debug",
+      "displayName": "Debug (Clang CL + Clang Tidy)",
+      "inherits": [
+        "debug",
+        "clang-tidy-windows-base"
+      ]
+    },
+    {
+      "name": "clang-tidy-windows-release",
+      "displayName": "Release (Clang CL + Clang Tidy)",
+      "inherits": [
+        "release",
+        "clang-tidy-windows-base"
       ]
     },
     {
@@ -188,13 +212,6 @@
       "hidden": true
     },
     {
-      "name": "gcc-release",
-      "inherits": [
-        "release",
-        "gcc-base"
-      ]
-    },
-    {
       "name": "gcc-debug",
       "inherits": [
         "debug",
@@ -202,8 +219,11 @@
       ]
     },
     {
-      "name": "ci-clang-release",
-      "inherits": "clang-release"
+      "name": "gcc-release",
+      "inherits": [
+        "release",
+        "gcc-base"
+      ]
     },
     {
       "name": "ci-clang-debug",
@@ -213,11 +233,8 @@
       ]
     },
     {
-      "name": "ci-gcc-release",
-      "inherits": [
-        "gcc-release",
-        "unix-coverage"
-      ]
+      "name": "ci-clang-release",
+      "inherits": "clang-release"
     },
     {
       "name": "ci-gcc-debug",
@@ -230,6 +247,13 @@
       ]
     },
     {
+      "name": "ci-gcc-release",
+      "inherits": [
+        "gcc-release",
+        "unix-coverage"
+      ]
+    },
+    {
       "name": "ci-sonar",
       "inherits": [
         "unix-coverage",
@@ -237,12 +261,12 @@
       ]
     },
     {
-      "name": "ci-clang-tidy-release",
-      "inherits": "clang-tidy-release"
-    },
-    {
       "name": "ci-clang-tidy-debug",
       "inherits": "clang-tidy-debug"
+    },
+    {
+      "name": "ci-clang-tidy-release",
+      "inherits": "clang-tidy-release"
     }
   ],
   "buildPresets": [
@@ -277,6 +301,14 @@
     {
       "name": "clang-tidy-release",
       "configurePreset": "clang-tidy-release"
+    },
+    {
+      "name": "clang-tidy-windows-debug",
+      "configurePreset": "clang-tidy-windows-debug"
+    },
+    {
+      "name": "clang-tidy-windows-release",
+      "configurePreset": "clang-tidy-windows-release"
     },
     {
       "name": "gcc-debug",
@@ -347,6 +379,14 @@
     {
       "name": "clang-tidy-release",
       "configurePreset": "clang-tidy-release"
+    },
+    {
+      "name": "clang-tidy-windows-debug",
+      "configurePreset": "clang-tidy-windows-debug"
+    },
+    {
+      "name": "clang-tidy-windows-release",
+      "configurePreset": "clang-tidy-windows-release"
     },
     {
       "name": "gcc-debug",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -139,8 +139,7 @@
       "inherits": [
         "clang-cl-base",
         "debug"
-      ],
-      "hidden": true
+      ]
     },
     {
       "name": "clang-cl-release",
@@ -148,8 +147,7 @@
       "inherits": [
         "clang-cl-base",
         "release"
-      ],
-      "hidden": true
+      ]
     },
     {
       "name": "clang-release",

--- a/code_generation/templates/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/attribute_classes.hpp.jinja
+++ b/code_generation/templates/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/attribute_classes.hpp.jinja
@@ -58,7 +58,7 @@ struct get_meta<{{ attribute_class.name }}> {
         meta.attributes = get_meta<{{ attribute_class.base }}>{}().attributes;
         {%- endif -%}
         {% for attribute in attribute_class.attributes %}
-        meta.attributes.push_back(get_data_attribute<&{{ attribute_class.full_name }}::{{ attribute.names }}>("{{ attribute.names }}"));
+        meta.attributes.push_back(get_data_attribute<{{ attribute_class.full_name }}, &{{ attribute_class.full_name }}::{{ attribute.names }}>("{{ attribute.names }}"));
         {%- endfor %}
         return meta;
     }

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -53,6 +53,8 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 
 * MSVC >= 17.5
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
+* Clang CL >= 14.0
+  * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 
 **macOS**
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/input.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/input.hpp
@@ -208,7 +208,7 @@ struct get_meta<BaseInput> {
         meta.size = sizeof(BaseInput);  
         meta.alignment = alignof(BaseInput);
         
-        meta.attributes.push_back(get_data_attribute<&BaseInput::id>("id"));
+        meta.attributes.push_back(get_data_attribute<BaseInput, &BaseInput::id>("id"));
         return meta;
     }
 };
@@ -221,7 +221,7 @@ struct get_meta<NodeInput> {
         meta.size = sizeof(NodeInput);  
         meta.alignment = alignof(NodeInput);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&NodeInput::u_rated>("u_rated"));
+        meta.attributes.push_back(get_data_attribute<NodeInput, &NodeInput::u_rated>("u_rated"));
         return meta;
     }
 };
@@ -234,10 +234,10 @@ struct get_meta<BranchInput> {
         meta.size = sizeof(BranchInput);  
         meta.alignment = alignof(BranchInput);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&BranchInput::from_node>("from_node"));
-        meta.attributes.push_back(get_data_attribute<&BranchInput::to_node>("to_node"));
-        meta.attributes.push_back(get_data_attribute<&BranchInput::from_status>("from_status"));
-        meta.attributes.push_back(get_data_attribute<&BranchInput::to_status>("to_status"));
+        meta.attributes.push_back(get_data_attribute<BranchInput, &BranchInput::from_node>("from_node"));
+        meta.attributes.push_back(get_data_attribute<BranchInput, &BranchInput::to_node>("to_node"));
+        meta.attributes.push_back(get_data_attribute<BranchInput, &BranchInput::from_status>("from_status"));
+        meta.attributes.push_back(get_data_attribute<BranchInput, &BranchInput::to_status>("to_status"));
         return meta;
     }
 };
@@ -250,12 +250,12 @@ struct get_meta<Branch3Input> {
         meta.size = sizeof(Branch3Input);  
         meta.alignment = alignof(Branch3Input);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::node_1>("node_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::node_2>("node_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::node_3>("node_3"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::status_1>("status_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::status_2>("status_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Input::status_3>("status_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::node_1>("node_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::node_2>("node_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::node_3>("node_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::status_1>("status_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::status_2>("status_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Input, &Branch3Input::status_3>("status_3"));
         return meta;
     }
 };
@@ -268,7 +268,7 @@ struct get_meta<SensorInput> {
         meta.size = sizeof(SensorInput);  
         meta.alignment = alignof(SensorInput);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&SensorInput::measured_object>("measured_object"));
+        meta.attributes.push_back(get_data_attribute<SensorInput, &SensorInput::measured_object>("measured_object"));
         return meta;
     }
 };
@@ -281,8 +281,8 @@ struct get_meta<ApplianceInput> {
         meta.size = sizeof(ApplianceInput);  
         meta.alignment = alignof(ApplianceInput);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ApplianceInput::node>("node"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceInput::status>("status"));
+        meta.attributes.push_back(get_data_attribute<ApplianceInput, &ApplianceInput::node>("node"));
+        meta.attributes.push_back(get_data_attribute<ApplianceInput, &ApplianceInput::status>("status"));
         return meta;
     }
 };
@@ -295,15 +295,15 @@ struct get_meta<LineInput> {
         meta.size = sizeof(LineInput);  
         meta.alignment = alignof(LineInput);
         meta.attributes = get_meta<BranchInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&LineInput::r1>("r1"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::x1>("x1"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::c1>("c1"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::tan1>("tan1"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::r0>("r0"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::x0>("x0"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::c0>("c0"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::tan0>("tan0"));
-        meta.attributes.push_back(get_data_attribute<&LineInput::i_n>("i_n"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::r1>("r1"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::x1>("x1"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::c1>("c1"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::tan1>("tan1"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::r0>("r0"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::x0>("x0"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::c0>("c0"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::tan0>("tan0"));
+        meta.attributes.push_back(get_data_attribute<LineInput, &LineInput::i_n>("i_n"));
         return meta;
     }
 };
@@ -328,30 +328,30 @@ struct get_meta<TransformerInput> {
         meta.size = sizeof(TransformerInput);  
         meta.alignment = alignof(TransformerInput);
         meta.attributes = get_meta<BranchInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::u1>("u1"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::u2>("u2"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::sn>("sn"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::uk>("uk"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::pk>("pk"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::i0>("i0"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::p0>("p0"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::winding_from>("winding_from"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::winding_to>("winding_to"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::clock>("clock"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_side>("tap_side"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_pos>("tap_pos"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_min>("tap_min"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_max>("tap_max"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_nom>("tap_nom"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::tap_size>("tap_size"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::uk_min>("uk_min"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::uk_max>("uk_max"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::pk_min>("pk_min"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::pk_max>("pk_max"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::r_grounding_from>("r_grounding_from"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::x_grounding_from>("x_grounding_from"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::r_grounding_to>("r_grounding_to"));
-        meta.attributes.push_back(get_data_attribute<&TransformerInput::x_grounding_to>("x_grounding_to"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::u1>("u1"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::u2>("u2"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::sn>("sn"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::uk>("uk"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::pk>("pk"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::i0>("i0"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::p0>("p0"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::winding_from>("winding_from"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::winding_to>("winding_to"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::clock>("clock"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_side>("tap_side"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_pos>("tap_pos"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_min>("tap_min"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_max>("tap_max"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_nom>("tap_nom"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::tap_size>("tap_size"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::uk_min>("uk_min"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::uk_max>("uk_max"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::pk_min>("pk_min"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::pk_max>("pk_max"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::r_grounding_from>("r_grounding_from"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::x_grounding_from>("x_grounding_from"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::r_grounding_to>("r_grounding_to"));
+        meta.attributes.push_back(get_data_attribute<TransformerInput, &TransformerInput::x_grounding_to>("x_grounding_to"));
         return meta;
     }
 };
@@ -364,49 +364,49 @@ struct get_meta<ThreeWindingTransformerInput> {
         meta.size = sizeof(ThreeWindingTransformerInput);  
         meta.alignment = alignof(ThreeWindingTransformerInput);
         meta.attributes = get_meta<Branch3Input>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::u1>("u1"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::u2>("u2"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::u3>("u3"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::sn_1>("sn_1"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::sn_2>("sn_2"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::sn_3>("sn_3"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_12>("uk_12"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_13>("uk_13"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_23>("uk_23"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_12>("pk_12"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_13>("pk_13"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_23>("pk_23"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::i0>("i0"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::p0>("p0"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::winding_1>("winding_1"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::winding_2>("winding_2"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::winding_3>("winding_3"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::clock_12>("clock_12"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::clock_13>("clock_13"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_side>("tap_side"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_pos>("tap_pos"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_min>("tap_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_max>("tap_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_nom>("tap_nom"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::tap_size>("tap_size"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_12_min>("uk_12_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_12_max>("uk_12_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_13_min>("uk_13_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_13_max>("uk_13_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_23_min>("uk_23_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::uk_23_max>("uk_23_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_12_min>("pk_12_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_12_max>("pk_12_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_13_min>("pk_13_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_13_max>("pk_13_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_23_min>("pk_23_min"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::pk_23_max>("pk_23_max"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::r_grounding_1>("r_grounding_1"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::x_grounding_1>("x_grounding_1"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::r_grounding_2>("r_grounding_2"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::x_grounding_2>("x_grounding_2"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::r_grounding_3>("r_grounding_3"));
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerInput::x_grounding_3>("x_grounding_3"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::u1>("u1"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::u2>("u2"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::u3>("u3"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::sn_1>("sn_1"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::sn_2>("sn_2"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::sn_3>("sn_3"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_12>("uk_12"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_13>("uk_13"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_23>("uk_23"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_12>("pk_12"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_13>("pk_13"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_23>("pk_23"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::i0>("i0"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::p0>("p0"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::winding_1>("winding_1"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::winding_2>("winding_2"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::winding_3>("winding_3"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::clock_12>("clock_12"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::clock_13>("clock_13"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_side>("tap_side"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_pos>("tap_pos"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_min>("tap_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_max>("tap_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_nom>("tap_nom"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::tap_size>("tap_size"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_12_min>("uk_12_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_12_max>("uk_12_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_13_min>("uk_13_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_13_max>("uk_13_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_23_min>("uk_23_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::uk_23_max>("uk_23_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_12_min>("pk_12_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_12_max>("pk_12_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_13_min>("pk_13_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_13_max>("pk_13_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_23_min>("pk_23_min"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::pk_23_max>("pk_23_max"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::r_grounding_1>("r_grounding_1"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::x_grounding_1>("x_grounding_1"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::r_grounding_2>("r_grounding_2"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::x_grounding_2>("x_grounding_2"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::r_grounding_3>("r_grounding_3"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerInput, &ThreeWindingTransformerInput::x_grounding_3>("x_grounding_3"));
         return meta;
     }
 };
@@ -419,7 +419,7 @@ struct get_meta<GenericLoadGenInput> {
         meta.size = sizeof(GenericLoadGenInput);  
         meta.alignment = alignof(GenericLoadGenInput);
         meta.attributes = get_meta<ApplianceInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&GenericLoadGenInput::type>("type"));
+        meta.attributes.push_back(get_data_attribute<GenericLoadGenInput, &GenericLoadGenInput::type>("type"));
         return meta;
     }
 };
@@ -432,8 +432,8 @@ struct get_meta<LoadGenInput<sym>> {
         meta.size = sizeof(LoadGenInput<sym>);  
         meta.alignment = alignof(LoadGenInput<sym>);
         meta.attributes = get_meta<GenericLoadGenInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&LoadGenInput<sym>::p_specified>("p_specified"));
-        meta.attributes.push_back(get_data_attribute<&LoadGenInput<sym>::q_specified>("q_specified"));
+        meta.attributes.push_back(get_data_attribute<LoadGenInput<sym>, &LoadGenInput<sym>::p_specified>("p_specified"));
+        meta.attributes.push_back(get_data_attribute<LoadGenInput<sym>, &LoadGenInput<sym>::q_specified>("q_specified"));
         return meta;
     }
 };
@@ -446,10 +446,10 @@ struct get_meta<ShuntInput> {
         meta.size = sizeof(ShuntInput);  
         meta.alignment = alignof(ShuntInput);
         meta.attributes = get_meta<ApplianceInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ShuntInput::g1>("g1"));
-        meta.attributes.push_back(get_data_attribute<&ShuntInput::b1>("b1"));
-        meta.attributes.push_back(get_data_attribute<&ShuntInput::g0>("g0"));
-        meta.attributes.push_back(get_data_attribute<&ShuntInput::b0>("b0"));
+        meta.attributes.push_back(get_data_attribute<ShuntInput, &ShuntInput::g1>("g1"));
+        meta.attributes.push_back(get_data_attribute<ShuntInput, &ShuntInput::b1>("b1"));
+        meta.attributes.push_back(get_data_attribute<ShuntInput, &ShuntInput::g0>("g0"));
+        meta.attributes.push_back(get_data_attribute<ShuntInput, &ShuntInput::b0>("b0"));
         return meta;
     }
 };
@@ -462,11 +462,11 @@ struct get_meta<SourceInput> {
         meta.size = sizeof(SourceInput);  
         meta.alignment = alignof(SourceInput);
         meta.attributes = get_meta<ApplianceInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&SourceInput::u_ref>("u_ref"));
-        meta.attributes.push_back(get_data_attribute<&SourceInput::u_ref_angle>("u_ref_angle"));
-        meta.attributes.push_back(get_data_attribute<&SourceInput::sk>("sk"));
-        meta.attributes.push_back(get_data_attribute<&SourceInput::rx_ratio>("rx_ratio"));
-        meta.attributes.push_back(get_data_attribute<&SourceInput::z01_ratio>("z01_ratio"));
+        meta.attributes.push_back(get_data_attribute<SourceInput, &SourceInput::u_ref>("u_ref"));
+        meta.attributes.push_back(get_data_attribute<SourceInput, &SourceInput::u_ref_angle>("u_ref_angle"));
+        meta.attributes.push_back(get_data_attribute<SourceInput, &SourceInput::sk>("sk"));
+        meta.attributes.push_back(get_data_attribute<SourceInput, &SourceInput::rx_ratio>("rx_ratio"));
+        meta.attributes.push_back(get_data_attribute<SourceInput, &SourceInput::z01_ratio>("z01_ratio"));
         return meta;
     }
 };
@@ -479,7 +479,7 @@ struct get_meta<GenericVoltageSensorInput> {
         meta.size = sizeof(GenericVoltageSensorInput);  
         meta.alignment = alignof(GenericVoltageSensorInput);
         meta.attributes = get_meta<SensorInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&GenericVoltageSensorInput::u_sigma>("u_sigma"));
+        meta.attributes.push_back(get_data_attribute<GenericVoltageSensorInput, &GenericVoltageSensorInput::u_sigma>("u_sigma"));
         return meta;
     }
 };
@@ -492,8 +492,8 @@ struct get_meta<VoltageSensorInput<sym>> {
         meta.size = sizeof(VoltageSensorInput<sym>);  
         meta.alignment = alignof(VoltageSensorInput<sym>);
         meta.attributes = get_meta<GenericVoltageSensorInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorInput<sym>::u_measured>("u_measured"));
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorInput<sym>::u_angle_measured>("u_angle_measured"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorInput<sym>, &VoltageSensorInput<sym>::u_measured>("u_measured"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorInput<sym>, &VoltageSensorInput<sym>::u_angle_measured>("u_angle_measured"));
         return meta;
     }
 };
@@ -506,8 +506,8 @@ struct get_meta<GenericPowerSensorInput> {
         meta.size = sizeof(GenericPowerSensorInput);  
         meta.alignment = alignof(GenericPowerSensorInput);
         meta.attributes = get_meta<SensorInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&GenericPowerSensorInput::measured_terminal_type>("measured_terminal_type"));
-        meta.attributes.push_back(get_data_attribute<&GenericPowerSensorInput::power_sigma>("power_sigma"));
+        meta.attributes.push_back(get_data_attribute<GenericPowerSensorInput, &GenericPowerSensorInput::measured_terminal_type>("measured_terminal_type"));
+        meta.attributes.push_back(get_data_attribute<GenericPowerSensorInput, &GenericPowerSensorInput::power_sigma>("power_sigma"));
         return meta;
     }
 };
@@ -520,8 +520,8 @@ struct get_meta<PowerSensorInput<sym>> {
         meta.size = sizeof(PowerSensorInput<sym>);  
         meta.alignment = alignof(PowerSensorInput<sym>);
         meta.attributes = get_meta<GenericPowerSensorInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&PowerSensorInput<sym>::p_measured>("p_measured"));
-        meta.attributes.push_back(get_data_attribute<&PowerSensorInput<sym>::q_measured>("q_measured"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorInput<sym>, &PowerSensorInput<sym>::p_measured>("p_measured"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorInput<sym>, &PowerSensorInput<sym>::q_measured>("q_measured"));
         return meta;
     }
 };
@@ -534,9 +534,9 @@ struct get_meta<FaultInput> {
         meta.size = sizeof(FaultInput);  
         meta.alignment = alignof(FaultInput);
         meta.attributes = get_meta<BaseInput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&FaultInput::fault_object>("fault_object"));
-        meta.attributes.push_back(get_data_attribute<&FaultInput::r_f>("r_f"));
-        meta.attributes.push_back(get_data_attribute<&FaultInput::x_f>("x_f"));
+        meta.attributes.push_back(get_data_attribute<FaultInput, &FaultInput::fault_object>("fault_object"));
+        meta.attributes.push_back(get_data_attribute<FaultInput, &FaultInput::r_f>("r_f"));
+        meta.attributes.push_back(get_data_attribute<FaultInput, &FaultInput::x_f>("x_f"));
         return meta;
     }
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
@@ -135,8 +135,8 @@ struct DataAttribute {
     CompareValueFunc compare_value;
 };
 
-template <class Base, auto member_ptr>
-requires std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>
+template <class Base, auto member_ptr,
+          std::enable_if_t<std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>>>
 inline size_t get_offset() {
     using struct_type = typename trait_pointer_to_member<decltype(member_ptr)>::struct_type;
     struct_type const obj{};
@@ -147,8 +147,8 @@ constexpr bool is_little_endian() {
     return std::endian::native == std::endian::little;
 }
 
-template <class Base, auto member_ptr>
-requires std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>
+template <class Base, auto member_ptr,
+          std::enable_if_t<std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>>>
 inline DataAttribute get_data_attribute(std::string const& name) {
     using value_type = typename trait_pointer_to_member<decltype(member_ptr)>::value_type;
     using single_data_type = data_type<value_type>;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
@@ -135,9 +135,10 @@ struct DataAttribute {
     CompareValueFunc compare_value;
 };
 
-template <class Base, auto member_ptr,
-          std::enable_if_t<std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>>>
-inline size_t get_offset() {
+template <class BaseType, auto member_ptr>
+inline std::enable_if_t<std::is_same_v<BaseType, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>,
+                        size_t>
+get_offset() {
     using struct_type = typename trait_pointer_to_member<decltype(member_ptr)>::struct_type;
     struct_type const obj{};
     return (size_t)(&(obj.*member_ptr)) - (size_t)&obj;
@@ -147,16 +148,17 @@ constexpr bool is_little_endian() {
     return std::endian::native == std::endian::little;
 }
 
-template <class Base, auto member_ptr,
-          std::enable_if_t<std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>>>
-inline DataAttribute get_data_attribute(std::string const& name) {
+template <class BaseType, auto member_ptr>
+inline std::enable_if_t<std::is_same_v<BaseType, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>,
+                        DataAttribute>
+get_data_attribute(std::string const& name) {
     using value_type = typename trait_pointer_to_member<decltype(member_ptr)>::value_type;
     using single_data_type = data_type<value_type>;
     DataAttribute attr{};
     attr.name = name;
     attr.numpy_type = single_data_type::numpy_type;
     attr.ctype = single_data_type::ctype;
-    attr.offset = get_offset<Base, member_ptr>();
+    attr.offset = get_offset<BaseType, member_ptr>();
     attr.size = sizeof(value_type);
     if constexpr (single_data_type::ndim > 0) {
         attr.dims = std::vector<size_t>(single_data_type::dims, single_data_type::dims + single_data_type::ndim);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
@@ -135,7 +135,8 @@ struct DataAttribute {
     CompareValueFunc compare_value;
 };
 
-template <auto member_ptr>
+template <class Base, auto member_ptr>
+requires std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>
 inline size_t get_offset() {
     using struct_type = typename trait_pointer_to_member<decltype(member_ptr)>::struct_type;
     struct_type const obj{};
@@ -146,7 +147,8 @@ constexpr bool is_little_endian() {
     return std::endian::native == std::endian::little;
 }
 
-template <auto member_ptr>
+template <class Base, auto member_ptr>
+requires std::is_same_v<Base, typename trait_pointer_to_member<decltype(member_ptr)>::struct_type>
 inline DataAttribute get_data_attribute(std::string const& name) {
     using value_type = typename trait_pointer_to_member<decltype(member_ptr)>::value_type;
     using single_data_type = data_type<value_type>;
@@ -154,7 +156,7 @@ inline DataAttribute get_data_attribute(std::string const& name) {
     attr.name = name;
     attr.numpy_type = single_data_type::numpy_type;
     attr.ctype = single_data_type::ctype;
-    attr.offset = get_offset<member_ptr>();
+    attr.offset = get_offset<Base, member_ptr>();
     attr.size = sizeof(value_type);
     if constexpr (single_data_type::ndim > 0) {
         attr.dims = std::vector<size_t>(single_data_type::dims, single_data_type::dims + single_data_type::ndim);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/output.hpp
@@ -162,8 +162,8 @@ struct get_meta<BaseOutput> {
         meta.size = sizeof(BaseOutput);  
         meta.alignment = alignof(BaseOutput);
         
-        meta.attributes.push_back(get_data_attribute<&BaseOutput::id>("id"));
-        meta.attributes.push_back(get_data_attribute<&BaseOutput::energized>("energized"));
+        meta.attributes.push_back(get_data_attribute<BaseOutput, &BaseOutput::id>("id"));
+        meta.attributes.push_back(get_data_attribute<BaseOutput, &BaseOutput::energized>("energized"));
         return meta;
     }
 };
@@ -176,11 +176,11 @@ struct get_meta<NodeOutput<sym>> {
         meta.size = sizeof(NodeOutput<sym>);  
         meta.alignment = alignof(NodeOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&NodeOutput<sym>::u_pu>("u_pu"));
-        meta.attributes.push_back(get_data_attribute<&NodeOutput<sym>::u>("u"));
-        meta.attributes.push_back(get_data_attribute<&NodeOutput<sym>::u_angle>("u_angle"));
-        meta.attributes.push_back(get_data_attribute<&NodeOutput<sym>::p>("p"));
-        meta.attributes.push_back(get_data_attribute<&NodeOutput<sym>::q>("q"));
+        meta.attributes.push_back(get_data_attribute<NodeOutput<sym>, &NodeOutput<sym>::u_pu>("u_pu"));
+        meta.attributes.push_back(get_data_attribute<NodeOutput<sym>, &NodeOutput<sym>::u>("u"));
+        meta.attributes.push_back(get_data_attribute<NodeOutput<sym>, &NodeOutput<sym>::u_angle>("u_angle"));
+        meta.attributes.push_back(get_data_attribute<NodeOutput<sym>, &NodeOutput<sym>::p>("p"));
+        meta.attributes.push_back(get_data_attribute<NodeOutput<sym>, &NodeOutput<sym>::q>("q"));
         return meta;
     }
 };
@@ -193,15 +193,15 @@ struct get_meta<BranchOutput<sym>> {
         meta.size = sizeof(BranchOutput<sym>);  
         meta.alignment = alignof(BranchOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::loading>("loading"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::p_from>("p_from"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::q_from>("q_from"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::i_from>("i_from"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::s_from>("s_from"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::p_to>("p_to"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::q_to>("q_to"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::i_to>("i_to"));
-        meta.attributes.push_back(get_data_attribute<&BranchOutput<sym>::s_to>("s_to"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::loading>("loading"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::p_from>("p_from"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::q_from>("q_from"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::i_from>("i_from"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::s_from>("s_from"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::p_to>("p_to"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::q_to>("q_to"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::i_to>("i_to"));
+        meta.attributes.push_back(get_data_attribute<BranchOutput<sym>, &BranchOutput<sym>::s_to>("s_to"));
         return meta;
     }
 };
@@ -214,19 +214,19 @@ struct get_meta<Branch3Output<sym>> {
         meta.size = sizeof(Branch3Output<sym>);  
         meta.alignment = alignof(Branch3Output<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::loading>("loading"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::p_1>("p_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::q_1>("q_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::i_1>("i_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::s_1>("s_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::p_2>("p_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::q_2>("q_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::i_2>("i_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::s_2>("s_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::p_3>("p_3"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::q_3>("q_3"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::i_3>("i_3"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Output<sym>::s_3>("s_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::loading>("loading"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::p_1>("p_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::q_1>("q_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::i_1>("i_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::s_1>("s_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::p_2>("p_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::q_2>("q_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::i_2>("i_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::s_2>("s_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::p_3>("p_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::q_3>("q_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::i_3>("i_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Output<sym>, &Branch3Output<sym>::s_3>("s_3"));
         return meta;
     }
 };
@@ -239,11 +239,11 @@ struct get_meta<ApplianceOutput<sym>> {
         meta.size = sizeof(ApplianceOutput<sym>);  
         meta.alignment = alignof(ApplianceOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ApplianceOutput<sym>::p>("p"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceOutput<sym>::q>("q"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceOutput<sym>::i>("i"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceOutput<sym>::s>("s"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceOutput<sym>::pf>("pf"));
+        meta.attributes.push_back(get_data_attribute<ApplianceOutput<sym>, &ApplianceOutput<sym>::p>("p"));
+        meta.attributes.push_back(get_data_attribute<ApplianceOutput<sym>, &ApplianceOutput<sym>::q>("q"));
+        meta.attributes.push_back(get_data_attribute<ApplianceOutput<sym>, &ApplianceOutput<sym>::i>("i"));
+        meta.attributes.push_back(get_data_attribute<ApplianceOutput<sym>, &ApplianceOutput<sym>::s>("s"));
+        meta.attributes.push_back(get_data_attribute<ApplianceOutput<sym>, &ApplianceOutput<sym>::pf>("pf"));
         return meta;
     }
 };
@@ -256,8 +256,8 @@ struct get_meta<VoltageSensorOutput<sym>> {
         meta.size = sizeof(VoltageSensorOutput<sym>);  
         meta.alignment = alignof(VoltageSensorOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorOutput<sym>::u_residual>("u_residual"));
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorOutput<sym>::u_angle_residual>("u_angle_residual"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorOutput<sym>, &VoltageSensorOutput<sym>::u_residual>("u_residual"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorOutput<sym>, &VoltageSensorOutput<sym>::u_angle_residual>("u_angle_residual"));
         return meta;
     }
 };
@@ -270,8 +270,8 @@ struct get_meta<PowerSensorOutput<sym>> {
         meta.size = sizeof(PowerSensorOutput<sym>);  
         meta.alignment = alignof(PowerSensorOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&PowerSensorOutput<sym>::p_residual>("p_residual"));
-        meta.attributes.push_back(get_data_attribute<&PowerSensorOutput<sym>::q_residual>("q_residual"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorOutput<sym>, &PowerSensorOutput<sym>::p_residual>("p_residual"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorOutput<sym>, &PowerSensorOutput<sym>::q_residual>("q_residual"));
         return meta;
     }
 };
@@ -296,8 +296,8 @@ struct get_meta<FaultShortCircuitOutput<sym>> {
         meta.size = sizeof(FaultShortCircuitOutput<sym>);  
         meta.alignment = alignof(FaultShortCircuitOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&FaultShortCircuitOutput<sym>::i_f>("i_f"));
-        meta.attributes.push_back(get_data_attribute<&FaultShortCircuitOutput<sym>::i_f_angle>("i_f_angle"));
+        meta.attributes.push_back(get_data_attribute<FaultShortCircuitOutput<sym>, &FaultShortCircuitOutput<sym>::i_f>("i_f"));
+        meta.attributes.push_back(get_data_attribute<FaultShortCircuitOutput<sym>, &FaultShortCircuitOutput<sym>::i_f_angle>("i_f_angle"));
         return meta;
     }
 };
@@ -310,9 +310,9 @@ struct get_meta<NodeShortCircuitOutput<sym>> {
         meta.size = sizeof(NodeShortCircuitOutput<sym>);  
         meta.alignment = alignof(NodeShortCircuitOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&NodeShortCircuitOutput<sym>::u_pu>("u_pu"));
-        meta.attributes.push_back(get_data_attribute<&NodeShortCircuitOutput<sym>::u>("u"));
-        meta.attributes.push_back(get_data_attribute<&NodeShortCircuitOutput<sym>::u_angle>("u_angle"));
+        meta.attributes.push_back(get_data_attribute<NodeShortCircuitOutput<sym>, &NodeShortCircuitOutput<sym>::u_pu>("u_pu"));
+        meta.attributes.push_back(get_data_attribute<NodeShortCircuitOutput<sym>, &NodeShortCircuitOutput<sym>::u>("u"));
+        meta.attributes.push_back(get_data_attribute<NodeShortCircuitOutput<sym>, &NodeShortCircuitOutput<sym>::u_angle>("u_angle"));
         return meta;
     }
 };
@@ -325,10 +325,10 @@ struct get_meta<BranchShortCircuitOutput<sym>> {
         meta.size = sizeof(BranchShortCircuitOutput<sym>);  
         meta.alignment = alignof(BranchShortCircuitOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&BranchShortCircuitOutput<sym>::i_from>("i_from"));
-        meta.attributes.push_back(get_data_attribute<&BranchShortCircuitOutput<sym>::i_from_angle>("i_from_angle"));
-        meta.attributes.push_back(get_data_attribute<&BranchShortCircuitOutput<sym>::i_to>("i_to"));
-        meta.attributes.push_back(get_data_attribute<&BranchShortCircuitOutput<sym>::i_to_angle>("i_to_angle"));
+        meta.attributes.push_back(get_data_attribute<BranchShortCircuitOutput<sym>, &BranchShortCircuitOutput<sym>::i_from>("i_from"));
+        meta.attributes.push_back(get_data_attribute<BranchShortCircuitOutput<sym>, &BranchShortCircuitOutput<sym>::i_from_angle>("i_from_angle"));
+        meta.attributes.push_back(get_data_attribute<BranchShortCircuitOutput<sym>, &BranchShortCircuitOutput<sym>::i_to>("i_to"));
+        meta.attributes.push_back(get_data_attribute<BranchShortCircuitOutput<sym>, &BranchShortCircuitOutput<sym>::i_to_angle>("i_to_angle"));
         return meta;
     }
 };
@@ -341,12 +341,12 @@ struct get_meta<Branch3ShortCircuitOutput<sym>> {
         meta.size = sizeof(Branch3ShortCircuitOutput<sym>);  
         meta.alignment = alignof(Branch3ShortCircuitOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_1>("i_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_1_angle>("i_1_angle"));
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_2>("i_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_2_angle>("i_2_angle"));
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_3>("i_3"));
-        meta.attributes.push_back(get_data_attribute<&Branch3ShortCircuitOutput<sym>::i_3_angle>("i_3_angle"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_1>("i_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_1_angle>("i_1_angle"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_2>("i_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_2_angle>("i_2_angle"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_3>("i_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3ShortCircuitOutput<sym>, &Branch3ShortCircuitOutput<sym>::i_3_angle>("i_3_angle"));
         return meta;
     }
 };
@@ -359,8 +359,8 @@ struct get_meta<ApplianceShortCircuitOutput<sym>> {
         meta.size = sizeof(ApplianceShortCircuitOutput<sym>);  
         meta.alignment = alignof(ApplianceShortCircuitOutput<sym>);
         meta.attributes = get_meta<BaseOutput>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ApplianceShortCircuitOutput<sym>::i>("i"));
-        meta.attributes.push_back(get_data_attribute<&ApplianceShortCircuitOutput<sym>::i_angle>("i_angle"));
+        meta.attributes.push_back(get_data_attribute<ApplianceShortCircuitOutput<sym>, &ApplianceShortCircuitOutput<sym>::i>("i"));
+        meta.attributes.push_back(get_data_attribute<ApplianceShortCircuitOutput<sym>, &ApplianceShortCircuitOutput<sym>::i_angle>("i_angle"));
         return meta;
     }
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/update.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/update.hpp
@@ -91,7 +91,7 @@ struct get_meta<BaseUpdate> {
         meta.size = sizeof(BaseUpdate);  
         meta.alignment = alignof(BaseUpdate);
         
-        meta.attributes.push_back(get_data_attribute<&BaseUpdate::id>("id"));
+        meta.attributes.push_back(get_data_attribute<BaseUpdate, &BaseUpdate::id>("id"));
         return meta;
     }
 };
@@ -104,8 +104,8 @@ struct get_meta<BranchUpdate> {
         meta.size = sizeof(BranchUpdate);  
         meta.alignment = alignof(BranchUpdate);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&BranchUpdate::from_status>("from_status"));
-        meta.attributes.push_back(get_data_attribute<&BranchUpdate::to_status>("to_status"));
+        meta.attributes.push_back(get_data_attribute<BranchUpdate, &BranchUpdate::from_status>("from_status"));
+        meta.attributes.push_back(get_data_attribute<BranchUpdate, &BranchUpdate::to_status>("to_status"));
         return meta;
     }
 };
@@ -118,9 +118,9 @@ struct get_meta<Branch3Update> {
         meta.size = sizeof(Branch3Update);  
         meta.alignment = alignof(Branch3Update);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&Branch3Update::status_1>("status_1"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Update::status_2>("status_2"));
-        meta.attributes.push_back(get_data_attribute<&Branch3Update::status_3>("status_3"));
+        meta.attributes.push_back(get_data_attribute<Branch3Update, &Branch3Update::status_1>("status_1"));
+        meta.attributes.push_back(get_data_attribute<Branch3Update, &Branch3Update::status_2>("status_2"));
+        meta.attributes.push_back(get_data_attribute<Branch3Update, &Branch3Update::status_3>("status_3"));
         return meta;
     }
 };
@@ -133,7 +133,7 @@ struct get_meta<ApplianceUpdate> {
         meta.size = sizeof(ApplianceUpdate);  
         meta.alignment = alignof(ApplianceUpdate);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ApplianceUpdate::status>("status"));
+        meta.attributes.push_back(get_data_attribute<ApplianceUpdate, &ApplianceUpdate::status>("status"));
         return meta;
     }
 };
@@ -146,7 +146,7 @@ struct get_meta<TransformerUpdate> {
         meta.size = sizeof(TransformerUpdate);  
         meta.alignment = alignof(TransformerUpdate);
         meta.attributes = get_meta<BranchUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&TransformerUpdate::tap_pos>("tap_pos"));
+        meta.attributes.push_back(get_data_attribute<TransformerUpdate, &TransformerUpdate::tap_pos>("tap_pos"));
         return meta;
     }
 };
@@ -159,7 +159,7 @@ struct get_meta<ThreeWindingTransformerUpdate> {
         meta.size = sizeof(ThreeWindingTransformerUpdate);  
         meta.alignment = alignof(ThreeWindingTransformerUpdate);
         meta.attributes = get_meta<Branch3Update>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&ThreeWindingTransformerUpdate::tap_pos>("tap_pos"));
+        meta.attributes.push_back(get_data_attribute<ThreeWindingTransformerUpdate, &ThreeWindingTransformerUpdate::tap_pos>("tap_pos"));
         return meta;
     }
 };
@@ -172,8 +172,8 @@ struct get_meta<LoadGenUpdate<sym>> {
         meta.size = sizeof(LoadGenUpdate<sym>);  
         meta.alignment = alignof(LoadGenUpdate<sym>);
         meta.attributes = get_meta<ApplianceUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&LoadGenUpdate<sym>::p_specified>("p_specified"));
-        meta.attributes.push_back(get_data_attribute<&LoadGenUpdate<sym>::q_specified>("q_specified"));
+        meta.attributes.push_back(get_data_attribute<LoadGenUpdate<sym>, &LoadGenUpdate<sym>::p_specified>("p_specified"));
+        meta.attributes.push_back(get_data_attribute<LoadGenUpdate<sym>, &LoadGenUpdate<sym>::q_specified>("q_specified"));
         return meta;
     }
 };
@@ -186,8 +186,8 @@ struct get_meta<SourceUpdate> {
         meta.size = sizeof(SourceUpdate);  
         meta.alignment = alignof(SourceUpdate);
         meta.attributes = get_meta<ApplianceUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&SourceUpdate::u_ref>("u_ref"));
-        meta.attributes.push_back(get_data_attribute<&SourceUpdate::u_ref_angle>("u_ref_angle"));
+        meta.attributes.push_back(get_data_attribute<SourceUpdate, &SourceUpdate::u_ref>("u_ref"));
+        meta.attributes.push_back(get_data_attribute<SourceUpdate, &SourceUpdate::u_ref_angle>("u_ref_angle"));
         return meta;
     }
 };
@@ -200,9 +200,9 @@ struct get_meta<VoltageSensorUpdate<sym>> {
         meta.size = sizeof(VoltageSensorUpdate<sym>);  
         meta.alignment = alignof(VoltageSensorUpdate<sym>);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorUpdate<sym>::u_sigma>("u_sigma"));
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorUpdate<sym>::u_measured>("u_measured"));
-        meta.attributes.push_back(get_data_attribute<&VoltageSensorUpdate<sym>::u_angle_measured>("u_angle_measured"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorUpdate<sym>, &VoltageSensorUpdate<sym>::u_sigma>("u_sigma"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorUpdate<sym>, &VoltageSensorUpdate<sym>::u_measured>("u_measured"));
+        meta.attributes.push_back(get_data_attribute<VoltageSensorUpdate<sym>, &VoltageSensorUpdate<sym>::u_angle_measured>("u_angle_measured"));
         return meta;
     }
 };
@@ -215,9 +215,9 @@ struct get_meta<PowerSensorUpdate<sym>> {
         meta.size = sizeof(PowerSensorUpdate<sym>);  
         meta.alignment = alignof(PowerSensorUpdate<sym>);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&PowerSensorUpdate<sym>::power_sigma>("power_sigma"));
-        meta.attributes.push_back(get_data_attribute<&PowerSensorUpdate<sym>::p_measured>("p_measured"));
-        meta.attributes.push_back(get_data_attribute<&PowerSensorUpdate<sym>::q_measured>("q_measured"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorUpdate<sym>, &PowerSensorUpdate<sym>::power_sigma>("power_sigma"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorUpdate<sym>, &PowerSensorUpdate<sym>::p_measured>("p_measured"));
+        meta.attributes.push_back(get_data_attribute<PowerSensorUpdate<sym>, &PowerSensorUpdate<sym>::q_measured>("q_measured"));
         return meta;
     }
 };
@@ -230,7 +230,7 @@ struct get_meta<FaultUpdate> {
         meta.size = sizeof(FaultUpdate);  
         meta.alignment = alignof(FaultUpdate);
         meta.attributes = get_meta<BaseUpdate>{}().attributes;
-        meta.attributes.push_back(get_data_attribute<&FaultUpdate::fault_object>("fault_object"));
+        meta.attributes.push_back(get_data_attribute<FaultUpdate, &FaultUpdate::fault_object>("fault_object"));
         return meta;
     }
 };

--- a/tests/package_tests/CMakePresets.json
+++ b/tests/package_tests/CMakePresets.json
@@ -111,22 +111,13 @@
       "inherits": [
         "clang-cl-base",
         "debug"
-      ],
-      "hidden": true
+      ]
     },
     {
       "name": "clang-cl-release",
       "displayName": "Release (Clang CL)",
       "inherits": [
         "clang-cl-base",
-        "release"
-      ],
-      "hidden": true
-    },
-    {
-      "name": "ci-clang-release",
-      "inherits": [
-        "ci-unix",
         "release"
       ]
     },
@@ -138,7 +129,7 @@
       ]
     },
     {
-      "name": "ci-gcc-release",
+      "name": "ci-clang-release",
       "inherits": [
         "ci-unix",
         "release"
@@ -149,6 +140,13 @@
       "inherits": [
         "ci-unix",
         "debug"
+      ]
+    },
+    {
+      "name": "ci-gcc-release",
+      "inherits": [
+        "ci-unix",
+        "release"
       ]
     },
     {


### PR DESCRIPTION
closes #241 

### Changes proposed in this PR include:

It was found that in #241 the culprit was the fact that the `trait_pointer_to_member` struct pointed to the wrong member variable in the memory layout. Maybe this was caused by some different memory or template overload order when dealing with inheritance

Overloading the template with a `requires` block that only generates the template when the provided base class is **identical** to the identified base class fixes this template choice mismatch

### Could you please pay extra attention to the points below when reviewing the PR:

Please try to repro this on your local machine (build with Clang CL Debug/Release + run all tests)

### Testing

I did a matrix test on my computer using `[msvc, clang-cl] x [debug, release]` with clean reconfigure and clean rebuild all targets and all tests passed after this change

(note: before this change, i verified that the bug in #241 was still there, so the change actually fixed the tests)
