### PR TITLE
Feature/cleanup more code smells

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
@@ -260,6 +260,8 @@ struct Idx2DBranch3 {
     // 1: node 1 -> internal node
     // 2: node 2 -> internal node
     std::array<Idx, 3> pos;
+
+    friend constexpr bool operator==(Idx2DBranch3 x, Idx2DBranch3 y) = default;
 };
 
 // couple component to math model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
@@ -261,7 +261,7 @@ struct Idx2DBranch3 {
     // 2: node 2 -> internal node
     std::array<Idx, 3> pos;
 
-    friend constexpr bool operator==(Idx2DBranch3 x, Idx2DBranch3 y) = default;
+    friend constexpr bool operator==(Idx2DBranch3 const& x, Idx2DBranch3 const& y) = default;
 };
 
 // couple component to math model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
@@ -129,13 +129,15 @@ class LoadGen final : public std::conditional_t<is_gen, GenericGenerator, Generi
     // scale load
     template <bool sym_calc>
     ComplexValue<sym_calc> scale_power(ComplexValue<sym_calc> u) const {
+        using enum LoadGenType;
+
         ComplexValue<sym_calc> const s = this->template calc_param<sym_calc>();
         switch (this->type()) {
-            case LoadGenType::const_pq:
+            case const_pq:
                 return s;
-            case LoadGenType::const_y:
+            case const_y:
                 return s * abs2(u);
-            case LoadGenType::const_i:
+            case const_i:
                 return s * cabs(u);
             default:
                 throw MissingCaseForEnumError(std::string(this->name) + " power scaling factor", this->type());

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/three_winding_transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/three_winding_transformer.hpp
@@ -81,10 +81,12 @@ class ThreeWindingTransformer : public Branch3 {
           z_grounding_1_{three_winding_transformer_input.r_grounding_1, three_winding_transformer_input.x_grounding_1},
           z_grounding_2_{three_winding_transformer_input.r_grounding_2, three_winding_transformer_input.x_grounding_2},
           z_grounding_3_{three_winding_transformer_input.r_grounding_3, three_winding_transformer_input.x_grounding_3} {
+        using enum WindingType;
+
         // check clock number
-        bool const is_1_wye = winding_1_ == WindingType::wye || winding_1_ == WindingType::wye_n;
-        bool const is_2_wye = winding_2_ == WindingType::wye || winding_2_ == WindingType::wye_n;
-        bool const is_3_wye = winding_3_ == WindingType::wye || winding_3_ == WindingType::wye_n;
+        bool const is_1_wye = winding_1_ == wye || winding_1_ == wye_n;
+        bool const is_2_wye = winding_2_ == wye || winding_2_ == wye_n;
+        bool const is_3_wye = winding_3_ == wye || winding_3_ == wye_n;
 
         // check clock 12
         if (  // clock should be between 0 and 12

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
@@ -54,9 +54,11 @@ class Transformer : public Branch {
               calculate_z_pu(transformer_input.r_grounding_from, transformer_input.x_grounding_from, u1_rated)},
           z_grounding_to_{
               calculate_z_pu(transformer_input.r_grounding_to, transformer_input.x_grounding_to, u2_rated)} {
+        using enum WindingType;
+
         // check on clock
-        bool const is_from_wye = winding_from_ == WindingType::wye || winding_from_ == WindingType::wye_n;
-        bool const is_to_wye = winding_to_ == WindingType::wye || winding_to_ == WindingType::wye_n;
+        bool const is_from_wye = winding_from_ == wye || winding_from_ == wye_n;
+        bool const is_to_wye = winding_to_ == wye || winding_to_ == wye_n;
         if (  // clock should be between 0 and 12
             clock_ < 0 || clock_ > 12 ||
             // even number is not possible if one side is wye winding and the other side is not wye winding.
@@ -201,6 +203,8 @@ class Transformer : public Branch {
         return calc_param_y_sym(y_series, y_shunt, k * std::exp(1.0i * (clock_ * deg_30)));
     }
     BranchCalcParam<false> asym_calc_param() const final {
+        using enum WindingType;
+
         auto const [y_series, y_shunt, k] = transformer_params();
         // positive sequence
         auto const param1 = calc_param_y_sym(y_series, y_shunt, k * std::exp(1.0i * (clock_ * deg_30)));
@@ -209,7 +213,7 @@ class Transformer : public Branch {
         // zero sequence, default zero
         BranchCalcParam<true> param0{};
         // YNyn
-        if (winding_from_ == WindingType::wye_n && winding_to_ == WindingType::wye_n) {
+        if (winding_from_ == wye_n && winding_to_ == wye_n) {
             double phase_shift_0 = 0.0;
             // flip sign for reverse connected
             if (clock_ == 2 || clock_ == 6 || clock_ == 10) {
@@ -220,25 +224,25 @@ class Transformer : public Branch {
             param0 = calc_param_y_sym(y0_series, y_shunt, k * std::exp(1.0i * phase_shift_0));
         }
         // YNd
-        if (winding_from_ == WindingType::wye_n && winding_to_ == WindingType::delta && from_status()) {
+        if (winding_from_ == wye_n && winding_to_ == delta && from_status()) {
             DoubleComplex const z0_series = 1.0 / y_series + 3.0 * z_grounding_from_ / k / k;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.yff() = (y0_series + y_shunt) / k / k;
         }
         // Dyn
-        if (winding_from_ == WindingType::delta && winding_to_ == WindingType::wye_n && to_status()) {
+        if (winding_from_ == delta && winding_to_ == wye_n && to_status()) {
             DoubleComplex const z0_series = 1.0 / y_series + 3.0 * z_grounding_to_;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.ytt() = (y0_series + y_shunt);
         }
         // ZN*
-        if (winding_from_ == WindingType::zigzag_n && from_status()) {
+        if (winding_from_ == zigzag_n && from_status()) {
             DoubleComplex const z0_series = (1.0 / y_series) * 0.1 + 3.0 * z_grounding_from_ / k / k;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.yff() = y0_series / k / k;
         }
         // *zn
-        if (winding_to_ == WindingType::zigzag_n && to_status()) {
+        if (winding_to_ == zigzag_n && to_status()) {
             DoubleComplex const z0_series = (1.0 / y_series) * 0.1 + 3.0 * z_grounding_to_;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.ytt() = y0_series;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
@@ -203,8 +203,6 @@ class Transformer : public Branch {
         return calc_param_y_sym(y_series, y_shunt, k * std::exp(1.0i * (clock_ * deg_30)));
     }
     BranchCalcParam<false> asym_calc_param() const final {
-        using enum WindingType;
-
         auto const [y_series, y_shunt, k] = transformer_params();
         // positive sequence
         auto const param1 = calc_param_y_sym(y_series, y_shunt, k * std::exp(1.0i * (clock_ * deg_30)));
@@ -213,7 +211,7 @@ class Transformer : public Branch {
         // zero sequence, default zero
         BranchCalcParam<true> param0{};
         // YNyn
-        if (winding_from_ == wye_n && winding_to_ == wye_n) {
+        if (winding_from_ == WindingType::wye_n && winding_to_ == WindingType::wye_n) {
             double phase_shift_0 = 0.0;
             // flip sign for reverse connected
             if (clock_ == 2 || clock_ == 6 || clock_ == 10) {
@@ -224,25 +222,25 @@ class Transformer : public Branch {
             param0 = calc_param_y_sym(y0_series, y_shunt, k * std::exp(1.0i * phase_shift_0));
         }
         // YNd
-        if (winding_from_ == wye_n && winding_to_ == delta && from_status()) {
+        if (winding_from_ == WindingType::wye_n && winding_to_ == WindingType::delta && from_status()) {
             DoubleComplex const z0_series = 1.0 / y_series + 3.0 * z_grounding_from_ / k / k;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.yff() = (y0_series + y_shunt) / k / k;
         }
         // Dyn
-        if (winding_from_ == delta && winding_to_ == wye_n && to_status()) {
+        if (winding_from_ == WindingType::delta && winding_to_ == WindingType::wye_n && to_status()) {
             DoubleComplex const z0_series = 1.0 / y_series + 3.0 * z_grounding_to_;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.ytt() = (y0_series + y_shunt);
         }
         // ZN*
-        if (winding_from_ == zigzag_n && from_status()) {
+        if (winding_from_ == WindingType::zigzag_n && from_status()) {
             DoubleComplex const z0_series = (1.0 / y_series) * 0.1 + 3.0 * z_grounding_from_ / k / k;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.yff() = y0_series / k / k;
         }
         // *zn
-        if (winding_to_ == zigzag_n && to_status()) {
+        if (winding_to_ == WindingType::zigzag_n && to_status()) {
             DoubleComplex const z0_series = (1.0 / y_series) * 0.1 + 3.0 * z_grounding_to_;
             DoubleComplex const y0_series = 1.0 / z0_series;
             param0.ytt() = y0_series;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
@@ -75,7 +75,7 @@ class Container<RetrievableTypes<GettableTypes...>, StorageableTypes...> {
         // template<class... Args> Args&&... args perfect forwarding
         assert(!construction_complete_);
         // throw if id already exists
-        if (map_.find(id) != map_.end()) {
+        if (map_.contains(id)) {
             throw ConflictID{id};
         }
         // find group and position

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
@@ -140,8 +140,6 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
     // different selection based on component type
     template <std::derived_from<Base> CompType, std::forward_iterator ForwardIterator>
     void add_component(ForwardIterator begin, ForwardIterator end) {
-        using enum MeasuredTerminalType;
-
         assert(!construction_complete_);
         size_t size = std::distance(begin, end);
         components_.template reserve<CompType>(size);
@@ -187,6 +185,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                 ID const measured_object = input.measured_object;
                 // check correctness of measured component type based on measured terminal type
                 switch (input.measured_terminal_type) {
+                    using enum MeasuredTerminalType;
+
                     case branch_from:
                     case branch_to:
                         components_.template get_item<Branch>(measured_object);
@@ -353,9 +353,9 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         std::transform(components_.template citer<GenericPowerSensor>().begin(),
                        components_.template citer<GenericPowerSensor>().end(),
                        comp_topo.power_sensor_object_idx.begin(), [this](GenericPowerSensor const& power_sensor) {
-                           using enum MeasuredTerminalType;
-
                            switch (power_sensor.get_terminal_type()) {
+                               using enum MeasuredTerminalType;
+
                                case branch_from:
                                case branch_to:
                                    return components_.template get_seq<Branch>(power_sensor.measured_object());
@@ -843,11 +843,11 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
             comp_topo_->power_sensor_object_idx.cbegin() +
                 components_.template get_start_idx<GenericPowerSensor, Component>(),
             res_it, [this, &math_output](GenericPowerSensor const& power_sensor, Idx const obj_seq) {
-                using enum MeasuredTerminalType;
-
                 auto const terminal_type = power_sensor.get_terminal_type();
                 Idx2D const obj_math_id = [&]() {
                     switch (terminal_type) {
+                        using enum MeasuredTerminalType;
+
                         case branch_from:
                         case branch_to:
                             return comp_coup_->branch[obj_seq];
@@ -878,6 +878,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                 }
 
                 switch (terminal_type) {
+                    using enum MeasuredTerminalType;
+
                     case branch_from:
                     // all power sensors in branch3 are at from side in the mathematical model
                     case branch3_1:

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
@@ -141,15 +141,17 @@ class IterativeCurrentPFSolver : public IterativePFSolver<sym, IterativeCurrentP
                 // load type
                 LoadGenType const type = load_gen_type[load_number];
                 switch (type) {
-                    case LoadGenType::const_pq:
+                    using enum LoadGenType;
+
+                    case const_pq:
                         // I_inj_i = conj(S_inj_j/U_i) for constant PQ type
                         rhs_u_[bus_number] += conj(input.s_injection[load_number] / u[bus_number]);
                         break;
-                    case LoadGenType::const_y:
+                    case const_y:
                         // I_inj_i = conj((S_inj_j * abs(U_i)^2) / U_i) = conj((S_inj_j) * U_i for const impedance type
                         rhs_u_[bus_number] += conj(input.s_injection[load_number]) * u[bus_number];
                         break;
-                    case LoadGenType::const_i:
+                    case const_i:
                         // I_inj_i = conj(S_inj_j*abs(U_i)/U_i) for const current type
                         rhs_u_[bus_number] +=
                             conj(input.s_injection[load_number] * cabs(u[bus_number]) / u[bus_number]);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
@@ -130,16 +130,18 @@ class IterativePFSolver {
                  ++load_gen) {
                 LoadGenType const type = (*load_gen_type_)[load_gen];
                 switch (type) {
-                    case LoadGenType::const_pq:
+                    using enum LoadGenType;
+
+                    case const_pq:
                         // always same power
                         output.load_gen[load_gen].s = input.s_injection[load_gen];
                         break;
-                    case LoadGenType::const_y:
+                    case const_y:
                         // power is quadratic relation to voltage
                         output.load_gen[load_gen].s =
                             input.s_injection[load_gen] * cabs(output.u[bus]) * cabs(output.u[bus]);
                         break;
-                    case LoadGenType::const_i:
+                    case const_i:
                         // power is linear relation to voltage
                         output.load_gen[load_gen].s = input.s_injection[load_gen] * cabs(output.u[bus]);
                         break;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
@@ -38,19 +38,21 @@ class MathSolver {
 
     MathOutput<sym> run_power_flow(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
                                    CalculationInfo& calculation_info, CalculationMethod calculation_method) {
+        using enum CalculationMethod;
+
         // set method to always linear if all load_gens have const_y
-        calculation_method = all_const_y_ ? CalculationMethod::linear : calculation_method;
+        calculation_method = all_const_y_ ? linear : calculation_method;
 
         switch (calculation_method) {
-            case CalculationMethod::default_method:
+            case default_method:
                 [[fallthrough]];  // use Newton-Raphson by default
-            case CalculationMethod::newton_raphson:
+            case newton_raphson:
                 return run_power_flow_newton_raphson(input, err_tol, max_iter, calculation_info);
-            case CalculationMethod::linear:
+            case linear:
                 return run_power_flow_linear(input, err_tol, max_iter, calculation_info);
-            case CalculationMethod::linear_current:
+            case linear_current:
                 return run_power_flow_linear_current(input, err_tol, max_iter, calculation_info);
-            case CalculationMethod::iterative_current:
+            case iterative_current:
                 return run_power_flow_iterative_current(input, err_tol, max_iter, calculation_info);
             default:
                 throw InvalidCalculationMethod{};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/power_grid_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/power_grid_model.hpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <numbers>
 #include <numeric>
 #include <string>
 #include <tuple>
@@ -45,19 +46,20 @@ using IdxCount = boost::counting_iterator<Idx>;
 struct Idx2D {
     Idx group;  // sequence number of outer module/groups
     Idx pos;    //  sequence number inside the group
+
+    friend constexpr bool operator==(Idx2D x, Idx2D y) = default;
 };
-inline bool operator==(Idx2D x, Idx2D y) {
-    return x.group == y.group && x.pos == y.pos;
-}
 
 // math constant
 using namespace std::complex_literals;
 using DoubleComplex = std::complex<double>;
-constexpr double sqrt3 = 1.73205080756887729;
-constexpr double sqrt3_inv = 1.0 / sqrt3;
+
+using std::numbers::inv_sqrt3;
+using std::numbers::pi;
+using std::numbers::sqrt3;
+
 constexpr DoubleComplex a2{-0.5, -sqrt3 / 2.0};
 constexpr DoubleComplex a{-0.5, sqrt3 / 2.0};
-constexpr double pi = 3.14159265358979323;
 constexpr double deg_30 = 1.0 / 6.0 * pi;
 constexpr double deg_120 = 2.0 / 3.0 * pi;
 constexpr double deg_240 = 4.0 / 3.0 * pi;
@@ -70,7 +72,7 @@ constexpr ID na_IntID = std::numeric_limits<ID>::min();
 constexpr double base_power_3p = 1e6;
 constexpr double base_power_1p = base_power_3p / 3.0;
 template <bool sym>
-constexpr double u_scale = sym ? 1.0 : sqrt3_inv;
+constexpr double u_scale = sym ? 1.0 : inv_sqrt3;
 template <bool sym>
 constexpr double base_power = sym ? base_power_3p : base_power_1p;
 // links are direct line between nodes with infinite element_admittance in theory

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/three_phase_tensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/three_phase_tensor.hpp
@@ -234,7 +234,7 @@ inline double mean_val(double z) {
 }
 
 template <bool sym, class T>
-inline auto process_mean_val(T&& m) {
+inline auto process_mean_val(const T& m) {
     if constexpr (sym) {
         return mean_val(m);
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/timer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/timer.hpp
@@ -14,7 +14,7 @@
 namespace power_grid_model {
 
 class Timer {
-   protected:
+   private:
     CalculationInfo *info_;
     int code_;
     std::string name_;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/timer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/timer.hpp
@@ -27,10 +27,9 @@ class Timer {
         : info_(&info), code_(code), name_(std::move(name)), start_(Clock::now()) {
     }
 
-    ~Timer() {
-        if (info_)
-            stop();
-    }
+    Timer(const Timer &) = delete;
+    Timer(Timer &&) = default;
+    Timer &operator=(const Timer &) = delete;
 
     Timer &operator=(Timer &&timer) noexcept {
         // Stop the current timer
@@ -47,6 +46,11 @@ class Timer {
 
         // Return reference
         return *this;
+    }
+
+    ~Timer() {
+        if (info_)
+            stop();
     }
 
     void stop() {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
@@ -511,14 +511,16 @@ class Topology {
         Idx2D find_math_object(Idx component_i) const {
             Idx const obj_idx = sensor_obj_idx[component_i];
             switch (power_sensor_terminal_type[component_i]) {
-                case MeasuredTerminalType::branch_from:
+                using enum MeasuredTerminalType;
+
+                case branch_from:
                     return branch_coupling[obj_idx];
                 // return relevant branch mapped from branch3
-                case MeasuredTerminalType::branch3_1:
+                case branch3_1:
                     return {branch3_coupling[obj_idx].group, branch3_coupling[obj_idx].pos[0]};
-                case MeasuredTerminalType::branch3_2:
+                case branch3_2:
                     return {branch3_coupling[obj_idx].group, branch3_coupling[obj_idx].pos[1]};
-                case MeasuredTerminalType::branch3_3:
+                case branch3_3:
                     return {branch3_coupling[obj_idx].group, branch3_coupling[obj_idx].pos[2]};
                 default:
                     assert(false);
@@ -637,11 +639,13 @@ class Topology {
         // branch 'from' power sensors
         // include all branch3 sensors
         auto const predicate_from_sensor = [&](Idx i) {
-            return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::branch_from ||
+            using enum MeasuredTerminalType;
+
+            return comp_topo_.power_sensor_terminal_type[i] == branch_from ||
                    // all branch3 sensors are at from side in the mathemtical model
-                   comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::branch3_1 ||
-                   comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::branch3_2 ||
-                   comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::branch3_3;
+                   comp_topo_.power_sensor_terminal_type[i] == branch3_1 ||
+                   comp_topo_.power_sensor_terminal_type[i] == branch3_2 ||
+                   comp_topo_.power_sensor_terminal_type[i] == branch3_3;
         };
         SensorBranchObjectFinder const object_finder_from_sensor{comp_topo_.power_sensor_object_idx,
                                                                  comp_topo_.power_sensor_terminal_type,

--- a/power_grid_model_c/power_grid_model_c/power_grid_model_c.cpp
+++ b/power_grid_model_c/power_grid_model_c/power_grid_model_c.cpp
@@ -35,7 +35,7 @@ struct PGM_Handle {
     IdxVector failed_scenarios;
     std::vector<std::string> batch_errs;
     mutable std::vector<char const*> batch_errs_c_str;
-    BatchParameter batch_parameter;
+    [[no_unique_address]] BatchParameter batch_parameter;
 };
 
 // options

--- a/tests/cpp_unit_tests/test_main_model.cpp
+++ b/tests/cpp_unit_tests/test_main_model.cpp
@@ -166,9 +166,8 @@ TEST_CASE("Test main model") {
         CHECK_THROWS_AS(main_model2.add_component<SymVoltageSensor>(state.sym_voltage_sensor_input), IDWrongType);
 
         // Test for all MeasuredTerminalType instances
-        std::vector<MeasuredTerminalType> const mt_types{
-            MeasuredTerminalType::branch_from, MeasuredTerminalType::branch_to, MeasuredTerminalType::generator,
-            MeasuredTerminalType::load,        MeasuredTerminalType::shunt,     MeasuredTerminalType::source};
+        using enum MeasuredTerminalType;
+        std::vector<MeasuredTerminalType> const mt_types{branch_from, branch_to, generator, load, shunt, source};
 
         // power sensor with terminal branch, with a measured id which is not a branch (node)
         for (auto const& mt_type : mt_types) {

--- a/tests/cpp_unit_tests/test_topology.cpp
+++ b/tests/cpp_unit_tests/test_topology.cpp
@@ -88,12 +88,6 @@
  */
 
 namespace power_grid_model {
-
-// define operators
-inline bool operator==(Idx2DBranch3 x, Idx2DBranch3 y) {
-    return x.group == y.group && x.pos == y.pos;
-}
-
 std::ostream& operator<<(std::ostream& s, Idx2D const& idx) {
     s << "(" << idx.group << ", " << idx.pos << ")";
     return s;

--- a/tests/cpp_validation_tests/test_validation.cpp
+++ b/tests/cpp_validation_tests/test_validation.cpp
@@ -295,7 +295,7 @@ struct CaseParam {
     bool sym{};
     bool is_batch{};
     double rtol{};
-    BatchParameter batch_parameter{};
+    [[no_unique_address]] BatchParameter batch_parameter{};
     std::map<std::string, double> atol;
 
     static std::string replace_backslash(std::string const& str) {


### PR DESCRIPTION
resolves some low-hanging fruits from sonar cloud. i did not dig too deep into which issues to resolve first, just looked at a couple easy ones:

* `using enum MeasuredTerminalType` https://sonarcloud.io/project/issues?open=AYe9198zcdHTx0no7scV&id=PowerGridModel_power-grid-model and equivalent (cfr. [cpp:S6177](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6177&rule_key=cpp%3AS6177))
* `std::numbers::sqrt3` https://sonarcloud.io/project/issues?open=AYe919-PcdHTx0no7sck&id=PowerGridModel_power-grid-model and equivalent (cfr. [cpp:S6164](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6164&rule_key=cpp%3AS6164))
* `using enum WindingType` https://sonarcloud.io/project/issues?open=AYe919uJcdHTx0no7sbU&id=PowerGridModel_power-grid-model and equivalent (cfr. [cpp:S6177](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6177&rule_key=cpp%3AS6177))
* `friend bool operator==(T, T) = default` https://sonarcloud.io/project/issues?open=AYe919-PcdHTx0no7scj&id=PowerGridModel_power-grid-model (cfr. [cpp:S6230](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6230&rule_key=cpp%3AS6230))
* `std::unordered_map::contains` https://sonarcloud.io/project/issues?open=AYe919_QcdHTx0no7sc7&id=PowerGridModel_power-grid-model (cfr. [cpp:S6171](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6171&rule_key=cpp%3AS6171))
* `using enum LoadGenType` https://sonarcloud.io/project/issues?open=AYe9194WcdHTx0no7sbf&id=PowerGridModel_power-grid-model (cfr. [cpp:S6177](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS6177&rule_key=cpp%3AS6177))
* remove unused move https://sonarcloud.io/project/issues?open=AYcsrspGzfpi9utDw93L&id=PowerGridModel_power-grid-model ([cpp:S5425](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS5425&rule_key=cpp%3AS5425))
* rule of three, five, zero https://sonarcloud.io/project/issues?open=AYcsrsoCzfpi9utDw916&id=PowerGridModel_power-grid-model ([cpp:S4963](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS4963&rule_key=cpp%3AS4963))
* `protected` member variables to `private` https://sonarcloud.io/project/issues?open=AYcsrsoCzfpi9utDw918&id=PowerGridModel_power-grid-model ([cpp:S3656](https://sonarcloud.io/organizations/powergridmodel/rules?open=cpp%3AS3656&rule_key=cpp%3AS3656))