### PR TITLE
run citations workflow when current workflow changes

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - CITATION.cff
+      - .github/workflows/citations.yml
 
   pull_request:
     paths:

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -9,8 +9,11 @@ on:
   push:
     branches:
       - main
+
+  pull_request:
     paths:
       - CITATION.cff
+      - .github/workflows/citations.yml
 
   workflow_dispatch:
 


### PR DESCRIPTION
When https://github.com/PowerGridModel/power-grid-model/pull/571 and https://github.com/PowerGridModel/power-grid-model-io/pull/244 happened, we needed to manually run the citations validation check. This adds that and thereby also provides a template for similar actions that only need to happen when certain files change.

Proof that this change works: https://github.com/PowerGridModel/power-grid-model/actions/runs/8817114815/job/24202727988?pr=575