### PR TITLE
catch not observable exception for base scenario

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
@@ -448,6 +448,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
             calculation_fn(*this, {}, ignore_output);
         } catch (const SparseMatrixError&) {
             // missing entries are provided in the update data
+        } catch (const NotObservableError&) {
+            // missing entries are provided in the update data
         }
 
         // error messages


### PR DESCRIPTION
Base scenario fails when blank sensors are given as input