### PR TITLE
Fix MacOS CI setup phase

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,9 @@ jobs:
 
       - name: Install cpp dependencies
         run: |
+          brew install python@3.12 || true
+          brew link --overwrite python@3.12
+          brew pin python@3.12
           brew install ninja boost eigen nlohmann-json msgpack-cxx doctest
 
       - name: Build and test


### PR DESCRIPTION
Caused by upstream issue https://github.com/actions/runner-images/issues/4020

see also this comment: https://github.com/BlueBrain/nmodl/pull/1212#pullrequestreview-1927189914 (credits to https://github.com/BlueBrain/nmodl/pull/1212 for finding this relatively clean workaround)