### PR TITLE
Fixes incorrect SonarCloud warning on template class deduction

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
@@ -93,7 +93,7 @@ class Appliance : public Base {
         return output;
     }
     ApplianceShortCircuitOutput get_sc_output(ComplexValue<symmetric_t> const& i) const {
-        ComplexValue<asymmetric_t> const iabc{i};
+        ComplexValue<asymmetric_t> const iabc{i}; // NOSONAR
         return get_sc_output(iabc);
     }
     template <symmetry_tag sym> ApplianceOutput<sym> get_output(ComplexValue<sym> const& u) const {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
@@ -114,9 +114,9 @@ class Branch3 : public Base {
     }
     Branch3ShortCircuitOutput get_sc_output(ComplexValue<symmetric_t> const& i_1, ComplexValue<symmetric_t> const& i_2,
                                             ComplexValue<symmetric_t> const& i_3) const {
-        ComplexValue<asymmetric_t> const iabc_1{i_1};
-        ComplexValue<asymmetric_t> const iabc_2{i_2};
-        ComplexValue<asymmetric_t> const iabc_3{i_3};
+        ComplexValue<asymmetric_t> const iabc_1{i_1}; // NOSONAR
+        ComplexValue<asymmetric_t> const iabc_2{i_2}; // NOSONAR
+        ComplexValue<asymmetric_t> const iabc_3{i_3}; // NOSONAR
         return get_sc_output(iabc_1, iabc_2, iabc_3);
     }
     template <symmetry_tag sym>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
@@ -76,7 +76,7 @@ class Fault final : public Base {
     }
 
     FaultShortCircuitOutput get_sc_output(ComplexValue<symmetric_t> i_f, double const u_rated) const {
-        ComplexValue<asymmetric_t> const iabc_f{i_f};
+        ComplexValue<asymmetric_t> const iabc_f{i_f}; // NOSONAR
         return get_sc_output(iabc_f, u_rated);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/node.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/node.hpp
@@ -53,7 +53,7 @@ class Node final : public Base {
     }
     NodeShortCircuitOutput get_sc_output(ComplexValue<symmetric_t> const& u_pu) const {
         // Convert the input positive sequence voltage to phase voltage
-        ComplexValue<asymmetric_t> const uabc_pu{u_pu};
+        ComplexValue<asymmetric_t> const uabc_pu{u_pu}; // NOSONAR
         return get_sc_output(uabc_pu);
     }
     template <symmetry_tag sym> NodeOutput<sym> get_null_output() const {

--- a/tests/cpp_unit_tests/test_fault.cpp
+++ b/tests/cpp_unit_tests/test_fault.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Test fault") {
 
     SUBCASE("Test get_short_circuit_output sym") {
         ComplexValue<symmetric_t> const i_f_pu = 1.0 + 1.0i;
-        ComplexValue<asymmetric_t> const i_f_res{i_f_pu};
+        ComplexValue<asymmetric_t> const i_f_res{i_f_pu}; // NOSONAR
         FaultShortCircuitOutput output = fault.get_sc_output(i_f_pu, u_rated);
         CHECK(output.id == 1);
         CHECK(output.energized);

--- a/tests/cpp_unit_tests/test_power_sensor.cpp
+++ b/tests/cpp_unit_tests/test_power_sensor.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Test power sensor") {
             sym_power_sensor_input.q_sigma = nan;
 
             ComplexValue<symmetric_t> const s_sym = (0.9 * 1e3 + 1i * 0.7 * 1e3) / 1e6;
-            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0};
+            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0}; // NOSONAR
 
             PowerSensor<symmetric_t> sym_power_sensor{sym_power_sensor_input};
 
@@ -170,7 +170,7 @@ TEST_CASE("Test power sensor") {
             sym_power_sensor_input.q_sigma = nan;
 
             ComplexValue<symmetric_t> const s_sym = (0.9 * 1e3 + 1i * 0.7 * 1e3) / 1e6;
-            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0};
+            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0}; // NOSONAR
 
             PowerSensor<symmetric_t> sym_power_sensor{sym_power_sensor_input};
 
@@ -315,7 +315,7 @@ TEST_CASE("Test power sensor") {
             asym_power_sensor_input.q_sigma = r_nan;
 
             ComplexValue<symmetric_t> const s_sym = (0.9 * 1e3 + 1i * 0.7 * 1e3) / 1e6;
-            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0};
+            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0}; // NOSONAR
 
             PowerSensor<asymmetric_t> asym_power_sensor{asym_power_sensor_input};
 
@@ -438,7 +438,7 @@ TEST_CASE("Test power sensor") {
             asym_power_sensor_input.q_sigma = r_nan;
 
             ComplexValue<symmetric_t> const s_sym = (0.9 * 1e3 + 1i * 0.7 * 1e3) / 1e6;
-            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0};
+            ComplexValue<asymmetric_t> const s_asym = s_sym * RealValue<asymmetric_t>{1.0}; // NOSONAR
 
             PowerSensor<asymmetric_t> asym_power_sensor{asym_power_sensor_input};
 


### PR DESCRIPTION
SonarCloud incorrectly generates warnings about a series of intended change of template. This branch fixes (supresses) that and removes the code smell.

ToDo:
The rest of the SonarCloud warnings on template class deduction will be addressed when a decision is made how to approach this. 