### PR TITLE
[Feature] common state queries + transformer concept

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
@@ -22,6 +22,8 @@ class Branch : public Base {
     using UpdateType = BranchUpdate;
     template <symmetry_tag sym> using OutputType = BranchOutput<sym>;
     using ShortCircuitOutputType = BranchShortCircuitOutput;
+    using SideType = BranchSide;
+
     static constexpr char const* name = "branch";
     ComponentType math_model_type() const final { return ComponentType::branch; }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
@@ -20,6 +20,8 @@ class Branch3 : public Base {
     using UpdateType = Branch3Update;
     template <symmetry_tag sym> using OutputType = Branch3Output<sym>;
     using ShortCircuitOutputType = Branch3ShortCircuitOutput;
+    using SideType = Branch3Side;
+
     static constexpr char const* name = "branch3";
     ComponentType math_model_type() const final { return ComponentType::branch3; }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/three_winding_transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/three_winding_transformer.hpp
@@ -409,4 +409,6 @@ class ThreeWindingTransformer : public Branch3 {
     }
 };
 
+static_assert(transformer_c<ThreeWindingTransformer>);
+
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
@@ -265,4 +265,6 @@ class Transformer : public Branch {
     }
 };
 
+static_assert(transformer_c<Transformer>);
+
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
@@ -12,7 +12,7 @@ namespace power_grid_model {
 namespace detail {
 template <typename T>
 concept enum_c = std::is_enum_v<T>;
-}
+} // namespace detail
 
 template <typename T>
 concept transformer_c = requires(T const& t, typename T::UpdateType u, typename T::SideType s) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
@@ -4,9 +4,36 @@
 
 #pragma once
 
+#include "../common/common.hpp"
 #include "../common/enum.hpp"
 
 namespace power_grid_model {
+
+namespace detail {
+template <typename T>
+concept enum_c = std::is_enum_v<T>;
+}
+
+template <typename T>
+concept transformer_c = requires(T const& t, typename T::UpdateType u, typename T::SideType s) {
+                            typename T::UpdateType;
+                            typename T::SideType;
+
+                            { T::name } -> std::convertible_to<std::string_view>;
+                            { t.math_model_type() } -> std::convertible_to<ComponentType>;
+
+                            { t.id() } -> std::same_as<ID>;
+                            { t.node(s) } -> std::same_as<ID>;
+                            { t.status(s) } -> std::convertible_to<bool>;
+
+                            { t.tap_side() } -> std::same_as<typename T::SideType>;
+                            { t.tap_pos() } -> std::convertible_to<IntS>;
+                            { t.tap_min() } -> std::convertible_to<IntS>;
+                            { t.tap_max() } -> std::convertible_to<IntS>;
+                            { t.tap_nom() } -> std::convertible_to<IntS>;
+
+                            { t.inverse(u) } -> std::same_as<typename T::UpdateType>;
+                        };
 
 constexpr double tap_adjust_impedance(double tap_pos, double tap_min, double tap_max, double tap_nom, double xk,
                                       double xk_min, double xk_max) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
@@ -58,6 +58,8 @@ template <class... T> class Container;
 template <class... GettableTypes, class... StorageableTypes>
 class Container<RetrievableTypes<GettableTypes...>, StorageableTypes...> {
   public:
+    using gettable_types = std::tuple<GettableTypes...>;
+
     static constexpr size_t num_storageable = sizeof...(StorageableTypes);
     static constexpr size_t num_gettable = sizeof...(GettableTypes);
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/input.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/input.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "state.hpp"
+#include "state_queries.hpp"
 
 #include "../all_components.hpp"
 
@@ -17,39 +18,37 @@ template <std::derived_from<Base> Component, class ComponentContainer, std::forw
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 inline void add_component(MainModelState<ComponentContainer>& state, ForwardIterator begin, ForwardIterator end,
                           double system_frequency) {
-    size_t const size = std::distance(begin, end);
-    state.components.template reserve<Component>(size);
+    reserve<Component>(state, std::distance(begin, end));
     // loop to add component
     for (auto it = begin; it != end; ++it) {
         auto const& input = *it;
         ID const id = input.id;
         // construct based on type of component
         if constexpr (std::derived_from<Component, Node>) {
-            state.components.template emplace<Component>(id, input);
+            emplace_component<Component>(state, id, input);
         } else if constexpr (std::derived_from<Component, Branch>) {
-            double const u1 = state.components.template get_item<Node>(input.from_node).u_rated();
-            double const u2 = state.components.template get_item<Node>(input.to_node).u_rated();
+            double const u1 = get_component<Node>(state, input.from_node).u_rated();
+            double const u2 = get_component<Node>(state, input.to_node).u_rated();
             // set system frequency for line
             if constexpr (std::same_as<Component, Line>) {
-                state.components.template emplace<Component>(id, input, system_frequency, u1, u2);
+                emplace_component<Component>(state, id, input, system_frequency, u1, u2);
             } else {
-                state.components.template emplace<Component>(id, input, u1, u2);
+                emplace_component<Component>(state, id, input, u1, u2);
             }
         } else if constexpr (std::derived_from<Component, Branch3>) {
-            double const u1 = state.components.template get_item<Node>(input.node_1).u_rated();
-            double const u2 = state.components.template get_item<Node>(input.node_2).u_rated();
-            double const u3 = state.components.template get_item<Node>(input.node_3).u_rated();
-            state.components.template emplace<Component>(id, input, u1, u2, u3);
+            double const u1 = get_component<Node>(state, input.node_1).u_rated();
+            double const u2 = get_component<Node>(state, input.node_2).u_rated();
+            double const u3 = get_component<Node>(state, input.node_3).u_rated();
+            emplace_component<Component>(state, id, input, u1, u2, u3);
         } else if constexpr (std::derived_from<Component, Appliance>) {
-            double const u = state.components.template get_item<Node>(input.node).u_rated();
-            state.components.template emplace<Component>(id, input, u);
+            double const u = get_component<Node>(state, input.node).u_rated();
+            emplace_component<Component>(state, id, input, u);
         } else if constexpr (std::derived_from<Component, GenericVoltageSensor>) {
-            double const u = state.components.template get_item<Node>(input.measured_object).u_rated();
-            state.components.template emplace<Component>(id, input, u);
+            double const u = get_component<Node>(state, input.measured_object).u_rated();
+            emplace_component<Component>(state, id, input, u);
         } else if constexpr (std::derived_from<Component, GenericPowerSensor>) {
             // it is not allowed to place a sensor at a link
-            if (state.components.get_idx_by_id(input.measured_object).group ==
-                state.components.template get_type_idx<Link>()) {
+            if (get_component_idx_by_id(state, input.measured_object).group == get_component_type_index<Link>(state)) {
                 throw InvalidMeasuredObject("Link", "PowerSensor");
             }
             ID const measured_object = input.measured_object;
@@ -60,47 +59,46 @@ inline void add_component(MainModelState<ComponentContainer>& state, ForwardIter
             case branch_from:
                 [[fallthrough]];
             case branch_to:
-                state.components.template get_item<Branch>(measured_object);
+                get_component<Branch>(state, measured_object);
                 break;
             case branch3_1:
             case branch3_2:
             case branch3_3:
-                state.components.template get_item<Branch3>(measured_object);
+                get_component<Branch3>(state, measured_object);
                 break;
             case shunt:
-                state.components.template get_item<Shunt>(measured_object);
+                get_component<Shunt>(state, measured_object);
                 break;
             case source:
-                state.components.template get_item<Source>(measured_object);
+                get_component<Source>(state, measured_object);
                 break;
             case load:
-                state.components.template get_item<GenericLoad>(measured_object);
+                get_component<GenericLoad>(state, measured_object);
                 break;
             case generator:
-                state.components.template get_item<GenericGenerator>(measured_object);
+                get_component<GenericGenerator>(state, measured_object);
                 break;
             case node:
-                state.components.template get_item<Node>(measured_object);
+                get_component<Node>(state, measured_object);
                 break;
             default:
                 throw MissingCaseForEnumError(std::string(GenericPowerSensor::name) + " item retrieval",
                                               input.measured_terminal_type);
             }
 
-            state.components.template emplace<Component>(id, input);
+            emplace_component<Component>(state, id, input);
         } else if constexpr (std::derived_from<Component, Fault>) {
             // check that fault object exists (currently, only faults at nodes are supported)
-            state.components.template get_item<Node>(input.fault_object);
-            state.components.template emplace<Component>(id, input);
+            get_component<Node>(state, input.fault_object);
+            emplace_component<Component>(state, id, input);
         } else if constexpr (std::derived_from<Component, TransformerTapRegulator>) {
-            Idx2D const regulated_object_idx = state.components.get_idx_by_id(input.regulated_object);
+            Idx2D const regulated_object_idx = get_component_idx_by_id(state, input.regulated_object);
 
             ID const regulated_terminal = [&input, &state, &regulated_object_idx] {
                 using enum ControlSide;
 
-                if (regulated_object_idx.group == state.components.template get_type_idx<Transformer>()) {
-                    auto const& regulated_object =
-                        state.components.template get_item<Transformer>(regulated_object_idx);
+                if (regulated_object_idx.group == get_component_type_index<Transformer>(state)) {
+                    auto const& regulated_object = get_component<Transformer>(state, regulated_object_idx);
                     switch (input.control_side) {
                     case to:
                         [[fallthrough]];
@@ -110,10 +108,8 @@ inline void add_component(MainModelState<ComponentContainer>& state, ForwardIter
                         throw MissingCaseForEnumError{std::string{Component::name} + " item retrieval",
                                                       input.control_side};
                     }
-                } else if (regulated_object_idx.group ==
-                           state.components.template get_type_idx<ThreeWindingTransformer>()) {
-                    auto const& regulated_object =
-                        state.components.template get_item<ThreeWindingTransformer>(regulated_object_idx);
+                } else if (regulated_object_idx.group == get_component_type_index<ThreeWindingTransformer>(state)) {
+                    auto const& regulated_object = get_component<ThreeWindingTransformer>(state, regulated_object_idx);
                     switch (input.control_side) {
                     case side_1:
                     case side_2:
@@ -128,11 +124,10 @@ inline void add_component(MainModelState<ComponentContainer>& state, ForwardIter
                 }
             }();
 
-            auto const regulated_object_type =
-                state.components.template get_item<Base>(regulated_object_idx).math_model_type();
-            double const u_rated = state.components.template get_item<Node>(regulated_terminal).u_rated();
+            auto const regulated_object_type = get_component<Base>(state, regulated_object_idx).math_model_type();
+            double const u_rated = get_component<Node>(state, regulated_terminal).u_rated();
 
-            state.components.template emplace<Component>(id, input, regulated_object_type, u_rated);
+            emplace_component<Component>(state, id, input, regulated_object_type, u_rated);
         }
     }
 }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/input.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/input.hpp
@@ -18,7 +18,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, std::forw
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 inline void add_component(MainModelState<ComponentContainer>& state, ForwardIterator begin, ForwardIterator end,
                           double system_frequency) {
-    reserve<Component>(state, std::distance(begin, end));
+    reserve_component<Component>(state, std::distance(begin, end));
     // loop to add component
     for (auto it = begin; it != end; ++it) {
         auto const& input = *it;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
@@ -22,13 +22,13 @@ constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> cons
 template <std::derived_from<Branch> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
-    return state.topo_comp_coup->branch.cbegin() + comp_sequence_offset<Branch, Component>(state);
+    return state.topo_comp_coup->branch.cbegin() + get_component_sequence_offset<Branch, Component>(state);
 }
 
 template <std::derived_from<Branch3> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
-    return state.topo_comp_coup->branch3.cbegin() + comp_sequence_offset<Branch3, Component>(state);
+    return state.topo_comp_coup->branch3.cbegin() + get_component_sequence_offset<Branch3, Component>(state);
 }
 
 template <std::same_as<Source> Component, class ComponentContainer>
@@ -40,7 +40,7 @@ constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> cons
 template <std::derived_from<GenericLoadGen> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
-    return state.topo_comp_coup->load_gen.cbegin() + comp_sequence_offset<GenericLoadGen, Component>(state);
+    return state.topo_comp_coup->load_gen.cbegin() + get_component_sequence_offset<GenericLoadGen, Component>(state);
 }
 
 template <std::same_as<Shunt> Component, class ComponentContainer>
@@ -53,14 +53,14 @@ template <std::derived_from<GenericVoltageSensor> Component, class ComponentCont
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
     return state.comp_topo->voltage_sensor_node_idx.cbegin() +
-           comp_sequence_offset<GenericVoltageSensor, Component>(state);
+           get_component_sequence_offset<GenericVoltageSensor, Component>(state);
 }
 
 template <std::derived_from<GenericPowerSensor> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
     return state.comp_topo->power_sensor_object_idx.cbegin() +
-           comp_sequence_offset<GenericPowerSensor, Component>(state);
+           get_component_sequence_offset<GenericPowerSensor, Component>(state);
 }
 
 template <std::same_as<Fault> Component, class ComponentContainer>
@@ -72,7 +72,7 @@ constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> cons
 template <std::same_as<TransformerTapRegulator> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
-    return state.comp_topo->regulated_object_idx.cbegin() + comp_sequence_offset<Regulator, Component>(state);
+    return state.comp_topo->regulated_object_idx.cbegin() + get_component_sequence_offset<Regulator, Component>(state);
 }
 
 template <typename Component, typename IndexType, class ComponentContainer, std::forward_iterator ResIt,

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
@@ -11,7 +11,7 @@
 namespace power_grid_model::main_core {
 template <typename ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
-inline Idx2D get_component_type_index(MainModelState<ComponentContainer> const& state) {
+inline Idx get_component_type_index(MainModelState<ComponentContainer> const& state) {
     return state.components.template get_type_idx<ComponentType>();
 }
 
@@ -21,13 +21,19 @@ constexpr auto get_component_size(MainModelState<ComponentContainer> const& stat
     return state.components.template size<ComponentType>();
 }
 
-template <typename ComponentType, class ComponentContainer, typename UpdateType>
+template <class ComponentContainer>
+    requires main_model_state_c<MainModelState<ComponentContainer>>
+inline Idx2D get_component_idx_by_id(MainModelState<ComponentContainer> const& state, ID id) {
+    return state.components.get_idx_by_id(id);
+}
+
+template <typename ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
 inline Idx2D get_component_idx_by_id(MainModelState<ComponentContainer> const& state, ID id) {
     return state.components.template get_idx_by_id<ComponentType>(id);
 }
 
-template <typename ComponentType, class ComponentContainer, typename UpdateType>
+template <typename ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
 inline Idx get_component_sequence(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
     return state.components.template get_seq<ComponentType>(id_or_index);
@@ -48,8 +54,20 @@ constexpr auto& get_component(MainModelState<ComponentContainer> const& state, a
 
 template <typename ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
-constexpr auto& get_component_by_sequence(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
-    return state.components.template get_item_by_seq<ComponentType>(id_or_index);
+constexpr auto& get_component(MainModelState<ComponentContainer>& state, auto const& id_or_index) {
+    return state.components.template get_item<ComponentType>(id_or_index);
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto& get_component_by_sequence(MainModelState<ComponentContainer> const& state, Idx sequence) {
+    return state.components.template get_item_by_seq<ComponentType>(sequence);
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto& get_component_by_sequence(MainModelState<ComponentContainer>& state, Idx sequence) {
+    return state.components.template get_item_by_seq<ComponentType>(sequence);
 }
 
 template <typename ComponentType, class ComponentContainer, typename... Args>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "state.hpp"
+
+#include "../all_components.hpp"
+
+namespace power_grid_model::main_core {
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+inline Idx2D get_component_type_index(MainModelState<ComponentContainer> const& state) {
+    return state.components.template get_type_idx<ComponentType>();
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto get_component_size(MainModelState<ComponentContainer> const& state) {
+    return state.components.template size<ComponentType>();
+}
+
+template <typename ComponentType, class ComponentContainer, typename UpdateType>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+inline Idx2D get_component_idx_by_id(MainModelState<ComponentContainer> const& state, ID id) {
+    return state.components.template get_idx_by_id<ComponentType>(id);
+}
+
+template <typename ComponentType, class ComponentContainer, typename UpdateType>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+inline Idx get_component_sequence(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
+    return state.components.template get_seq<ComponentType>(id_or_index);
+}
+
+template <std::derived_from<Base> BaseComponent, std::derived_from<Base> Component, class ComponentContainer>
+    requires std::derived_from<Component, BaseComponent> &&
+             model_component_state_c<MainModelState, ComponentContainer, Component>
+constexpr auto get_component_sequence_offset(MainModelState<ComponentContainer> const& state) {
+    return state.components.template get_start_idx<BaseComponent, Component>();
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto& get_component(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
+    return state.components.template get_item<ComponentType>(id_or_index);
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto& get_component_by_sequence(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
+    return state.components.template get_item_by_seq<ComponentType>(id_or_index);
+}
+
+template <typename ComponentType, class ComponentContainer, typename... Args>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto emplace_component(MainModelState<ComponentContainer>& state, ID id, Args&&... args) {
+    return state.components.template emplace<ComponentType>(id, std::forward<Args>(args)...);
+}
+
+template <typename ComponentType, class ComponentContainer, typename... Args>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr void reserve_component(MainModelState<ComponentContainer>& state, std::integral auto size) {
+    state.components.template reserve<ComponentType>(size);
+}
+
+template <typename ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto get_component_citer(MainModelState<ComponentContainer> const& state) {
+    return state.components.template citer<ComponentType>();
+}
+
+template <std::derived_from<Branch> ComponentType, class ComponentContainer>
+    requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
+constexpr auto get_math_id(MainModelState<ComponentContainer> const& state, Idx topology_sequence_idx) {
+    return state.topo_comp_coup->branch[topology_sequence_idx];
+}
+} // namespace power_grid_model::main_core

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
@@ -18,17 +18,11 @@ template <typename Component, class ComponentContainer, typename ResType, typena
              std::convertible_to<std::invoke_result_t<ResFunc, Component const&>, ResType>
 constexpr void register_topo_components(MainModelState<ComponentContainer> const& state, std::vector<ResType>& target,
                                         ResFunc&& func) {
-    auto const begin = state.components.template citer<Component>().begin();
-    auto const end = state.components.template citer<Component>().end();
+    auto const begin = get_component_citer<Component>(state).begin();
+    auto const end = get_component_citer<Component>(state).end();
 
     target.resize(std::distance(begin, end));
     std::transform(begin, end, target.begin(), func);
-}
-
-template <typename Component, class ComponentContainer>
-    requires model_component_state_c<MainModelState, ComponentContainer, Component>
-constexpr auto get_seq(MainModelState<ComponentContainer> const& state, ID id) {
-    return state.components.template get_seq<Component>(id);
 }
 
 } // namespace detail
@@ -37,7 +31,7 @@ template <std::same_as<Node> Component, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
-    comp_topo.n_node = state.components.template size<Node>();
+    comp_topo.n_node = get_component_size<Node>(state);
 }
 
 template <std::same_as<Branch> Component, class ComponentContainer>
@@ -45,8 +39,8 @@ template <std::same_as<Branch> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.branch_node_idx, [&state](Branch const& branch) {
-        return BranchIdx{detail::get_seq<Node>(state, branch.from_node()),
-                         detail::get_seq<Node>(state, branch.to_node())};
+        return BranchIdx{get_component_sequence<Node>(state, branch.from_node()),
+                         get_component_sequence<Node>(state, branch.to_node())};
     });
 }
 
@@ -55,9 +49,9 @@ template <std::same_as<Branch3> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.branch3_node_idx, [&state](Branch3 const& branch3) {
-        return Branch3Idx{detail::get_seq<Node>(state, branch3.node_1()),
-                          detail::get_seq<Node>(state, branch3.node_2()),
-                          detail::get_seq<Node>(state, branch3.node_3())};
+        return Branch3Idx{get_component_sequence<Node>(state, branch3.node_1()),
+                          get_component_sequence<Node>(state, branch3.node_2()),
+                          get_component_sequence<Node>(state, branch3.node_3())};
     });
 }
 
@@ -66,7 +60,7 @@ template <std::same_as<Source> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.source_node_idx, [&state](Source const& source) {
-        return detail::get_seq<Node>(state, source.node());
+        return get_component_sequence<Node>(state, source.node());
     });
 }
 
@@ -75,7 +69,7 @@ template <std::same_as<Shunt> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.shunt_node_idx, [&state](Shunt const& shunt) {
-        return detail::get_seq<Node>(state, shunt.node());
+        return get_component_sequence<Node>(state, shunt.node());
     });
 }
 
@@ -85,7 +79,7 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(
         state, comp_topo.load_gen_node_idx,
-        [&state](GenericLoadGen const& load_gen) { return detail::get_seq<Node>(state, load_gen.node()); });
+        [&state](GenericLoadGen const& load_gen) { return get_component_sequence<Node>(state, load_gen.node()); });
 
     detail::register_topo_components<Component>(state, comp_topo.load_gen_type,
                                                 [](GenericLoadGen const& load_gen) { return load_gen.type(); });
@@ -97,7 +91,7 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(
         state, comp_topo.voltage_sensor_node_idx, [&state](GenericVoltageSensor const& voltage_sensor) {
-            return detail::get_seq<Node>(state, voltage_sensor.measured_object());
+            return get_component_sequence<Node>(state, voltage_sensor.measured_object());
         });
 }
 
@@ -115,21 +109,21 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
             case branch_from:
                 [[fallthrough]];
             case branch_to:
-                return detail::get_seq<Branch>(state, measured_object);
+                return get_component_sequence<Branch>(state, measured_object);
             case source:
-                return detail::get_seq<Source>(state, measured_object);
+                return get_component_sequence<Source>(state, measured_object);
             case shunt:
-                return detail::get_seq<Shunt>(state, measured_object);
+                return get_component_sequence<Shunt>(state, measured_object);
             case load:
                 [[fallthrough]];
             case generator:
-                return detail::get_seq<GenericLoadGen>(state, measured_object);
+                return get_component_sequence<GenericLoadGen>(state, measured_object);
             case branch3_1:
             case branch3_2:
             case branch3_3:
-                return detail::get_seq<Branch3>(state, measured_object);
+                return get_component_sequence<Branch3>(state, measured_object);
             case node:
-                return detail::get_seq<Node>(state, measured_object);
+                return get_component_sequence<Node>(state, measured_object);
             default:
                 throw MissingCaseForEnumError("Power sensor idx to seq transformation",
                                               power_sensor.get_terminal_type());
@@ -149,9 +143,9 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
         state, comp_topo.regulated_object_idx, [&state](Regulator const& regulator) {
             switch (regulator.regulated_object_type()) {
             case ComponentType::branch:
-                return detail::get_seq<Branch>(state, regulator.regulated_object());
+                return get_component_sequence<Branch>(state, regulator.regulated_object());
             case ComponentType::branch3:
-                return detail::get_seq<Branch3>(state, regulator.regulated_object());
+                return get_component_sequence<Branch3>(state, regulator.regulated_object());
             default:
                 throw MissingCaseForEnumError("Regulator idx to seq transformation", regulator.regulated_object_type());
             }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "state.hpp"
+#include "state_queries.hpp"
 
 #include "../all_components.hpp"
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
@@ -954,7 +954,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                Idx2D const& changed_component_idx) {
                 if constexpr (std::derived_from<ComponentType, Branch>) {
                     Idx2D const math_idx =
-                        state.topo_comp_coup->branch[get_component_sequence<Branch>(state, changed_component_idx)];
+                        state.topo_comp_coup
+                            ->branch[main_core::get_component_sequence<Branch>(state, changed_component_idx)];
                     if (math_idx.group == -1) {
                         return;
                     }
@@ -962,7 +963,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                     increments[math_idx.group].branch_param_to_change.push_back(math_idx.pos);
                 } else if constexpr (std::derived_from<ComponentType, Branch3>) {
                     Idx2DBranch3 const math_idx =
-                        state.topo_comp_coup->branch3[get_component_sequence<Branch3>(state, changed_component_idx)];
+                        state.topo_comp_coup
+                            ->branch3[main_core::get_component_sequence<Branch3>(state, changed_component_idx)];
                     if (math_idx.group == -1) {
                         return;
                     }
@@ -974,7 +976,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                     }
                 } else if constexpr (std::same_as<ComponentType, Shunt>) {
                     Idx2D const math_idx =
-                        state.topo_comp_coup->shunt[get_component_sequence<Shunt>(state, changed_component_idx)];
+                        state.topo_comp_coup
+                            ->shunt[main_core::get_component_sequence<Shunt>(state, changed_component_idx)];
                     if (math_idx.group == -1) {
                         return;
                     }
@@ -1112,7 +1115,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
             if (math_idx.group == -1) {
                 continue;
             }
-            (input[math_idx.group].*component)[math_idx.pos] = get_component_by_sequence<Component>(state, i).status();
+            (input[math_idx.group].*component)[math_idx.pos] =
+                main_core::get_component_by_sequence<Component>(state, i).status();
         }
     }
 


### PR DESCRIPTION
Cherry-picked from https://github.com/PowerGridModel/power-grid-model/pull/557

* common state queries (e.g. shorthands for `state.common.template *`)
* `transformer_c` concept
* `using gettable_types` in `Container`
* `using SideType` in `Branch` and `Branch3`