### PR TITLE
also run macos arm64 in merge group

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,7 +263,7 @@ jobs:
   test-python-macos-arm64:
     runs-on: flyci-macos-large-latest-m1
     needs: [build-cpp-test-macos, build-and-test-python]
-    if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+    if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event_name == 'merge_group')
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Relates to #479 .

We cannot enable MacOS arm64 testing on PRs, because PRs have multiple (even up til quite a lot of) reruns/commits/... with a successful CI run. That would eventually result in our total amount of free minutes being used up for FlyCI.

Since merge queue CI runs typically only run once for each PR, we may "abuse" it to do this additional check before final release to `main` without prohibitively increasing the risk of going over the limit for free minutes on FlyCI runners.