### PR TITLE
DGC 2106 Changes support python version from 3.8 to 3.9

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Upgrade pip
         run: pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test-command = "pytest {package}/tests"
 #    PyPy
 #    musllinux when python < 3.9
 #    musllinux in aarch64
-skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
+skip = ["pp*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test-command = "pytest {package}/tests"
 #    PyPy
 #    musllinux when python < 3.9
 #    musllinux in aarch64
-skip = ["pp*", "cp39-musllinux*", "*-musllinux_aarch64"]
+skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ test-extras = ["dev"]
 test-command = "pytest {package}/tests"
 # we do not support 
 #    PyPy
-#    musllinux when python < 3.9
 #    musllinux in aarch64
 skip = ["pp*", "*-musllinux_aarch64"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.21.0",
 ]
@@ -79,7 +79,7 @@ addopts = ["--cov=power_grid_model", "--cov-report", "term", "--cov-report", "ht
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"
@@ -107,7 +107,7 @@ test-command = "pytest {package}/tests"
 #    PyPy
 #    musllinux when python < 3.9
 #    musllinux in aarch64
-skip = ["pp*", "cp38-musllinux*", "*-musllinux_aarch64"]
+skip = ["pp*", "cp39-musllinux*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
Support Python >3.9 in PGM