### PR TITLE
Build musllinux 1.2 in the pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,8 +224,50 @@ jobs:
       - name: Test
         run: pytest
 
+  # TODO, remove this after official musllinux 1.2 image is there 
+  build-musllinux:
+    runs-on: ubuntu-latest
+    container: python:3.9-alpine3.17
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: version
+          path: .
+      
+      - name: Install dependency
+        run: |
+          apk update
+          apk add gcc g++
+          pip install build auditwheel patchelf
+          
+      - name: Build
+        env:
+          CC: gcc
+          CXX: g++
+        run: |
+          python -m build --wheel .
+          auditwheel show dist/*
+          auditwheel repair dist/*
+          ls -al wheelhouse/
+          
+      - name: Test
+        run: |
+          pip install wheelhouse/*
+          pip install pytest pytest-cov
+          pytest
+      
+      - name: Keep wheel files
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheelhouse
+          path: ./wheelhouse/*.whl  
+
   publish-wheels:
-    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]
+    # TODO remove build-musllinux after official musllinux 1.2 image is there 
+    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda, build-musllinux]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,7 @@ jobs:
   # TODO, remove this after official musllinux 1.2 image is there 
   build-musllinux:
     runs-on: ubuntu-latest
+    needs: [aquire-python-version-build-sdist]
     container: python:3.9-alpine3.17
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,12 @@ test-command = "pytest {package}/tests"
 #    PyPy
 #    musllinux when python < 3.9
 #    musllinux in aarch64
-skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
+
+# we disable musllinux in cibuildwheel because there is not support for musllinux 1.2 yet
+# we build separately at this moment
+skip = ["pp*", "*musllinux*"]
+# TODO restore this
+# skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 import os
 import platform
 import shutil
-import sys
 from itertools import chain
 from pathlib import Path
 from typing import List
@@ -166,16 +165,10 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     else:
         # flags for Linux and Mac
         cflags += [
+            "-std=c++20",
             "-O3",
             "-fvisibility=hidden",
         ]
-        # add c++20 or c++2a flag depending on gcc version
-        # TODO remove this if musllinux upgrade to newer gcc version
-        if "GCC 9." in sys.version:
-            cflags += ["-std=c++2a"]
-        else:
-            cflags += ["-std=c++20"]
-        lflags += ["-lpthread", "-O3"]
         # extra flag for Mac
         if platform.system() == "Darwin":
             # compiler flag to set version

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
             "-O3",
             "-fvisibility=hidden",
         ]
+        lflags += ["-lpthread", "-O3"]
         # extra flag for Mac
         if platform.system() == "Darwin":
             # compiler flag to set version


### PR DESCRIPTION
# Problem

The official `musllinux_1_1` image has an old compiler (GCC 9.3) which does not support many C++20 feature.

# Final Solution

If official `musllinux_1_2` image is published, we can use (hopefully) GCC 12.2.

# Work around solution

We now build `musllinux_1_2` separately in the image `python:3.9-alpine3.17`, which has GCC 12.2
