### PR TITLE
bump gcc in CI to 13 to test faster compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,8 @@ jobs:
         compiler: [gcc, clang]
         include:
           - compiler: gcc
-            cc: gcc-11
-            cxx: g++-11
+            cc: gcc-13
+            cxx: g++-13
           - compiler: clang
             cc: clang-15
             cxx: clang++-15

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -44,7 +44,7 @@ You need a C++ compiler with C++20 support. Below is a list of tested compilers:
 * gcc >= 11.0
   * Version 12.x tested using the version in the `manylinux_2_28` container.
   * Version 12.x tested using the musllinux build with custom compiler
-  * Version 11.x tested in CI
+  * Version 13.x tested in CI
 * Clang >= 15.0
   * Version 15.x tested in CI
   * Version 15.x tested in CI with code quality checks
@@ -166,8 +166,8 @@ WSL), or in a physical/virtual machine.
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-15            # or g++-11
-export CC=clang-15               # gcc-11
+export CXX=clang++-15            # or g++-13
+export CC=clang-15               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
 export LLVM_COV=llvm-cov-15
 export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
@@ -15,16 +15,6 @@
 
 namespace power_grid_model {
 
-// calculation info
-#ifdef POWER_GRID_MODEL_CPP_BENCHMARK
-#if defined(__cpp_lib_hardware_interference_size)
-constexpr size_t cache_line_size = std::hardware_destructive_interference_size;
-#else
-constexpr size_t cache_line_size = 64;
-#endif
-class alignas(cache_line_size) CalculationInfo : public std::map<std::string, double, std::less<>> {};
-#else
 using CalculationInfo = std::map<std::string, double, std::less<>>;
-#endif
 
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
@@ -9,10 +9,6 @@
 #include <map>
 #include <string>
 
-#ifdef POWER_GRID_MODEL_CPP_BENCHMARK
-#include <new>
-#endif
-
 namespace power_grid_model {
 
 using CalculationInfo = std::map<std::string, double, std::less<>>;


### PR DESCRIPTION
Relates to #486 

Reorganizing headers did not seem to help. Instead, there appear to have been some significant changes in gcc since `gcc-10` (C++ CI uses `gcc-11`, python build uses `gcc-12`).

This PR checks `gcc-13`, which is also likely the version that will be used on `ubuntu-24.04` that will come out next month.