### PR TITLE
Changed the datatype of `indptr` from `int32`/'integer' to `int64`

### DIFF
--- a/src/power_grid_model/core/power_grid_model.py
+++ b/src/power_grid_model/core/power_grid_model.py
@@ -399,7 +399,7 @@ class PowerGridModel:
                             - Dimension 1: Each updated element per batch for this component type.
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
@@ -479,7 +479,7 @@ class PowerGridModel:
                             - Dimension 1: Each updated element per batch for this component type.
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
@@ -549,7 +549,7 @@ class PowerGridModel:
                             - Dimension 1: each updated element per batch for this component type
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -17,7 +17,7 @@ SparseBatchArray = Dict[str, np.ndarray]
 """
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
-- indptr: a one-dimensional numpy int32 array
+- indptr: a one-dimensional numpy int64 array
 - data: a one-dimensional structured numpy array. The exact dtype depends on the type of component.
 - Example: {"indptr": <1d-array>, "data": <1d-array>}
 """


### PR DESCRIPTION
A minor correction to the documentation. In all mentioned places, datatype of `indptr` is specified as `int64`.

Relates to https://github.com/PowerGridModel/power-grid-model/pull/514 (commented by @TonyXiang8787 in https://github.com/PowerGridModel/power-grid-model/pull/514/files )