### PR TITLE
Feature/recombine enumerated zip sequence

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/grouped_index_vector.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/grouped_index_vector.hpp
@@ -209,13 +209,13 @@ class DenseGroupedIdxVector {
         constexpr auto distance_to(GroupIterator const& other) const { return other.group_ - group_; }
 
         constexpr void increment() {
-            group_ += 1;
+            ++group_;
             group_range_ = std::make_pair(group_range_.second,
                                           std::find_if(group_range_.second, std::cend(*dense_vector_),
                                                        [group = group_](Idx value) { return value > group; }));
         }
         constexpr void decrement() {
-            group_ -= 1;
+            --group_;
             group_range_ =
                 std::make_pair(std::find_if(std::make_reverse_iterator(group_range_.first), std::crend(*dense_vector_),
                                             [group = group_](Idx value) { return value < group; })

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
@@ -89,10 +89,8 @@ void calculate_result(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input,
     output.load_gen.resize(load_gens_per_bus.element_size());
     output.bus_injection.resize(sources_per_bus.size());
 
-    for (auto const& [bus_number, sources] : enumerated_zip_sequence(sources_per_bus)) {
+    for (auto const& [bus_number, sources, load_gens] : enumerated_zip_sequence(sources_per_bus, load_gens_per_bus)) {
         common_solver_functions::calculate_source_result<sym>(sources, bus_number, y_bus, input, output);
-    }
-    for (auto const& [bus_number, load_gens] : enumerated_zip_sequence(load_gens_per_bus)) {
         common_solver_functions::calculate_load_gen_result<sym>(load_gens, bus_number, input, output, load_gen_func);
     }
     output.bus_injection = y_bus.calculate_injection(output.u);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
@@ -120,10 +120,9 @@ template <bool sym> class IterativeCurrentPFSolver : public IterativePFSolver<sy
         std::fill(rhs_u_.begin(), rhs_u_.end(), ComplexValue<sym>{0.0});
 
         // loop buses: i
-        for (auto const& [bus_number, load_gens] : enumerated_zip_sequence(*this->load_gens_per_bus_)) {
+        for (auto const& [bus_number, load_gens, sources] :
+             enumerated_zip_sequence(*this->load_gens_per_bus_, *this->sources_per_bus_)) {
             add_loads(load_gens, bus_number, input, load_gen_type, u);
-        }
-        for (auto const& [bus_number, sources] : enumerated_zip_sequence(*this->sources_per_bus_)) {
             add_sources(sources, bus_number, y_bus, input);
         }
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -314,19 +314,15 @@ template <bool sym> class MeasuredValues {
     void process_appliance_measurements(StateEstimationInput<sym> const& input) {
         MathModelTopology const& topo = math_topology();
 
-        for (auto const& [bus, shunts] : enumerated_zip_sequence(topo.shunts_per_bus)) {
+        for (auto const& [bus, shunts, load_gens, sources] :
+             enumerated_zip_sequence(topo.shunts_per_bus, topo.load_gens_per_bus, topo.sources_per_bus)) {
             process_bus_objects(shunts, topo.power_sensors_per_shunt, input.shunt_status, input.measured_shunt_power,
                                 main_value_, idx_shunt_power_);
-        }
-        for (auto const& [bus, load_gens] : enumerated_zip_sequence(topo.load_gens_per_bus)) {
             process_bus_objects(load_gens, topo.power_sensors_per_load_gen, input.load_gen_status,
                                 input.measured_load_gen_power, extra_value_, idx_load_gen_power_);
-        }
-        for (auto const& [bus, sources] : enumerated_zip_sequence(topo.sources_per_bus)) {
             process_bus_objects(sources, topo.power_sensors_per_source, input.source_status,
                                 input.measured_source_power, extra_value_, idx_source_power_);
-        }
-        for (Idx bus = 0; bus != topo.n_bus(); ++bus) {
+
             combine_appliances_to_injection_measurements(input, topo, bus);
         }
     }


### PR DESCRIPTION
Resolve comments from knowledge sharing session:

* `++` and `--` instead of `+= 1` and `-= 1`
* zip-like loop over both `sources` and `load_gens` instead of two loops

@TonyXiang8787 I did a benchmark on (Clang CL) release build comparing `main` and this branch and it appears that `main` is almost consistently better. See also the benchmark outputs in [benchmark.zip](https://github.com/PowerGridModel/power-grid-model/files/13111445/benchmark.zip). My guess is that the zipped loop actually introduces more cache misses because there are more variables in the output. Maybe you can try to reproduce this? I think it would be a shame to replace efficient code by something that is less efficient, but I don't want to block this change if we cannot reproduce the regression


