### PR TITLE
github actions windows fail with test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,21 +114,22 @@ jobs:
           $vsPath = &(Join-Path ${env:ProgramFiles(x86)} '\Microsoft Visual Studio\Installer\vswhere.exe') -property installationpath
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+
           # generate cmake cache
-          cmake --preset ${{ env.PRESET }} -DCMAKE_PREFIX_PATH=C:\conda_envs\cpp_pkgs\Library
+          cmake --preset ${{ env.PRESET }} -DCMAKE_PREFIX_PATH=C:\conda_envs\cpp_pkgs\Library; if(!$?) { Exit $LASTEXITCODE }
           # build
-          cmake --build --preset ${{ env.PRESET }} --verbose -j 1
+          cmake --build --preset ${{ env.PRESET }} --verbose -j 1; if(!$?) { Exit $LASTEXITCODE }
           # test
-          ctest --test-dir . --output-on-failure
+          ctest --test-dir cpp_build\${{ env.PRESET }} --output-on-failure; if(!$?) { Exit $LASTEXITCODE }
           # install
-          cmake --build --preset ${{ env.PRESET }} --verbose -j 1 --target install
+          cmake --build --preset ${{ env.PRESET }} --verbose -j 1 --target install; if(!$?) { Exit $LASTEXITCODE }
 
           # build and run integration test
-          cd tests/package_tests
-          cmake --preset ${{ env.PRESET }}
-          cmake --build --preset ${{ env.PRESET }} --verbose -j 1
-          cmake --build --preset ${{ env.PRESET }} --verbose -j 1 --target install
-          install\${{ env.PRESET }}\bin\power_grid_model_package_test
+          cd tests/package_tests; if(!$?) { Exit $LASTEXITCODE }
+          cmake --preset ${{ env.PRESET }}; if(!$?) { Exit $LASTEXITCODE }
+          cmake --build --preset ${{ env.PRESET }} --verbose -j 1; if(!$?) { Exit $LASTEXITCODE }
+          cmake --build --preset ${{ env.PRESET }} --verbose -j 1 --target install; if(!$?) { Exit $LASTEXITCODE }
+          install\${{ env.PRESET }}\bin\power_grid_model_package_test; if(!$?) { Exit $LASTEXITCODE }
 
   build-cpp-test-macos:
     if: (github.event_name == 'push')  || (github.event_name == 'workflow_dispatch') || (!startsWith(github.head_ref, 'release'))

--- a/tests/cpp_unit_tests/test_main_model.cpp
+++ b/tests/cpp_unit_tests/test_main_model.cpp
@@ -1133,8 +1133,4 @@ TEST_CASE("Test main model - incomplete input but complete dataset") {
     }
 }
 
-TEST_CASE("always fail") {
-    CHECK(false);
-}
-
 }  // namespace power_grid_model

--- a/tests/cpp_unit_tests/test_main_model.cpp
+++ b/tests/cpp_unit_tests/test_main_model.cpp
@@ -1133,4 +1133,8 @@ TEST_CASE("Test main model - incomplete input but complete dataset") {
     }
 }
 
+TEST_CASE("always fail") {
+    CHECK(false);
+}
+
 }  // namespace power_grid_model


### PR DESCRIPTION
The github actions for Windows did not fail even though individual steps failed. Was able to repro locally and determined that it was because of `trap` behaviour of PowerShell. This fixes that.

* PowerShell doesn't have an option like `bash -e` or `trap err`.
* There is an option to set default error behaviour using `$ErrorActionPreference = 'Stop'` but it doesn't work for executables (only for scripts that `throw`)
* There is an alternative (see https://stackoverflow.com/questions/9948517/how-to-stop-a-powershell-script-on-the-first-error ) but it requires setting up a separate function and calling it after every single line.
* This was the only short-hand that worked