### PR TITLE
Quick patch on remaining issues on the docs.

### DIFF
--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -40,21 +40,14 @@ SPDX-License-Identifier: MPL-2.0
 ## data types
 
 ```{eval-rst}
-.. autoclass:: power_grid_model.data_types.SparseBatchArray
-.. autoclass:: power_grid_model.data_types.BatchArray
+.. autoclass:: power_grid_model.data_types.Dataset
 .. autoclass:: power_grid_model.data_types.SingleDataset
 .. autoclass:: power_grid_model.data_types.BatchDataset
-.. autoclass:: power_grid_model.data_types.Dataset
-.. autoclass:: power_grid_model.data_types.BatchList
-.. autoclass:: power_grid_model.data_types.NominalValue
-.. autoclass:: power_grid_model.data_types.RealValue
-.. autoclass:: power_grid_model.data_types.AsymValue
-.. autoclass:: power_grid_model.data_types.AttributeValue
-.. autoclass:: power_grid_model.data_types.Component
-.. autoclass:: power_grid_model.data_types.ComponentList
-.. autoclass:: power_grid_model.data_types.SinglePythonDataset
-.. autoclass:: power_grid_model.data_types.BatchPythonDataset
-.. autoclass:: power_grid_model.data_types.PythonDataset
+.. autoclass:: power_grid_model.data_types.DataArray
+.. autoclass:: power_grid_model.data_types.SingleArray
+.. autoclass:: power_grid_model.data_types.BatchArray
+.. autoclass:: power_grid_model.data_types.SparseBatchArray
+.. autoclass:: power_grid_model.data_types.DenseBatchArray
 ```
 
 ## utils

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -31,6 +31,12 @@ SPDX-License-Identifier: MPL-2.0
 .. autofunction:: power_grid_model.validation.errors_to_string
 ```
 
+### errors
+
+```{eval-rst}
+.. autoclass:: power_grid_model.validation.errors.ValidationError
+```
+
 ## data types
 
 ```{eval-rst}
@@ -51,12 +57,6 @@ SPDX-License-Identifier: MPL-2.0
 .. autoclass:: power_grid_model.data_types.PythonDataset
 ```
 
-### errors
-
-```{eval-rst}
-.. autoclass:: power_grid_model.validation.errors.ValidationError
-```
-
 ## utils
 
 ```{eval-rst}
@@ -72,6 +72,6 @@ SPDX-License-Identifier: MPL-2.0
 .. autofunction:: power_grid_model.utils.msgpack_serialize_to_file
 .. autofunction:: power_grid_model.utils.import_json_data
 .. autofunction:: power_grid_model.utils.export_json_data
-.. autofunction:: power_grid_model._utils.get_and_verify_batch_sizes
-.. autofunction:: power_grid_model._utils.get_batch_size
+.. autofunction:: power_grid_model.utils.get_and_verify_batch_sizes
+.. autofunction:: power_grid_model.utils.get_batch_size
 ```

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -46,8 +46,8 @@ SPDX-License-Identifier: MPL-2.0
 .. autoclass:: power_grid_model.data_types.DataArray
 .. autoclass:: power_grid_model.data_types.SingleArray
 .. autoclass:: power_grid_model.data_types.BatchArray
-.. autoclass:: power_grid_model.data_types.SparseBatchArray
 .. autoclass:: power_grid_model.data_types.DenseBatchArray
+.. autoclass:: power_grid_model.data_types.SparseBatchArray
 ```
 
 ## utils

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -72,6 +72,6 @@ SPDX-License-Identifier: MPL-2.0
 .. autofunction:: power_grid_model.utils.msgpack_serialize_to_file
 .. autofunction:: power_grid_model.utils.import_json_data
 .. autofunction:: power_grid_model.utils.export_json_data
-.. autofunction:: power_grid_model.utils.get_and_verify_batch_sizes
-.. autofunction:: power_grid_model.utils.get_batch_size
+.. autofunction:: power_grid_model._utils.get_and_verify_batch_sizes
+.. autofunction:: power_grid_model._utils.get_batch_size
 ```

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -12,9 +12,9 @@ Some terms regarding the data structures are explained here, including the defin
 
 - **Dataset:** Either a single or a batch dataset.
     - **SingleDataset:** A data type storing input data (i.e. all elements of all components) for a single scenario.
-    - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can be either a sparse or a dense one.
-        - **SparseBatchDataset:**  Dictionaries with a one-dimensional numpy int32 array and a one-dimensional structured numpy arrays. 
-        - **DenseBatchDataset:** A dictionary where the keys are the component types and the values are two-dimensional structured numpy arrays.
+    - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can contain sparse or dense data, depending on the component.
+        - **BatchArray:** An array of dictionaries where the keys are the component types and the values are two-dimensional structured numpy arrays.
+            - **SparseBatchArray:**  A dictionary with a one-dimensional numpy int64 array and a one-dimensional structured numpy arrays. 
 
 ### Type of Dataset 
 

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -13,8 +13,11 @@ Some terms regarding the data structures are explained here, including the defin
 - **Dataset:** Either a single or a batch dataset.
     - **SingleDataset:** A data type storing input data (i.e. all elements of all components) for a single scenario.
     - **BatchDataset:** A data type storing update and or output data for one or more scenarios. A batch dataset can contain sparse or dense data, depending on the component.
-        - **BatchArray:** An array of dictionaries where the keys are the component types and the values are two-dimensional structured numpy arrays.
-            - **SparseBatchArray:**  A dictionary with a one-dimensional numpy int64 array and a one-dimensional structured numpy arrays. 
+- **DataArray** A data array can be a single or a batch array. It is a numpy structured array.     
+    - **SingleArray** A dictionary where the keys are the component types and the values are one-dimensional structured numpy arrays.
+    - **BatchArray:** An array of dictionaries where the keys are the component types and the values are two-dimensional structured numpy arrays.
+        - **DenseBatchArray:** A two-dimensional structured numpy array containing a list of components of the same type for each scenario.
+        - **SparseBatchArray:** A dictionary with a one-dimensional numpy int64 array and a one-dimensional structured numpy arrays. 
 
 ### Type of Dataset 
 

--- a/src/power_grid_model/core/power_grid_model.py
+++ b/src/power_grid_model/core/power_grid_model.py
@@ -399,7 +399,7 @@ class PowerGridModel:
                             - Dimension 1: Each updated element per batch for this component type.
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
@@ -479,7 +479,7 @@ class PowerGridModel:
                             - Dimension 1: Each updated element per batch for this component type.
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
@@ -549,7 +549,7 @@ class PowerGridModel:
                             - Dimension 1: each updated element per batch for this component type
                         - For inhomogeneous update batch (a dictionary containing two keys):
 
-                            - indptr: A 1D integer numpy array with length n_batch + 1. Given batch number k, the
+                            - indptr: A 1D numpy int64 array with length n_batch + 1. Given batch number k, the
                               update array for this batch is data[indptr[k]:indptr[k + 1]]. This is the concept of
                               compressed sparse structure.
                               https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -33,6 +33,7 @@ SparseBatchArray = Dict[str, Union[np.ndarray, SingleArray]]
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
 - data: a :class:`SingleArray`. The exact dtype depends on the type of component.
+
 - indptr: a one-dimensional numpy int64 array containing n+1 elements where n is the amount of scenarios.
     - The elements are the indices in the data that point to the first element of that scenario.
     - The last element is one after the data index of the last element of the last scenario.
@@ -40,6 +41,7 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
 - Examples:
     - structure: {"indptr": <1d-array>, "data": :class:`SingleArray`}
+
     - concrete example: {"indptr": [0, 2, 2, 3], "data": [(0, 1, 1), (1, 1, 1), (0, 0, 0)]}
         - the scenario 0 sets the statuses of components ids 0 and 1 to 1 (and keeps defaults for other components)
         - scenario 1 keeps the default values for all components
@@ -115,7 +117,7 @@ When representing a grid as a native python structure, each attribute (u_rated e
 a real value, or a tuple of three real values.
 
 - Examples:
-    - real: 10500.0    
+    - real: 10500.0
     - nominal: 123
     - asym: (10400.0, 10500.0, 10600.0)
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -61,14 +61,14 @@ A data array can be a :class:`SingleArray` or a :class:`BatchArray`.
 SingleDataset = Union[SingleArray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are
-:class:`SingleArray`s
+:class:`SingleArray`
 
 - Example: {"node": :class:`SingleArray`, "line": :class:`SingleArray`}
 """
 
 BatchDataset = Dict[str, BatchArray]
 """
-A batch dataset is a dictionary where the keys are the component types and the values are :class:`BatchArray`s
+A batch dataset is a dictionary where the keys are the component types and the values are :class:`BatchArray`
 
 - Example: {"node": :class:`DenseBatchArray`, "line": :class:`SparseBatchArray`}
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -22,7 +22,13 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 - Example: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
-BatchArray = Union[np.ndarray, SparseBatchArray]
+DenseBatchArray = Union[np.ndarray]
+"""
+A dense batch array is a two-dimensional structured numpy array containing a list of components of 
+the same type for each scenario.
+"""
+
+BatchArray = Union[DenseBatchArray, SparseBatchArray]
 """
 A batch is a either a dense or a sparse batch array.
 
@@ -33,7 +39,20 @@ dense: <2d-array>
 sparse: {"indptr": <1d-array>, "data": <1d-array>}
 """
 
-SingleDataset = Dict[str, np.ndarray]
+SingleArray = Dict[str, np.ndarray]
+"""
+A single array is a dictionary where the keys are the component types and the values are one-dimensional
+structured numpy arrays.
+
+- Example: {"node": <1d-array>, "line": <1d-array>}
+"""
+
+DataArray = Union[SingleArray, BatchArray]
+"""
+A data array can be a single or a batch array. It is a numpy structured array.
+"""
+
+SingleDataset = Union[SingleArray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are one-dimensional
 structured numpy arrays.

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -28,18 +28,18 @@ A dense batch array is a two-dimensional structured numpy array containing a lis
 the same type for each scenario.
 """
 
-SparseBatchArray = Dict[str, np.ndarray]
+SparseBatchArray = Dict[str, Union[np.ndarray, SingleArray]]
 """
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
-- data: a one-dimensional structured numpy array. The exact dtype depends on the type of component.
+- data: a :class:`SingleArray`. The exact dtype depends on the type of component.
 - indptr: a one-dimensional numpy int64 array containing n+1 elements where n is the amount of scenarios.
     - The elements are the indices in the data that point to the first element of that scenario.
     - The last element is one after the data index of the last element of the last scenario.
     - Usually, the last element will therefore be the size of the data.
 
 - Examples:
-    - structure: {"indptr": <1d-array>, "data": SingleArray}
+    - structure: {"indptr": <1d-array>, "data": :class:`SingleArray`}
     - concrete example: {"indptr": [0, 2, 2, 3], "data": [(0, 1, 1), (1, 1, 1), (0, 0, 0)]}
         - the scenario 0 sets the statuses of components ids 0 and 1 to 1 (and keeps defaults for other components)
         - scenario 1 keeps the default values for all components
@@ -48,42 +48,36 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
 BatchArray = Union[DenseBatchArray, SparseBatchArray]
 """
-A batch is a either a dense or a sparse batch array.
-
-- Examples:
-    - dense: <2d-array>
-    - sparse: {"indptr": SingleArray, "data": SingleArray}
+A batch array is a either a :class:`DenseBatchArray` or a :class:`SparseBatchArray`.
 """
 
 DataArray = Union[SingleArray, BatchArray]
 """
-A data array can be a single or a batch array. It is a numpy structured array.
+A data array can be a :class:`SingleArray` or a :class:`BatchArray`.
 """
 
 SingleDataset = Union[SingleArray]
 """
-A single dataset is a dictionary where the keys are the component types and the values are one-dimensional
-structured numpy arrays.
+A single dataset is a dictionary where the keys are the component types and the values are
+:class:`SingleArray`s
 
-- Example: {"node": SingleArray, "line": SingleArray}
+- Example: {"node": :class:`SingleArray`, "line": :class:`SingleArray`}
 """
 
 BatchDataset = Dict[str, BatchArray]
 """
-A batch dataset is a dictionary where the keys are the component types and the values are either two-dimensional
-structured numpy arrays (dense batch array) or dictionaries with an indptr and a one-dimensional structured numpy
-array (sparse batch array).
+A batch dataset is a dictionary where the keys are the component types and the values are :class:`BatchArray`s
 
-- Example: {"node": <2d-array>, "line": {"indptr": SingleArray, "data": SingleArray}}
+- Example: {"node": :class:`DenseBatchArray`, "line": :class:`SparseBatchArray`}
 """
 
 Dataset = Union[SingleDataset, BatchDataset]
 """
-A general data set can be a single or a batch dataset.
+A general data set can be a :class:`SingleDataset` or a :class:`BatchDataset`.
 
 - Examples:
-    - single: {"node": SingleArray, "line": SingleArray}
-    - batch: {"node": <2d-array>, "line": {"indptr": SingleArray, "data": SingleArray}}
+    - single: {"node": :class:`SingleArray`, "line": :class:`SingleArray`}
+    - batch: {"node": :class:`DenseBatchArray`, "line": :class:`SparseBatchArray`}
 """
 
 BatchList = List[SingleDataset]
@@ -91,7 +85,7 @@ BatchList = List[SingleDataset]
 A batch list is an alternative representation of a batch. It is a list of single datasets, where each single dataset
 is actually a batch. The batch list is intended as an intermediate data type, during conversions.
 
-- Example: [{"node": SingleArray, "line": SingleArray}, {"node": SingleArray, "line": SingleArray}]
+- Example: [:class:`SingleDataset`, {"node": :class:`SingleDataset`}]
 """
 
 NominalValue = int

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -18,8 +18,8 @@ SingleArray = Union[np.ndarray]
 A single array is a one-dimensional structured containing a list of components of the same type.
 
 - Examples:
-  - structure: <1d-array>
-  - concrete example: array([(0, 10500.0), (0, 10500.0)], dtype=power_grid_meta_data["input"]["node"].dtype)
+    - structure: <1d-array>
+    - concrete: array([(0, 10500.0), (0, 10500.0)], dtype=power_grid_meta_data["input"]["node"].dtype)
 """
 
 DenseBatchArray = Union[np.ndarray]
@@ -34,16 +34,16 @@ A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
 - data: a one-dimensional structured numpy array. The exact dtype depends on the type of component.
 - indptr: a one-dimensional numpy int64 array containing n+1 elements where n is the amount of scenarios.
-  - The elements are the indices in the data that point to the first element of that scenario.
-  - The last element is one after the data index of the last element of the last scenario.
-  - Usually, the last element will therefore be the size of the data.
+    - The elements are the indices in the data that point to the first element of that scenario.
+    - The last element is one after the data index of the last element of the last scenario.
+    - Usually, the last element will therefore be the size of the data.
 
 - Examples:
-  - structure: {"indptr": <1d-array>, "data": SingleArray}
-  - concrete example: {"indptr": [0, 2, 2, 3], "data": [(0, 1, 1), (1, 1, 1), (0, 0, 0)]}
-    - the scenario 0 sets the statuses of components ids 0 and 1 to 1 (and keeps defaults for other components)
-    - scenario 1 keeps the default values for all components
-    - scenario 2 sets the statuses of component with id 0 to 0 (and keeps defaults for other components)
+    - structure: {"indptr": <1d-array>, "data": SingleArray}
+    - concrete example: {"indptr": [0, 2, 2, 3], "data": [(0, 1, 1), (1, 1, 1), (0, 0, 0)]}
+        - the scenario 0 sets the statuses of components ids 0 and 1 to 1 (and keeps defaults for other components)
+        - scenario 1 keeps the default values for all components
+        - scenario 2 sets the statuses of component with id 0 to 0 (and keeps defaults for other components)
 """
 
 BatchArray = Union[DenseBatchArray, SparseBatchArray]
@@ -51,10 +51,8 @@ BatchArray = Union[DenseBatchArray, SparseBatchArray]
 A batch is a either a dense or a sparse batch array.
 
 - Examples:
-
-dense: <2d-array>
-
-sparse: {"indptr": SingleArray, "data": SingleArray}
+    - dense: <2d-array>
+    - sparse: {"indptr": SingleArray, "data": SingleArray}
 """
 
 DataArray = Union[SingleArray, BatchArray]
@@ -84,8 +82,8 @@ Dataset = Union[SingleDataset, BatchDataset]
 A general data set can be a single or a batch dataset.
 
 - Examples:
-  - single: {"node": SingleArray, "line": SingleArray}
-  - batch: {"node": <2d-array>, "line": {"indptr": SingleArray, "data": SingleArray}}
+    - single: {"node": SingleArray, "line": SingleArray}
+    - batch: {"node": <2d-array>, "line": {"indptr": SingleArray, "data": SingleArray}}
 """
 
 BatchList = List[SingleDataset]
@@ -123,9 +121,9 @@ When representing a grid as a native python structure, each attribute (u_rated e
 a real value, or a tuple of three real values.
 
 - Examples:
-  - real: 10500.0    
-  - nominal: 123
-  - asym: (10400.0, 10500.0, 10600.0)
+    - real: 10500.0    
+    - nominal: 123
+    - asym: (10400.0, 10500.0, 10600.0)
 """
 
 Component = Dict[str, Union[AttributeValue, str]]
@@ -166,14 +164,8 @@ BatchDataset, but in a native python format, without using numpy. Actually it lo
 
 - Example: 
 
-  [
-    {
-      "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],
-    },
-    {
-      "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],
-    }
-  ]
+  [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+   {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """
 
 PythonDataset = Union[SinglePythonDataset, BatchPythonDataset]
@@ -191,12 +183,6 @@ A general python data set can be a single or a batch python dataset.
 
   - batch:
 
-    [
-      {
-        "line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],
-      },
-      {
-        "line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],
-      }
-    ]
+    [{"line": [{"id": 3, "from_status": 0, "to_status": 0, ...}],},
+     {"line": [{"id": 3, "from_status": 1, "to_status": 1, ...}],}]
 """

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -60,7 +60,7 @@ DataArray = Union[SingleArray, BatchArray]
 A data array can be a :class:`SingleArray` or a :class:`BatchArray`.
 """
 
-SingleDataset = Union[SingleArray]
+SingleDataset = Dict[str, SingleArray]
 """
 A single dataset is a dictionary where the keys are the component types and the values are
 :class:`SingleArray`

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -18,6 +18,7 @@ SingleArray = Union[np.ndarray]
 A single array is a one-dimensional structured containing a list of components of the same type.
 
 - Examples:
+
     - structure: <1d-array>
     - concrete: array([(0, 10500.0), (0, 10500.0)], dtype=power_grid_meta_data["input"]["node"].dtype)
 """
@@ -33,16 +34,17 @@ SparseBatchArray = Dict[str, Union[np.ndarray, SingleArray]]
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
 - data: a :class:`SingleArray`. The exact dtype depends on the type of component.
-
 - indptr: a one-dimensional numpy int64 array containing n+1 elements where n is the amount of scenarios.
+
     - The elements are the indices in the data that point to the first element of that scenario.
     - The last element is one after the data index of the last element of the last scenario.
     - Usually, the last element will therefore be the size of the data.
 
 - Examples:
-    - structure: {"indptr": <1d-array>, "data": :class:`SingleArray`}
 
+    - structure: {"indptr": <1d-array>, "data": :class:`SingleArray`}
     - concrete example: {"indptr": [0, 2, 2, 3], "data": [(0, 1, 1), (1, 1, 1), (0, 0, 0)]}
+
         - the scenario 0 sets the statuses of components ids 0 and 1 to 1 (and keeps defaults for other components)
         - scenario 1 keeps the default values for all components
         - scenario 2 sets the statuses of component with id 0 to 0 (and keeps defaults for other components)
@@ -78,6 +80,7 @@ Dataset = Union[SingleDataset, BatchDataset]
 A general data set can be a :class:`SingleDataset` or a :class:`BatchDataset`.
 
 - Examples:
+
     - single: {"node": :class:`SingleArray`, "line": :class:`SingleArray`}
     - batch: {"node": :class:`DenseBatchArray`, "line": :class:`SparseBatchArray`}
 """
@@ -117,6 +120,7 @@ When representing a grid as a native python structure, each attribute (u_rated e
 a real value, or a tuple of three real values.
 
 - Examples:
+
     - real: 10500.0
     - nominal: 123
     - asym: (10400.0, 10500.0, 10600.0)

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -17,7 +17,7 @@ SparseBatchArray = Dict[str, np.ndarray]
 """
 A sparse batch array is a dictionary containing the keys `indptr` and `data`.
 
-- indptr: a one-dimensional numpy int32 array
+- indptr: a one-dimensional numpy int64 array
 - data: a one-dimensional structured numpy array. The exact dtype depends on the type of component.
 - Example: {"indptr": <1d-array>, "data": <1d-array>}
 """


### PR DESCRIPTION
ToDo:

The hierarchy of batch datatypes is rather arbitrary and non-consistent, should we consider change that in the future?

Relates to https://github.com/PowerGridModel/power-grid-model/pull/518 and https://github.com/PowerGridModel/power-grid-model/pull/514

Preview in https://power-grid-model--521.org.readthedocs.build/en/521/api_reference/python-api-reference.html#power_grid_model.data_types.Dataset