### PR TITLE
Feature improve sparse matrix behaviour

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -203,8 +203,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
                     block_perm_array[pivot_row_col] = {lu_factor.permutationP(), lu_factor.permutationQ()};
                     return block_perm_array[pivot_row_col];
                 } else {
-                    auto const& lu_factor = lu_matrix[pivot_idx];
-                    if (!is_normal(lu_factor)) {
+                    if (!is_normal(lu_matrix[pivot_idx])) {
                         throw SparseMatrixError{};
                     }
                     return {};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -203,7 +203,8 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
                     block_perm_array[pivot_row_col] = {lu_factor.permutationP(), lu_factor.permutationQ()};
                     return block_perm_array[pivot_row_col];
                 } else {
-                    if (lu_matrix[pivot_idx] == 0.0) {
+                    auto const& lu_factor = lu_matrix[pivot_idx];
+                    if (!is_normal(lu_factor)) {
                         throw SparseMatrixError{};
                     }
                     return {};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/three_phase_tensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/three_phase_tensor.hpp
@@ -52,6 +52,11 @@ template <scalar_value T> class Vector : public Eigen3Vector<T> {
     explicit Vector(std::piecewise_construct_t /* tag */, T const& x) { (*this) << x, x, x; }
     // constructor of three values
     Vector(T const& x1, T const& x2, T const& x3) { (*this) << x1, x2, x3; }
+    // for complex, it is possible to construct from real part and imaginary part
+    template <std::floating_point U>
+        requires std::same_as<T, std::complex<U>>
+    Vector(Vector<U> real_part, Vector<U> imag_part)
+        : Vector{{real_part(0), imag_part(0)}, {real_part(1), imag_part(1)}, {real_part(2), imag_part(2)}} {}
 };
 
 template <scalar_value T> class Tensor : public Eigen3Tensor<T> {
@@ -275,7 +280,16 @@ inline bool is_nan(Enum x) {
 
 // is normal
 inline auto is_normal(std::floating_point auto value) { return std::isnormal(value); }
-inline auto is_normal(RealValue<false> const& value) {
+template <std::floating_point T> inline auto is_normal(std::complex<T> const& value) {
+    if (value.real() == T{0}) {
+        return is_normal(value.imag());
+    }
+    if (value.imag() == T{0}) {
+        return is_normal(value.real());
+    }
+    return is_normal(value.real()) && is_normal(value.imag());
+}
+template <class Derived> inline auto is_normal(Eigen::ArrayBase<Derived> const& value) {
     return is_normal(value(0)) && is_normal(value(1)) && is_normal(value(2));
 }
 

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -347,20 +347,45 @@ TEST_CASE_TEMPLATE("Test load generator", LoadGeneratorType, SymLoad, AsymLoad, 
 
     SUBCASE("Partial initialization and full update") {
         InputType input{};
-
-        input.p_specified = r_nan;
-        input.q_specified = RealValueType{1.0};
-
         UpdateType update{};
-        update.p_specified = RealValueType{1.0};
-        update.q_specified = r_nan;
+
+        input.status = 1;
+
+        SUBCASE("p_specified not provided") {
+            input.p_specified = r_nan;
+            input.q_specified = RealValueType{1.0};
+
+            update.p_specified = RealValueType{1.0};
+            update.q_specified = r_nan;
+        }
+
+        SUBCASE("q_specified not provided") {
+            input.p_specified = RealValueType{1.0};
+            input.q_specified = r_nan;
+
+            update.p_specified = r_nan;
+            update.q_specified = RealValueType{1.0};
+        }
+
+        SUBCASE("both not provided") {
+            input.p_specified = r_nan;
+            input.q_specified = r_nan;
+
+            update.p_specified = RealValueType{1.0};
+            update.q_specified = RealValueType{1.0};
+        }
 
         LoadGeneratorType load_gen{input, 1.0};
+
+        auto const result_incomplete = load_gen.template calc_param<true>(true);
+        CHECK(std::isnan(result_incomplete.real()));
+        CHECK(std::isnan(result_incomplete.imag()));
+
         load_gen.update(update);
 
-        auto const result = load_gen.template calc_param<true>(true);
-        CHECK_FALSE(std::isnan(result.real()));
-        CHECK_FALSE(std::isnan(result.imag()));
+        auto const result_complete = load_gen.template calc_param<true>(true);
+        CHECK_FALSE(std::isnan(result_complete.real()));
+        CHECK_FALSE(std::isnan(result_complete.imag()));
     }
 
     SUBCASE("Update inverse") {

--- a/tests/cpp_unit_tests/test_main_model.cpp
+++ b/tests/cpp_unit_tests/test_main_model.cpp
@@ -1108,7 +1108,8 @@ TEST_CASE("Test main model - incomplete input but complete dataset") {
     input_data["node"] = DataPointer<true>{state.node_input.data(), static_cast<Idx>(state.node_input.size())};
     input_data["line"] = DataPointer<true>{state.line_input.data(), static_cast<Idx>(state.line_input.size())};
     input_data["link"] = DataPointer<true>{state.link_input.data(), static_cast<Idx>(state.link_input.size())};
-    input_data["source"] = DataPointer<true>{state.source_input.data(), static_cast<Idx>(state.source_input.size())};
+    input_data["source"] =
+        DataPointer<true>{incomplete_source_input.data(), static_cast<Idx>(incomplete_source_input.size())};
     input_data["sym_load"] =
         DataPointer<true>{incomplete_sym_load_input.data(), static_cast<Idx>(incomplete_sym_load_input.size())};
     input_data["asym_load"] =
@@ -1201,6 +1202,36 @@ TEST_CASE("Test main model - incomplete input but complete dataset") {
         CHECK(test_asym_node[2].u_pu(1) == doctest::Approx(ref_asym_node[2].u_pu(1)));
         CHECK(test_asym_node[2].u_pu(2) == doctest::Approx(ref_asym_node[2].u_pu(2)));
     }
+
+    SUBCASE("Symmetrical - Incomplete") {
+        update_data = {};
+
+        std::vector<NodeOutput<true>> test_sym_node(state.sym_node.size());
+        std::vector<NodeOutput<true>> ref_sym_node(state.sym_node.size());
+        test_result_data["node"] = DataPointer<false>{test_sym_node.data(), static_cast<Idx>(test_sym_node.size())};
+        ref_result_data["node"] = DataPointer<false>{ref_sym_node.data(), static_cast<Idx>(ref_sym_node.size())};
+
+        CHECK_THROWS_AS(test_model.calculate_power_flow<true>(1e-8, 1, linear), SparseMatrixError);
+        CHECK_THROWS_AS(test_model.calculate_power_flow<true>(1e-8, 1, linear, test_result_data), SparseMatrixError);
+        CHECK_THROWS_AS(test_model.calculate_power_flow<true>(1e-8, 1, linear, test_result_data, update_data),
+                        SparseMatrixError);
+    }
+
+    SUBCASE("Asymmetrical - Incomplete") {
+        update_data = {};
+
+        std::vector<NodeOutput<false>> test_sym_node(state.sym_node.size());
+        std::vector<NodeOutput<false>> ref_sym_node(state.sym_node.size());
+        test_result_data["node"] = DataPointer<false>{test_sym_node.data(), static_cast<Idx>(test_sym_node.size())};
+        ref_result_data["node"] = DataPointer<false>{ref_sym_node.data(), static_cast<Idx>(ref_sym_node.size())};
+
+        CHECK_THROWS_AS(test_model.calculate_power_flow<false>(1e-8, 1, linear), SparseMatrixError);
+        CHECK_THROWS_AS(test_model.calculate_power_flow<false>(1e-8, 1, linear, test_result_data), SparseMatrixError);
+        CHECK_THROWS_AS(test_model.calculate_power_flow<false>(1e-8, 1, linear, test_result_data, update_data),
+                        SparseMatrixError);
+    }
 }
+
+TEST_CASE("Test main model - sparse errors") {}
 
 } // namespace power_grid_model

--- a/tests/cpp_unit_tests/test_main_model.cpp
+++ b/tests/cpp_unit_tests/test_main_model.cpp
@@ -1232,6 +1232,4 @@ TEST_CASE("Test main model - incomplete input but complete dataset") {
     }
 }
 
-TEST_CASE("Test main model - sparse errors") {}
-
 } // namespace power_grid_model

--- a/tests/cpp_validation_tests/test_validation.cpp
+++ b/tests/cpp_validation_tests/test_validation.cpp
@@ -262,7 +262,7 @@ void assert_result(ConstDataset const& result, ConstDataset const& reference_res
                         CHECK(match);
                     } else {
                         std::stringstream case_sstr;
-                        case_sstr << "scenario: #" << scenario << ", Component: " << type_name << " #" << obj
+                        case_sstr << "dataset scenario: #" << scenario << ", Component: " << type_name << " #" << obj
                                   << ", attribute: " << attr.name
                                   << ": actual = " << get_as_string(result_ptr, attr, obj) + " vs. expected = "
                                   << get_as_string(reference_result_ptr, attr, obj);
@@ -552,6 +552,8 @@ void validate_batch_case(CaseParam const& param) {
 
         // run in loops
         for (Idx scenario = 0; scenario != n_scenario; ++scenario) {
+            CAPTURE(scenario);
+
             MainModel model_copy{model};
 
             // update and run
@@ -567,6 +569,8 @@ void validate_batch_case(CaseParam const& param) {
         // run in one-go, with different threading possibility
         auto const batch_result = create_result_dataset(validation_case.input, output_prefix, true, n_scenario);
         for (Idx const threading : {-1, 0, 1, 2}) {
+            CAPTURE(threading);
+
             func(model, calculation_method_mapping.at(param.calculation_method), batch_result.dataset,
                  validation_case.update_batch.const_dataset, threading);
 


### PR DESCRIPTION
* improve the throwing of sparse matrix errors.
* improve the behaviour when required values `p_specified` and/or `q_specified` are not provided

The original behaviour is not necessarily an issue because:

* sparse matrix errors will already always be thrown in supported but underdetermined
* not providing both P and Q was already undefined behaviour (UB) according to the PGM docs. The data validator already forbids the edge case where P and/or Q are not specified.

this is **not** a breaking change.
