### PR TITLE
allow for infinite voltage measurement sigmas

### DIFF
--- a/tests/data/state_estimation/high-variance-measurement/input.json
+++ b/tests/data/state_estimation/high-variance-measurement/input.json
@@ -45,6 +45,18 @@
       "measured_object": 11,
       "u_measured": 10.5e3,
       "u_sigma": 105.0
+    },
+    {
+      "id": 72,
+      "measured_object": 11,
+      "u_measured": 10.5e3,
+      "u_sigma": 1e300
+    },
+    {
+      "id": 73,
+      "measured_object": 12,
+      "u_measured": 10.5e3,
+      "u_sigma": 1e300
     }
   ],
   "sym_power_sensor": [


### PR DESCRIPTION
During wrap-up of creating the workshop for infinite sigmas (related to yesterday's demo) I noticed that infinite voltage sigmas are still illegal. This fix was quite straightforward so i went ahead and did it