### PR TITLE
Preparing steps 2-3 so that step 1 can start

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -19,12 +19,14 @@ namespace tap_position_optimizer {
 
 namespace detail = power_grid_model::optimizer::detail;
 
-using TrafoGraphIdx = size_t; // Questionable: should we simply use Idx?
+using TrafoGraphIdx = Idx;
 using EdgeWeight = int64_t;
+using WeightedTrafo = std::pair<Idx2D, EdgeWeight>;
+using WeightedTrafoList = std::vector<WeightedTrafo>;
 const int infty = INT_MAX;
 
 struct TrafoGraphVertex {
-    TrafoGraphIdx status{}; // status = 1 if the vertex is a source
+    bool is_source{}; // is_source = true if the vertex is a source
 };
 
 struct TrafoGraphEdge {
@@ -38,51 +40,54 @@ using TransformerGraph = boost::compressed_sparse_row_graph<boost::directedS, Tr
 
 template <main_core::main_model_state_c State>
 inline auto build_transformer_graph(State const& /*state*/) -> TransformerGraph {
-    // TODO(mgovers): implement
+    // TODO(nbharambe): implement
     return {};
 }
 
-inline auto get_edge_weights(TransformerGraph const& graph) -> std::vector<std::pair<Idx2D, EdgeWeight>> {
-    // Step 2: Initialize the rank of all vertices (transformer nodes) as infinite (INT_MAX)
-    std::vector<EdgeWeight> rank(boost::num_vertices(graph), infty);
-    std::vector<Idx2D> sources(boost::num_vertices(graph));
+inline auto process_edges_dijkstra(Idx v, std::vector<EdgeWeight>& rank, std::vector<Idx2D>& sources,
+                                   TransformerGraph const& graph) -> void {
+    using TrafoGraphElement = std::pair<EdgeWeight, TrafoGraphIdx>;
+    std::priority_queue<TrafoGraphElement, std::vector<TrafoGraphElement>, std::greater<>> pq;
+    rank[v] = 0;
+    sources[v] = {v, v};
+    pq.push({0, v});
 
-    // Step 3: Loop all the connected sources (status == 1)
-    for (auto v : boost::make_iterator_range(boost::vertices(graph))) {
-        if (graph[v].status == 1) {
-            // a. Perform Dijkstra shortest path algorithm from the vertex with that source.
-            // This is to determine the shortest path of all vertices to this particular source.
-            std::priority_queue<std::pair<EdgeWeight, TrafoGraphIdx>, std::vector<std::pair<EdgeWeight, TrafoGraphIdx>>,
-                                std::greater<>>
-                pq;
-            rank[v] = 0;
-            sources[v] = {static_cast<Idx>(v), static_cast<Idx>(v)};
-            pq.push({0, v});
+    while (!pq.empty()) {
+        auto [dist, u] = pq.top();
+        pq.pop();
 
-            while (!pq.empty()) {
-                auto [dist, u] = pq.top();
-                pq.pop();
+        if (dist != rank[u]) {
+            continue;
+        }
 
-                if (dist != rank[u]) {
-                    continue;
-                }
+        for (auto e : boost::make_iterator_range(boost::out_edges(u, graph))) {
+            auto v = boost::target(e, graph);
+            const EdgeWeight weight = graph[e].weight;
 
-                for (auto e : boost::make_iterator_range(boost::out_edges(u, graph))) {
-                    auto v = boost::target(e, graph);
-                    const EdgeWeight weight = graph[e].weight;
-
-                    if (rank[u] + weight < rank[v]) {
-                        rank[v] = rank[u] + weight;
-                        sources[v] = {sources[u].group, static_cast<Idx>(v)};
-                        pq.push({rank[v], v});
-                    }
-                }
+            if (rank[u] + weight < rank[v]) {
+                rank[v] = rank[u] + weight;
+                sources[v] = {sources[u].group, static_cast<Idx>(v)};
+                pq.push({rank[v], v});
             }
         }
     }
+}
 
-    // Convert rank vector to vector of pairs
-    std::vector<std::pair<Idx2D, EdgeWeight>> result;
+// Step 2: Initialize the rank of all vertices (transformer nodes) as infinite (INT_MAX)
+// Step 3: Loop all the connected sources (status == 1)
+//      a. Perform Dijkstra shortest path algorithm from the vertex with that source.
+//         This is to determine the shortest path of all vertices to this particular source.
+inline auto get_edge_weights(TransformerGraph const& graph) -> WeightedTrafoList {
+    std::vector<EdgeWeight> rank(boost::num_vertices(graph), infty);
+    std::vector<Idx2D> sources(boost::num_vertices(graph));
+
+    for (auto v : boost::make_iterator_range(boost::vertices(graph))) {
+        if (graph[v].is_source) {
+            process_edges_dijkstra(v, rank, sources, graph);
+        }
+    }
+
+    WeightedTrafoList result;
     for (size_t i = 0; i < rank.size(); ++i) {
         result.emplace_back(sources[i], rank[i]);
     }
@@ -90,17 +95,13 @@ inline auto get_edge_weights(TransformerGraph const& graph) -> std::vector<std::
     return result;
 }
 
-inline auto rank_transformers(std::vector<std::pair<Idx2D, EdgeWeight>> const& /*distances*/) -> std::vector<Idx2D> {
-    // TODO(mgovers): rank Idx2D of transformers as listed in the container
-
-    // Step 4: Loop all transformers with automatic tap changers, including the transformers which are not
-    //         fully connected
-    //   a.Rank of the transformer <-
-    //       i. Infinity(INT_MAX), if tap side of the transformer is disconnected.
-    //          The transformer regulation should be ignored
-    //       ii.Rank of the vertex at the tap side of the transformer, if tap side of the transformer is connected
-    return {};
-}
+// Step 4: Loop all transformers with automatic tap changers, including the transformers which are not
+//         fully connected
+//   a.Rank of the transformer <-
+//       i. Infinity(INT_MAX), if tap side of the transformer is disconnected.
+//          The transformer regulation should be ignored
+//       ii.Rank of the vertex at the tap side of the transformer, if tap side of the transformer is connected
+inline auto rank_transformers(WeightedTrafoList const& w_trafo_list) -> std::vector<Idx2D> { return {}; }
 
 template <main_core::main_model_state_c State> inline auto rank_transformers(State const& state) -> std::vector<Idx2D> {
     return rank_transformers(get_edge_weights(build_transformer_graph(state)));
@@ -129,7 +130,7 @@ class TapPositionOptimizer : public detail::BaseOptimizer<StateCalculator, State
 
   private:
     auto optimize(State const& /*state*/, std::vector<Idx2D> const& /*order*/) -> ResultType {
-        // TODO(jguo): implement outter loop tap changer
+        // TODO(mgovers): implement outter loop tap changer
         throw PowerGridError{};
     }
 


### PR DESCRIPTION
In this PR, the tentative implementation for steps 2-3 of the transformers ranking is cleaned up. The code part related to the Dijkstra algorithm could use some further optimization but it will be for next steps. The goal is to merge steps 2-3 a.s.a.p.