### PR TITLE
Feature/fix clang tidy

### DIFF
--- a/tests/cpp_validation_tests/test_validation.cpp
+++ b/tests/cpp_validation_tests/test_validation.cpp
@@ -93,7 +93,7 @@ Buffer parse_single_type(json const& j, MetaComponent const& meta) {
     size_t const length = j.size();
     size_t const obj_size = meta.size;
     buffer.ptr = create_buffer(obj_size, length);
-    meta.set_nan(buffer.ptr.get(), 0, length);
+    meta.set_nan(buffer.ptr.get(), 0, static_cast<PGM_MetaComponent::Idx>(length));
     for (Idx position = 0; position != static_cast<Idx>(length); ++position) {
         parse_single_object(buffer.ptr.get(), j[position], meta, position);
     }


### PR DESCRIPTION
Apparently, #296 was auto-merged even though one of the checks failed (`clang-tidy`). This fixes that