### PR TITLE
Feature/improve fault enum order

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -493,14 +493,14 @@ the meaning of `RealValueInput` is different, as shown in the table below.
 `fault` defines a short circuit location in the grid. At this moment a fault can only happen at a `node`.
 
 #### Input
-| name           | data type                                                | unit    | description                                         |       required       |  update  |   valid values    |
-| -------------- | -------------------------------------------------------- | ------- | --------------------------------------------------- | :------------------: | :------: | :---------------: |
-| `status`       | `int8_t`                                                 | -       | whether the fault is active                         |       &#10004;       | &#10004; |    `0` or `1`     |
-| `fault_type`   | {py:class}`FaultType <power_grid_model.enum.FaultType>   | -       | the type of the fault                               |       &#10004;       | &#10004; |                   |
-| `fault_phase`  | {py:class}`FaultPhase <power_grid_model.enum.FaultPhase> | -       | the phase(s) of the fault                           |       &#10004;       | &#10004; |                   |
-| `fault_object` | `int32_t`                                                | -       | ID of the component where the short circuit happens |       &#10004;       | &#10004; | A valid `node` ID |
-| `r_f`          | `double`                                                 | ohm (Ω) | short circuit resistance                            | &#10060; default 0.0 | &#10060; |                   |
-| `x_f`          | `double`                                                 | ohm (Ω) | short circuit reactance                             | &#10060; default 0.0 | &#10060; |                   |
+| name           | data type                                                 | unit    | description                                         |       required       |  update  |   valid values    |
+| -------------- | --------------------------------------------------------- | ------- | --------------------------------------------------- | :------------------: | :------: | :---------------: |
+| `status`       | `int8_t`                                                  | -       | whether the fault is active                         |       &#10004;       | &#10004; |    `0` or `1`     |
+| `fault_type`   | {py:class}`FaultType <power_grid_model.enum.FaultType>`   | -       | the type of the fault                               |       &#10004;       | &#10004; |                   |
+| `fault_phase`  | {py:class}`FaultPhase <power_grid_model.enum.FaultPhase>` | -       | the phase(s) of the fault                           |       &#10004;       | &#10004; |                   |
+| `fault_object` | `int32_t`                                                 | -       | ID of the component where the short circuit happens |       &#10004;       | &#10004; | A valid `node` ID |
+| `r_f`          | `double`                                                  | ohm (Ω) | short circuit resistance                            | &#10060; default 0.0 | &#10060; |                   |
+| `x_f`          | `double`                                                  | ohm (Ω) | short circuit reactance                             | &#10060; default 0.0 | &#10060; |                   |
 
 #### Steady state output
 A `fault` has no steady state output.

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/enum.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/enum.hpp
@@ -76,13 +76,13 @@ enum class YBusElementType : IntS {
 
 enum class FaultType : IntS {
     three_phase = 0,
-    two_phase = 1,
-    two_phase_to_ground = 2,
-    single_phase_to_ground = 3,
+    single_phase_to_ground = 1,
+    two_phase = 2,
+    two_phase_to_ground = 3,
     default_value = na_IntS
 };
 
-enum class FaultPhase : IntS { a = 0, b = 1, c = 2, ab = 3, ac = 4, bc = 5, abc = 6, default_value = na_IntS };
+enum class FaultPhase : IntS { abc = 0, a = 1, b = 2, c = 3, ab = 4, ac = 5, bc = 6, default_value = na_IntS };
 
 }  // namespace power_grid_model
 

--- a/src/power_grid_model/enum.py
+++ b/src/power_grid_model/enum.py
@@ -116,9 +116,9 @@ class FaultType(IntEnum):
     """The type of fault represented by a fault component"""
 
     three_phase = 0
-    two_phase = 1
-    two_phase_to_ground = 2
-    single_phase_to_ground = 3
+    single_phase_to_ground = 1
+    two_phase = 2
+    two_phase_to_ground = 3
     default_value = -128
     """
     Unspecified fault phase. Like np.nan. Needs to be overloaded at the latest in the update_data
@@ -128,33 +128,33 @@ class FaultType(IntEnum):
 class FaultPhase(IntEnum):
     """The faulty phase(s) affected by the provided fault type"""
 
-    a = 0
+    abc = 0
+    """
+    All phases are faulty in a three-phase fault
+    """
+    a = 1
     """
     The first phase is faulty in a single-phase-to-ground fault
     """
-    b = 1
+    b = 2
     """
     The second phase is faulty in a single-phase-to-ground fault
     """
-    c = 2
+    c = 3
     """
     The third phase is faulty in a single-phase-to-ground fault
     """
-    ab = 3
+    ab = 4
     """
     The first and second phase are faulty in a two-phase or two-phase-to-ground fault
     """
-    ac = 4
+    ac = 5
     """
     The first and third phase are faulty in a two-phase or two-phase-to-ground fault
     """
-    bc = 5
+    bc = 6
     """
     The first and second phase are faulty in a two-phase or two-phase-to-ground fault
-    """
-    abc = 6
-    """
-    All phases are faulty in a three-phase fault
     """
     default_value = -128
     """

--- a/tests/data/short_circuit/single_phase_to_ground_a/input.json
+++ b/tests/data/short_circuit/single_phase_to_ground_a/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 0, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 1, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/single_phase_to_ground_b/input.json
+++ b/tests/data/short_circuit/single_phase_to_ground_b/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 1, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 2, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/single_phase_to_ground_c/input.json
+++ b/tests/data/short_circuit/single_phase_to_ground_c/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 2, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 3, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/three_phase_abc/input.json
+++ b/tests/data/short_circuit/three_phase_abc/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 0, "fault_phase": 6, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 0, "fault_phase": 0, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_ab/input.json
+++ b/tests/data/short_circuit/two_phase_ab/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 3, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 4, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_ac/input.json
+++ b/tests/data/short_circuit/two_phase_ac/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 4, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 5, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_bc/input.json
+++ b/tests/data/short_circuit/two_phase_bc/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 1, "fault_phase": 5, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 6, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_to_ground_ab/input.json
+++ b/tests/data/short_circuit/two_phase_to_ground_ab/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 3, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 4, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_to_ground_ac/input.json
+++ b/tests/data/short_circuit/two_phase_to_ground_ac/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 4, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 5, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }

--- a/tests/data/short_circuit/two_phase_to_ground_bc/input.json
+++ b/tests/data/short_circuit/two_phase_to_ground_bc/input.json
@@ -26,6 +26,6 @@
     ],
   "fault":
     [
-      {"id": 10, "status": 1, "fault_type": 2, "fault_phase": 5, "fault_object": 3, "r": 0.1, "x": 0.1}
+      {"id": 10, "status": 1, "fault_type": 3, "fault_phase": 6, "fault_object": 3, "r": 0.1, "x": 0.1}
     ]
 }


### PR DESCRIPTION
It was found that the fault types and phases enum order is quite annoying.

From a user perspctive, it is expected to have e.g. `three_phases` to match with the `abc` int value, e.g.: `0` resp `0`.

Currently, the values do not match: `three_phases == 0` but `abc == 6`

This PR resolves that mismatch