### PR TITLE
Enhanced documentation on batch datasets 

### DIFF
--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -48,7 +48,7 @@ SPDX-License-Identifier: MPL-2.0
 .. autoclass:: power_grid_model.data_types.ComponentList
 .. autoclass:: power_grid_model.data_types.SinglePythonDataset
 .. autoclass:: power_grid_model.data_types.BatchPythonDataset
-.. autoclass:: power_grid_model.data_types.BatchPythonDataset
+.. autoclass:: power_grid_model.data_types.PythonDataset
 ```
 
 ### errors

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -34,21 +34,21 @@ SPDX-License-Identifier: MPL-2.0
 ## data types
 
 ```{eval-rst}
-.. autofunction:: power_grid_model.data_types.SparseBatchArray
-.. autofunction:: power_grid_model.data_types.BatchArray
-.. autofunction:: power_grid_model.data_types.SingleDataset
-.. autofunction:: power_grid_model.data_types.BatchDataset
-.. autofunction:: power_grid_model.data_types.Dataset
-.. autofunction:: power_grid_model.data_types.Batchlist
-.. autofunction:: power_grid_model.data_types.NominalValue
-.. autofunction:: power_grid_model.data_types.RealValue
-.. autofunction:: power_grid_model.data_types.AsymValue
-.. autofunction:: power_grid_model.data_types.AttributeValue
-.. autofunction:: power_grid_model.data_types.Component
-.. autofunction:: power_grid_model.data_types.ComponentList
-.. autofunction:: power_grid_model.data_types.SinglePythonDataset
-.. autofunction:: power_grid_model.data_types.BatchPythonDataset
-.. autofunction:: power_grid_model.data_types.BatchPythonDataset
+.. autoclass:: power_grid_model.data_types.SparseBatchArray
+.. autoclass:: power_grid_model.data_types.BatchArray
+.. autoclass:: power_grid_model.data_types.SingleDataset
+.. autoclass:: power_grid_model.data_types.BatchDataset
+.. autoclass:: power_grid_model.data_types.Dataset
+.. autoclass:: power_grid_model.data_types.Batchlist
+.. autoclass:: power_grid_model.data_types.NominalValue
+.. autoclass:: power_grid_model.data_types.RealValue
+.. autoclass:: power_grid_model.data_types.AsymValue
+.. autoclass:: power_grid_model.data_types.AttributeValue
+.. autoclass:: power_grid_model.data_types.Component
+.. autoclass:: power_grid_model.data_types.ComponentList
+.. autoclass:: power_grid_model.data_types.SinglePythonDataset
+.. autoclass:: power_grid_model.data_types.BatchPythonDataset
+.. autoclass:: power_grid_model.data_types.BatchPythonDataset
 ```
 
 ### errors

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -39,7 +39,7 @@ SPDX-License-Identifier: MPL-2.0
 .. autoclass:: power_grid_model.data_types.SingleDataset
 .. autoclass:: power_grid_model.data_types.BatchDataset
 .. autoclass:: power_grid_model.data_types.Dataset
-.. autoclass:: power_grid_model.data_types.Batchlist
+.. autoclass:: power_grid_model.data_types.BatchList
 .. autoclass:: power_grid_model.data_types.NominalValue
 .. autoclass:: power_grid_model.data_types.RealValue
 .. autoclass:: power_grid_model.data_types.AsymValue

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -34,21 +34,21 @@ SPDX-License-Identifier: MPL-2.0
 ## data types
 
 ```{eval-rst}
-.. autoclass:: power_grid_model.data_types.SparseBatchArray
-.. autoclass:: power_grid_model.data_types.BatchArray
-.. autoclass:: power_grid_model.data_types.SingleDataset
-.. autoclass:: power_grid_model.data_types.BatchDataset
-.. autoclass:: power_grid_model.data_types.Dataset
-.. autoclass:: power_grid_model.data_types.Batchlist
-.. autoclass:: power_grid_model.data_types.NominalValue
-.. autoclass:: power_grid_model.data_types.RealValue
-.. autoclass:: power_grid_model.data_types.AsymValue
-.. autoclass:: power_grid_model.data_types.AttributeValue
-.. autoclass:: power_grid_model.data_types.Component
-.. autoclass:: power_grid_model.data_types.ComponentList
-.. autoclass:: power_grid_model.data_types.SinglePythonDataset
-.. autoclass:: power_grid_model.data_types.BatchPythonDataset
-.. autoclass:: power_grid_model.data_types.BatchPythonDataset
+.. autofunction:: power_grid_model.data_types.SparseBatchArray
+.. autofunction:: power_grid_model.data_types.BatchArray
+.. autofunction:: power_grid_model.data_types.SingleDataset
+.. autofunction:: power_grid_model.data_types.BatchDataset
+.. autofunction:: power_grid_model.data_types.Dataset
+.. autofunction:: power_grid_model.data_types.Batchlist
+.. autofunction:: power_grid_model.data_types.NominalValue
+.. autofunction:: power_grid_model.data_types.RealValue
+.. autofunction:: power_grid_model.data_types.AsymValue
+.. autofunction:: power_grid_model.data_types.AttributeValue
+.. autofunction:: power_grid_model.data_types.Component
+.. autofunction:: power_grid_model.data_types.ComponentList
+.. autofunction:: power_grid_model.data_types.SinglePythonDataset
+.. autofunction:: power_grid_model.data_types.BatchPythonDataset
+.. autofunction:: power_grid_model.data_types.BatchPythonDataset
 ```
 
 ### errors

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -31,6 +31,13 @@ SPDX-License-Identifier: MPL-2.0
 .. autofunction:: power_grid_model.validation.errors_to_string
 ```
 
+## data_types
+
+```{eval-rst}
+.. automodule:: power_grid_model.data_types
+   :undoc-members:
+```
+
 ### errors
 
 ```{eval-rst}

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -31,11 +31,24 @@ SPDX-License-Identifier: MPL-2.0
 .. autofunction:: power_grid_model.validation.errors_to_string
 ```
 
-## data_types
+## data types
 
 ```{eval-rst}
-.. automodule:: power_grid_model.data_types
-   :undoc-members:
+.. autoclass:: power_grid_model.data_types.SparseBatchArray
+.. autoclass:: power_grid_model.data_types.BatchArray
+.. autoclass:: power_grid_model.data_types.SingleDataset
+.. autoclass:: power_grid_model.data_types.BatchDataset
+.. autoclass:: power_grid_model.data_types.Dataset
+.. autoclass:: power_grid_model.data_types.Batchlist
+.. autoclass:: power_grid_model.data_types.NominalValue
+.. autoclass:: power_grid_model.data_types.RealValue
+.. autoclass:: power_grid_model.data_types.AsymValue
+.. autoclass:: power_grid_model.data_types.AttributeValue
+.. autoclass:: power_grid_model.data_types.Component
+.. autoclass:: power_grid_model.data_types.ComponentList
+.. autoclass:: power_grid_model.data_types.SinglePythonDataset
+.. autoclass:: power_grid_model.data_types.BatchPythonDataset
+.. autoclass:: power_grid_model.data_types.BatchPythonDataset
 ```
 
 ### errors

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -6,16 +6,15 @@ SPDX-License-Identifier: MPL-2.0
 
 # Dataset Terminology
 
-Some terms regarding the data structures are explained here, including the definition of dataset, component, and attribute.
+Some terms regarding the data structures are explained here, including the definition of dataset, component, and attribute. For detailed data types used throughout the power grid model, please refer to [Python API Reference](../api_reference/python-api-reference.md).
 
 ## Data structures
 
 - **Dataset:** Either a single or a batch dataset.
-- **SingleDataset:** A data type storing input data (ie. all elements of all components) for a single scenario.
-- **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be either a sparse or a dense one.
-    - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy. 
-    - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
-
+    - **SingleDataset:** A data type storing input data (i.e. all elements of all components) for a single scenario.
+    - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be either a sparse or a dense one.
+        - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy arrays. 
+        - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
 
 ### Type of Dataset 
 

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -10,11 +10,14 @@ Some terms regarding the data structures are explained here, including the defin
 
 ## Data structures
 
-- **SingleDataset:** A data type storing input data (ie. all elements of all components) for a single scenario
+- **Dataset:** Either a single or a batch dataset.
+    - **SingleDataset:** A data type storing input data (ie. all elements of all components) for a single scenario.
 
-- **BatchDataset:** A data type storing update and or output data for one or more scenarios
+    - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be a sparse or dense one.
+        
+        - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy. 
+        - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
 
-- **Dataset:** Either a single or a batch dataset
 
 ### Type of Dataset 
 

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -11,12 +11,10 @@ Some terms regarding the data structures are explained here, including the defin
 ## Data structures
 
 - **Dataset:** Either a single or a batch dataset.
-    - **SingleDataset:** A data type storing input data (ie. all elements of all components) for a single scenario.
-
-    - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be a sparse or dense one.
-        
-        - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy. 
-        - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
+- **SingleDataset:** A data type storing input data (ie. all elements of all components) for a single scenario.
+- **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be either a sparse or a dense one.
+    - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy. 
+    - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
 
 
 ### Type of Dataset 

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -28,7 +28,7 @@ A batch is a either a dense or a sparse batch array.
 
 - Examples:
 
-dense: <2d-array>; 
+dense: <2d-array>
 
 sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
@@ -58,8 +58,7 @@ A general data set can be a single or a batch dataset.
 
 single: {"node": <1d-array>, "line": <1d-array>}
 
-batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
-
+batch: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 """
 
 BatchList = List[SingleDataset]
@@ -88,7 +87,7 @@ AsymValue = Tuple[RealValue, RealValue, RealValue]
 """
 Asymmetrical values are three-phase values like p or u_measured.
 
--Example: (10400.0, 10500.0, 10600.0)
+- Example: (10400.0, 10500.0, 10600.0)
 """
 
 AttributeValue = Union[RealValue, NominalValue, AsymValue]
@@ -142,7 +141,7 @@ BatchDataset, but in a native python format, without using numpy. Actually it lo
 
 - Example: 
 
-[{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+ [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
 
  {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """
@@ -153,15 +152,15 @@ A general python data set can be a single or a batch python dataset.
 
 - Examples:
 
-single:
+ single:
 
-{"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
+ {"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
 
  "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
 
  batch:
 
-[{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+ [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
 
  {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -25,8 +25,11 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 BatchArray = Union[np.ndarray, SparseBatchArray]
 """
 A batch is a either a dense or a sparse batch array.
+
 - Examples:
-dense:  <2d-array>
+
+dense: <2d-array>; 
+
 sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
@@ -34,6 +37,7 @@ SingleDataset = Dict[str, np.ndarray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are one-dimensional
 structured numpy arrays.
+
 - Example: {"node": <1d-array>, "line": <1d-array>}
 """
 
@@ -42,14 +46,18 @@ BatchDataset = Dict[str, BatchArray]
 A batch dataset is a dictionary where the keys are the component types and the values are either two-dimensional
 structured numpy arrays (dense batch array) or dictionaries with an indptr and a one-dimensional structured numpy
 array (sparse batch array).
+
 - Example: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 """
 
 Dataset = Union[SingleDataset, BatchDataset]
 """
 A general data set can be a single or a batch dataset.
+
 - Examples:
+
 single: {"node": <1d-array>, "line": <1d-array>}
+
 batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 
 """
@@ -58,24 +66,28 @@ BatchList = List[SingleDataset]
 """
 A batch list is an alternative representation of a batch. It is a list of single datasets, where each single dataset
 is actually a batch. The batch list is intended as an intermediate data type, during conversions.
+
 - Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
 """
 
 NominalValue = int
 """
-Nominal values can be IDs, booleans, enums, tap pos
+Nominal values can be IDs, booleans, enums, tap pos.
+
 - Example: 123
 """
 
 RealValue = float
 """
 Symmetrical values can be anything like cable properties, symmetric loads, etc.
+
 - Example: 10500.0
 """
 
 AsymValue = Tuple[RealValue, RealValue, RealValue]
 """
 Asymmetrical values are three-phase values like p or u_measured.
+
 -Example: (10400.0, 10500.0, 10600.0)
 """
 
@@ -83,9 +95,13 @@ AttributeValue = Union[RealValue, NominalValue, AsymValue]
 """
 When representing a grid as a native python structure, each attribute (u_rated etc) is either a nominal value,
 a real value, or a tuple of three real values.
+
 - Examples:
+
 real: 10500.0    
+
 nominal: 123
+
 asym: (10400.0, 10500.0, 10600.0)
 """
 
@@ -93,6 +109,7 @@ Component = Dict[str, Union[AttributeValue, str]]
 """
 A component, when represented in native python format, is a dictionary, where the keys are the attributes and the values
 are the corresponding values. It is allowed to add extra fields, containing either an AttributeValue or a string.
+
 - Example: {"id": 1, "u_rated": 10500.0, "original_id": "Busbar #1"}
 """
 
@@ -100,6 +117,7 @@ ComponentList = List[Component]
 """
 A component list is a list containing components. In essence it stores the same information as a np.ndarray,
 but in a native python format, without using numpy.
+
 - Example: [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}]
 """
 
@@ -108,8 +126,11 @@ SinglePythonDataset = Dict[str, ComponentList]
 A single dataset in native python representation is a dictionary, where the keys are the component names and the
 values are a list of all the instances of such a component. In essence it stores the same information as a
 SingleDataset, but in a native python format, without using numpy.
+
 - Example: 
+
 {"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}], 
+
  "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
 """
 
@@ -118,19 +139,29 @@ BatchPythonDataset = List[SinglePythonDataset]
 A batch dataset in native python representation is a list of dictionaries, where the keys are the component names and
 the values are a list of all the instances of such a component. In essence it stores the same information as a
 BatchDataset, but in a native python format, without using numpy. Actually it looks more like the BatchList.
+
 - Example: 
+
 [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+
  {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """
 
 PythonDataset = Union[SinglePythonDataset, BatchPythonDataset]
 """
 A general python data set can be a single or a batch python dataset.
+
 - Examples:
+
 single:
+
 {"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
+
  "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
-batch:
+
+ batch:
+
 [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+
  {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -4,7 +4,7 @@
 
 """
 Many data types are used throughout the power grid model project. In an attempt to clarify type hints, some types
-have been defined and explained in this file
+have been defined and explained in this file.
 """
 
 from typing import Dict, List, Tuple, Union
@@ -19,7 +19,8 @@ A sparse batch array is a dictionary containing the keys "indptr" and "data".
     indptr: a one-dimensional numpy int32 array
     data: a one-dimensional structured numpy array. The exact dtype depends on the type component.
 
-Example: {"indptr": <1d-array>, "data": <1d-array>}
+Example: 
+    {"indptr": <1d-array>, "data": <1d-array>}
 """
 
 BatchArray = Union[np.ndarray, SparseBatchArray]

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -16,29 +16,25 @@ import numpy as np
 SparseBatchArray = Dict[str, np.ndarray]
 """
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
-    - indptr: a one-dimensional numpy int32 array
-    
-    - data: a one-dimensional structured numpy array. The exact dtype depends on the type component.
 
-Example: {"indptr": <1d-array>, "data": <1d-array>}
+- indptr: a one-dimensional numpy int32 array
+- data: a one-dimensional structured numpy array. The exact dtype depends on the type of component.
+- Example: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
 BatchArray = Union[np.ndarray, SparseBatchArray]
 """
 A batch is a either a dense or a sparse batch array.
-
-Examples:
-    dense:  <2d-array>
-
-    sparse: {"indptr": <1d-array>, "data": <1d-array>}
+    - Examples:
+        - dense:  <2d-array>
+        - sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
 SingleDataset = Dict[str, np.ndarray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are one-dimensional
 structured numpy arrays.
-
-Example: {"node": <1d-array>, "line": <1d-array>}
+    - Example: {"node": <1d-array>, "line": <1d-array>}
 """
 
 BatchDataset = Dict[str, BatchArray]
@@ -46,18 +42,15 @@ BatchDataset = Dict[str, BatchArray]
 A batch dataset is a dictionary where the keys are the component types and the values are either two-dimensional
 structured numpy arrays (dense batch array) or dictionaries with an indptr and a one-dimensional structured numpy
 array (sparse batch array).
-
-Example: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
+    - Example: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 """
 
 Dataset = Union[SingleDataset, BatchDataset]
 """
 A general data set can be a single or a batch dataset.
-
-Examples:
-    - single: {"node": <1d-array>, "line": <1d-array>}
-    
-    - batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
+    - Examples:
+        - single: {"node": <1d-array>, "line": <1d-array>}
+        - batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 
 """
 
@@ -65,57 +58,49 @@ BatchList = List[SingleDataset]
 """
 A batch list is an alternative representation of a batch. It is a list of single datasets, where each single dataset
 is actually a batch. The batch list is intended as an intermediate data type, during conversions.
-
-Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
+    - Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
 """
 
 NominalValue = int
 """
 Nominal values can be IDs, booleans, enums, tap pos
-
-Example: 123
+    - Example: 123
 """
 
 RealValue = float
 """
 Symmetrical values can be anything like cable properties, symmetric loads, etc.
-
-Example: 10500.0
+    - Example: 10500.0
 """
 
 AsymValue = Tuple[RealValue, RealValue, RealValue]
 """
 Asymmetrical values are three-phase values like p or u_measured.
-
-Example: (10400.0, 10500.0, 10600.0)
+    -Example: (10400.0, 10500.0, 10600.0)
 """
 
 AttributeValue = Union[RealValue, NominalValue, AsymValue]
 """
 When representing a grid as a native python structure, each attribute (u_rated etc) is either a nominal value,
 a real value, or a tuple of three real values.
-
-Examples:
-    - real:    10500.0
-    
-    - nominal: 123
-    - asym:    (10400.0, 10500.0, 10600.0)
+    - Examples:
+        - real: 10500.0    
+        - nominal: 123
+        - asym: (10400.0, 10500.0, 10600.0)
 """
 
 Component = Dict[str, Union[AttributeValue, str]]
 """
 A component, when represented in native python format, is a dictionary, where the keys are the attributes and the values
 are the corresponding values. It is allowed to add extra fields, containing either an AttributeValue or a string.
-
-Example: {"id": 1, "u_rated": 10500.0, "original_id": "Busbar #1"}
+    - Example: {"id": 1, "u_rated": 10500.0, "original_id": "Busbar #1"}
 """
 
 ComponentList = List[Component]
 """
 A component list is a list containing components. In essence it stores the same information as a np.ndarray,
 but in a native python format, without using numpy.
-
-Example: [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}]
+    - Example: [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}]
 """
 
 SinglePythonDataset = Dict[str, ComponentList]
@@ -123,12 +108,7 @@ SinglePythonDataset = Dict[str, ComponentList]
 A single dataset in native python representation is a dictionary, where the keys are the component names and the
 values are a list of all the instances of such a component. In essence it stores the same information as a
 SingleDataset, but in a native python format, without using numpy.
-
-Example:
-    {
-        "node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
-        "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],
-    }
+    - Example: {"line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
 """
 
 BatchPythonDataset = List[SinglePythonDataset]
@@ -136,35 +116,20 @@ BatchPythonDataset = List[SinglePythonDataset]
 A batch dataset in native python representation is a list of dictionaries, where the keys are the component names and
 the values are a list of all the instances of such a component. In essence it stores the same information as a
 BatchDataset, but in a native python format, without using numpy. Actually it looks more like the BatchList.
-
-Example:
-    [
-        {
-            "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],
-        },
-        {
-            "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],
-        }
-    ]
+    - Example: [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+        {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """
 
 PythonDataset = Union[SinglePythonDataset, BatchPythonDataset]
 """
 A general python data set can be a single or a batch python dataset.
-
-Examples:
-    single:
-        {
-            "node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
-            "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],
-        }
-    batch:
+    - Examples:
+        - single:
+        {   "node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
+            "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],     }
+        - batch:
         [
-            {
-                "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],
-            },
-            {
-                "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],
-            }
+            {   "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+            {   "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}
         ]
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -128,7 +128,7 @@ SingleDataset, but in a native python format, without using numpy.
 
 - Example: 
 
-{"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}], 
+ {"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}], 
 
  "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -15,20 +15,21 @@ import numpy as np
 
 SparseBatchArray = Dict[str, np.ndarray]
 """
-A sparse batch array is a dictionary containing the keys "indptr" and "data".
-    indptr: a one-dimensional numpy int32 array
-    data: a one-dimensional structured numpy array. The exact dtype depends on the type component.
+A sparse batch array is a dictionary containing the keys `indptr` and `data`.
+    - indptr: a one-dimensional numpy int32 array
+    
+    - data: a one-dimensional structured numpy array. The exact dtype depends on the type component.
 
-Example: 
-    {"indptr": <1d-array>, "data": <1d-array>}
+Example: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
 BatchArray = Union[np.ndarray, SparseBatchArray]
 """
-A batch is a either a dense or a sparse batch array
+A batch is a either a dense or a sparse batch array.
 
 Examples:
     dense:  <2d-array>
+
     sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
@@ -54,8 +55,9 @@ Dataset = Union[SingleDataset, BatchDataset]
 A general data set can be a single or a batch dataset.
 
 Examples:
-    single: {"node": <1d-array>, "line": <1d-array>}
-    batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
+    - single: {"node": <1d-array>, "line": <1d-array>}
+    
+    - batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 
 """
 
@@ -94,9 +96,10 @@ When representing a grid as a native python structure, each attribute (u_rated e
 a real value, or a tuple of three real values.
 
 Examples:
-    real:    10500.0
-    nominal: 123
-    asym:    (10400.0, 10500.0, 10600.0)
+    - real:    10500.0
+    
+    - nominal: 123
+    - asym:    (10400.0, 10500.0, 10600.0)
 """
 
 Component = Dict[str, Union[AttributeValue, str]]

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -25,16 +25,16 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 BatchArray = Union[np.ndarray, SparseBatchArray]
 """
 A batch is a either a dense or a sparse batch array.
-    - Examples:
-        - dense:  <2d-array>
-        - sparse: {"indptr": <1d-array>, "data": <1d-array>}
+- Examples:
+dense:  <2d-array>
+sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
 SingleDataset = Dict[str, np.ndarray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are one-dimensional
 structured numpy arrays.
-    - Example: {"node": <1d-array>, "line": <1d-array>}
+- Example: {"node": <1d-array>, "line": <1d-array>}
 """
 
 BatchDataset = Dict[str, BatchArray]
@@ -42,15 +42,15 @@ BatchDataset = Dict[str, BatchArray]
 A batch dataset is a dictionary where the keys are the component types and the values are either two-dimensional
 structured numpy arrays (dense batch array) or dictionaries with an indptr and a one-dimensional structured numpy
 array (sparse batch array).
-    - Example: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
+- Example: {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 """
 
 Dataset = Union[SingleDataset, BatchDataset]
 """
 A general data set can be a single or a batch dataset.
-    - Examples:
-        - single: {"node": <1d-array>, "line": <1d-array>}
-        - batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
+- Examples:
+single: {"node": <1d-array>, "line": <1d-array>}
+batch:  {"node": <2d-array>, "line": {"indptr": <1d-array>, "data": <1d-array>}}
 
 """
 
@@ -58,49 +58,49 @@ BatchList = List[SingleDataset]
 """
 A batch list is an alternative representation of a batch. It is a list of single datasets, where each single dataset
 is actually a batch. The batch list is intended as an intermediate data type, during conversions.
-    - Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
+- Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
 """
 
 NominalValue = int
 """
 Nominal values can be IDs, booleans, enums, tap pos
-    - Example: 123
+- Example: 123
 """
 
 RealValue = float
 """
 Symmetrical values can be anything like cable properties, symmetric loads, etc.
-    - Example: 10500.0
+- Example: 10500.0
 """
 
 AsymValue = Tuple[RealValue, RealValue, RealValue]
 """
 Asymmetrical values are three-phase values like p or u_measured.
-    -Example: (10400.0, 10500.0, 10600.0)
+-Example: (10400.0, 10500.0, 10600.0)
 """
 
 AttributeValue = Union[RealValue, NominalValue, AsymValue]
 """
 When representing a grid as a native python structure, each attribute (u_rated etc) is either a nominal value,
 a real value, or a tuple of three real values.
-    - Examples:
-        - real: 10500.0    
-        - nominal: 123
-        - asym: (10400.0, 10500.0, 10600.0)
+- Examples:
+real: 10500.0    
+nominal: 123
+asym: (10400.0, 10500.0, 10600.0)
 """
 
 Component = Dict[str, Union[AttributeValue, str]]
 """
 A component, when represented in native python format, is a dictionary, where the keys are the attributes and the values
 are the corresponding values. It is allowed to add extra fields, containing either an AttributeValue or a string.
-    - Example: {"id": 1, "u_rated": 10500.0, "original_id": "Busbar #1"}
+- Example: {"id": 1, "u_rated": 10500.0, "original_id": "Busbar #1"}
 """
 
 ComponentList = List[Component]
 """
 A component list is a list containing components. In essence it stores the same information as a np.ndarray,
 but in a native python format, without using numpy.
-    - Example: [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}]
+- Example: [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}]
 """
 
 SinglePythonDataset = Dict[str, ComponentList]
@@ -108,7 +108,9 @@ SinglePythonDataset = Dict[str, ComponentList]
 A single dataset in native python representation is a dictionary, where the keys are the component names and the
 values are a list of all the instances of such a component. In essence it stores the same information as a
 SingleDataset, but in a native python format, without using numpy.
-    - Example: {"line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
+- Example: 
+{"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}], 
+ "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
 """
 
 BatchPythonDataset = List[SinglePythonDataset]
@@ -116,20 +118,19 @@ BatchPythonDataset = List[SinglePythonDataset]
 A batch dataset in native python representation is a list of dictionaries, where the keys are the component names and
 the values are a list of all the instances of such a component. In essence it stores the same information as a
 BatchDataset, but in a native python format, without using numpy. Actually it looks more like the BatchList.
-    - Example: [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
-        {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
+- Example: 
+[{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+ {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """
 
 PythonDataset = Union[SinglePythonDataset, BatchPythonDataset]
 """
 A general python data set can be a single or a batch python dataset.
-    - Examples:
-        - single:
-        {   "node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
-            "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],     }
-        - batch:
-        [
-            {   "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
-            {   "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}
-        ]
+- Examples:
+single:
+{"node": [{"id": 1, "u_rated": 10500.0}, {"id": 2, "u_rated": 10500.0}],
+ "line": [{"id": 3, "from_node": 1, "to_node": 2, ...}],}
+batch:
+[{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+ {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """


### PR DESCRIPTION
In the [Dataset Terminology](https://power-grid-model.readthedocs.io/en/stable/user_manual/dataset-terminology.html) in the documentation, only a very brief mention is made on what a batch dataset is. There's even less documentation on sparse datasets - not even in the advanced documentation.

This PR is related with issue #434 