### PR TITLE
Feature/reduce clang tidy build

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -62,7 +62,7 @@ jobs:
           brew install boost eigen nlohmann-json doctest
 
       - name: Set build target in case of push
-        if: github.event_name == 'push'
+        if: github.event_name != 'workflow_dispatch'
         run: |
           echo "TARGET=power_grid_model_c" >> $GITHUB_ENV
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,8 +17,12 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        type: string
-        default: power_grid_model_c  # only build the C API by default
+        type: choice
+        description: The CMake target to run
+        default: power_grid_model_c
+        options:
+          - all
+          - power_grid_model_c
         required: true
 
 concurrency:
@@ -62,7 +66,7 @@ jobs:
         run: |
           echo "TARGET=${{ github.event.inputs.target }}"
 
-      - name: Build
+      - name: Configure
         run: |
           cmake --preset ${{ env.PRESET }}
           cmake --build --preset ${{ env.PRESET }} --target ${{ env.TARGET }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Override build target in case of workflow dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "TARGET=${{ github.event.inputs }}"
+          echo "TARGET=${{ github.event.inputs.target }}"
 
       - name: Build
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,6 +14,13 @@ on:
   # run pipeline on pull request
   pull_request:
 
+  workflow_dispatch:
+    inputs:
+      target:
+        type: string
+        default: power_grid_model_c  # only build the C API by default
+        required: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -46,4 +53,4 @@ jobs:
         run: |
           brew install boost eigen nlohmann-json doctest
       - name: Build and test
-        run: ./build.sh -p ${{ env.PRESET }}
+        run: ./build.sh -p ${{ env.PRESET }} --target ${{ github.event.inputs.target }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,7 +43,6 @@ jobs:
       CXX: clang++-14
       CLANG_TIDY: clang-tidy-14
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
-      TARGET: nonexistant
 
     steps:
       - uses: actions/checkout@v3
@@ -61,12 +60,16 @@ jobs:
         run: |
           brew install boost eigen nlohmann-json doctest
 
-      - name: Override build target in case of workflow dispatch
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          echo "TARGET=power_grid_model_c"
-
       - name: Configure
         run: |
           cmake --preset ${{ env.PRESET }}
-          cmake --build --preset ${{ env.PRESET }} --target ${{ env.TARGET }}
+
+      - name: Build target (push trigger)
+        if: github.event_name == 'push'
+        run: |
+          cmake --build --preset ${{ env.PRESET }} --target power_grid_model_c
+
+      - name: Build target (workflow dispatch trigger)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          cmake --build --preset ${{ env.PRESET }} --target ${{ github.event.inputs.target }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,7 +43,7 @@ jobs:
       CXX: clang++-14
       CLANG_TIDY: clang-tidy-14
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
-      TARGET: power_grid_model_c
+      TARGET: nonexistant
 
     steps:
       - uses: actions/checkout@v3
@@ -62,9 +62,9 @@ jobs:
           brew install boost eigen nlohmann-json doctest
 
       - name: Override build target in case of workflow dispatch
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch'
         run: |
-          echo "TARGET=${{ github.event.inputs.target }}"
+          echo "TARGET=power_grid_model_c"
 
       - name: Configure
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,6 +43,7 @@ jobs:
       CXX: clang++-14
       CLANG_TIDY: clang-tidy-14
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
+      TARGET: nonexistent
 
     steps:
       - uses: actions/checkout@v3
@@ -60,16 +61,17 @@ jobs:
         run: |
           brew install boost eigen nlohmann-json doctest
 
-      - name: Configure
-        run: |
-          cmake --preset ${{ env.PRESET }}
-
-      - name: Build target (push trigger)
-        if: github.event_name == 'push'
-        run: |
-          cmake --build --preset ${{ env.PRESET }} --target power_grid_model_c
-
-      - name: Build target (workflow dispatch trigger)
+      - name: Override build target in case of workflow dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
-          cmake --build --preset ${{ env.PRESET }} --target ${{ github.event.inputs.target }}
+          echo "TARGET=${{ github.event.inputs.target }}" >> $GITHUB_ENV
+
+      - name: Override build target in case of workflow dispatch
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "TARGET=power_grid_model_c" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          cmake --preset ${{ env.PRESET }}
+          cmake --build --preset ${{ env.PRESET }} --target ${{ env.TARGET }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -64,4 +64,5 @@ jobs:
 
       - name: Build
         run: |
-          cmake --preset ${{ env.PRESET }} --target ${{ env.TARGET }}
+          cmake --preset ${{ env.PRESET }}
+          cmake --build --preset ${{ env.PRESET }} --target ${{ env.TARGET }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,18 +39,29 @@ jobs:
       CXX: clang++-14
       CLANG_TIDY: clang-tidy-14
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
+      TARGET: power_grid_model_c
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Install packages
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build
+
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+
       - name: Install C++ dependencies
         run: |
           brew install boost eigen nlohmann-json doctest
-      - name: Build and test
-        run: ./build.sh -p ${{ env.PRESET }} --target ${{ github.event.inputs.target }}
+
+      - name: Override build target in case of workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "TARGET=${{ github.event.inputs }}"
+
+      - name: Build
+        run: |
+          cmake --preset ${{ env.PRESET }} --target ${{ env.TARGET }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,7 +43,7 @@ jobs:
       CXX: clang++-14
       CLANG_TIDY: clang-tidy-14
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
-      TARGET: nonexistent
+      TARGET: nonexistent  # will be overwritten later in this action
 
     steps:
       - uses: actions/checkout@v3
@@ -61,15 +61,15 @@ jobs:
         run: |
           brew install boost eigen nlohmann-json doctest
 
-      - name: Override build target in case of workflow dispatch
+      - name: Set build target in case of push
+        if: github.event_name == 'push'
+        run: |
+          echo "TARGET=power_grid_model_c" >> $GITHUB_ENV
+
+      - name: Set build target in case of workflow dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo "TARGET=${{ github.event.inputs.target }}" >> $GITHUB_ENV
-
-      - name: Override build target in case of workflow dispatch
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          echo "TARGET=power_grid_model_c" >> $GITHUB_ENV
 
       - name: Build
         run: |


### PR DESCRIPTION
Not fond of it but this is the only way to improve the compile time for clang tidy without matrix testing for build target

* only build the C API target for clang tidy by default
* add manual trigger option to override the target