### PR TITLE
add merge queue stuff for CI

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -14,9 +14,11 @@ on:
   # run pipeline on push event of main branch
   push:
     branches:
-      - main      
+      - main
   # run pipeline on pull request
   pull_request:
+  # run pipeline on merge queue
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -11,7 +11,9 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
-
+  # run pipeline on merge queue
+  merge_group:
+  # run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,19 @@ on:
   # run pipeline on push event of main branch
   push:
     branches:
-      - main      
+      - main
   # run pipeline on pull request
   pull_request:
-  # Allows you to run this workflow manually from the Actions tab
+  # run pipeline on merge queue
+  merge_group:
+  # run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      create_release:
+        type: boolean
+        description: Create a (pre-)release when CI passes
+        default: true
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -331,7 +339,7 @@ jobs:
         run: echo "${{ steps.tag.outputs.tag }}"
 
       - name: Upload wheels
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.create_release == 'true'))
         run: |
           pip install twine
           echo "Publish to PyPI..."
@@ -339,7 +347,7 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.create_release == 'true'))
         with:
           files: |
             ./wheelhouse/*

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -11,6 +11,8 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
+  # run pipeline on merge queue
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,6 +11,8 @@ on:
       - main
   # run pipeline on pull request
   pull_request:
+  # run pipeline on merge queue
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Part 1 of #528 

* Add `on: merge_group` to CI jobs
* Add option to not create a pre-release when running manually

See https://github.com/PowerGridModel/power-grid-model-io/pull/237 for proof that these changes work