### PR TITLE
bump Clang CI on Linux to LLVM-15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,8 @@ jobs:
             cc: gcc-11
             cxx: g++-11
           - compiler: clang
-            cc: clang-14
-            cxx: clang++-14
+            cc: clang-15
+            cxx: clang++-15
 
     env:
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
@@ -82,7 +82,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build
+          sudo apt-get install -y ninja-build clang-15
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,9 +26,9 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      LLVM_COV: llvm-cov-14
-      CC: clang-14
-      CXX: clang++-14
+      LLVM_COV: llvm-cov-15
+      CC: clang-15
+      CXX: clang++-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,7 +36,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build lcov gcovr
+          sudo apt-get install -y ninja-build clang-15 lcov gcovr
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -45,8 +45,8 @@ You need a C++ compiler with C++20 support. Below is a list of tested compilers:
   * Version 12.x tested using the version in the `manylinux_2_28` container.
   * Version 12.x tested using the musllinux build with custom compiler
   * Version 11.x tested in CI
-* Clang >= 14.0
-  * Version 14.x tested in CI
+* Clang >= 15.0
+  * Version 15.x tested in CI
   * Version 15.x tested in CI with code quality checks
 
 You can define the environment variable `CXX` to for example `clang++` to specify the C++ compiler.
@@ -55,7 +55,7 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 
 * MSVC >= 17.5
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
-* Clang CL >= 14.0
+* Clang CL >= 15.0
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 
 **macOS**
@@ -137,7 +137,7 @@ using `cmake <project_dir>` from a terminal that has the environment set up. E.g
 
 * For x64 Windows native development using MSVC or Clang CL, use the `x64 Native Command Prompt`, which uses
   `vcvarsall.bat` to set the appropriate build environment.
-* For Linux/WSL using the LLVM-14 `clang`, `source` or `export` `CC=clang-14`, `CXX=clang++-14` and `LLVM_COV=llvm-cov-14`. Optionally, you can `export` `CLANG_TIDY=clang-tidy-14`.
+* For Linux/WSL using the LLVM-15 `clang`, `source` or `export` `CC=clang-15`, `CXX=clang++-15` and `LLVM_COV=llvm-cov-15`. Optionally, you can `export` `CLANG_TIDY=clang-tidy-15`.
 ```
 
 ## Build Script for Linux/macOS
@@ -166,11 +166,11 @@ WSL), or in a physical/virtual machine.
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-14            # or g++-11
-export CC=clang-14               # gcc-11
+export CXX=clang++-15            # or g++-11
+export CC=clang-15               # gcc-11
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
-export LLVM_COV=llvm-cov-14
-export CLANG_TIDY=clang-tidy-14  # only if you want to use one of the clang-tidy presets
+export LLVM_COV=llvm-cov-15
+export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets
 ```
 
 ### Ubuntu Software Packages


### PR DESCRIPTION
This should fix the issue for us mentioned in https://github.com/actions/runner-images/issues/8659

now the new Ubuntu image for github runners is fully rolled-out, this prevents us from merging, e.g. https://github.com/PowerGridModel/power-grid-model/pull/417