### PR TITLE
[FEATURE] add support for same-ranked transformers

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -53,7 +53,7 @@ struct TrafoGraphEdge {
 
 using TrafoGraphEdges = std::vector<std::pair<TrafoGraphIdx, TrafoGraphIdx>>;
 using TrafoGraphEdgeProperties = std::vector<TrafoGraphEdge>;
-using RankedTransformerGroups = std::vector<Idx2D>;
+using RankedTransformerGroups = std::vector<std::vector<Idx2D>>;
 
 struct RegulatedObjects {
     std::set<Idx> transformers{};
@@ -256,8 +256,15 @@ inline auto rank_transformers(TrafoGraphEdgeProperties const& w_trafo_list) -> R
     std::sort(sorted_trafos.begin(), sorted_trafos.end(),
               [](const TrafoGraphEdge& a, const TrafoGraphEdge& b) { return a.weight < b.weight; });
 
-    RankedTransformerGroups groups(sorted_trafos.size());
-    std::ranges::transform(sorted_trafos, groups.begin(), [](const TrafoGraphEdge& x) { return x.regulated_idx; });
+    RankedTransformerGroups groups;
+    auto previous_weight = std::numeric_limits<EdgeWeight>::lowest();
+    for (auto const& trafo : sorted_trafos) {
+        if (trafo.weight > previous_weight) {
+            groups.emplace_back();
+            previous_weight = trafo.weight;
+        }
+        groups.back().push_back(trafo.regulated_idx);
+    }
     return groups;
 }
 

--- a/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
+++ b/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
@@ -190,7 +190,7 @@ TEST_CASE("Test Transformer ranking") {
                                    {{{4, 0}, 1}, {unregulated_idx, 1}, {unregulated_idx, 1}, {unregulated_idx, 1}});
         expected_edges_prop.insert(expected_edges_prop.end(), 10, {unregulated_idx, 0});
 
-        const std::vector<pgm_tap::TrafoGraphVertex> expected_vertex_props{{true},  {false}, {false}, {false}, {false},
+        std::vector<pgm_tap::TrafoGraphVertex> const expected_vertex_props{{true},  {false}, {false}, {false}, {false},
                                                                            {false}, {false}, {false}, {false}, {false}};
 
         pgm_tap::TransformerGraph actual_graph = pgm_tap::build_transformer_graph(state);
@@ -238,8 +238,8 @@ TEST_CASE("Test Transformer ranking") {
             g[*vi].is_source = vertex_props[*vi].is_source;
         }
 
-        const pgm_tap::TrafoGraphEdgeProperties regulated_edge_weights = get_edge_weights(g);
-        const pgm_tap::TrafoGraphEdgeProperties ref_regulated_edge_weights{{{0, 1}, 0}, {{2, 3}, 2}};
+        pgm_tap::TrafoGraphEdgeProperties const regulated_edge_weights = get_edge_weights(g);
+        pgm_tap::TrafoGraphEdgeProperties const ref_regulated_edge_weights{{{0, 1}, 0}, {{2, 3}, 2}};
         CHECK(regulated_edge_weights == ref_regulated_edge_weights);
     }
 
@@ -247,16 +247,20 @@ TEST_CASE("Test Transformer ranking") {
         pgm_tap::TrafoGraphEdgeProperties trafoList{
             {Idx2D{1, 1}, pgm_tap::infty}, {Idx2D{1, 2}, 5}, {Idx2D{1, 3}, 4}, {Idx2D{2, 1}, 4}};
 
-        const pgm_tap::RankedTransformerGroups referenceList{Idx2D{1, 3}, Idx2D{2, 1}, Idx2D{1, 2}, Idx2D{1, 1}};
+        pgm_tap::RankedTransformerGroups const referenceList{{Idx2D{1, 3}, Idx2D{2, 1}}, {Idx2D{1, 2}}, {Idx2D{1, 1}}};
 
-        const pgm_tap::RankedTransformerGroups sortedTrafoList = pgm_tap::rank_transformers(trafoList);
-        CHECK(sortedTrafoList == referenceList);
+        pgm_tap::RankedTransformerGroups const sortedTrafoList = pgm_tap::rank_transformers(trafoList);
+        REQUIRE(sortedTrafoList.size() == referenceList.size());
+        for (Idx idx = 0; idx < sortedTrafoList.size(); ++idx) {
+            CAPTURE(idx);
+            CHECK(sortedTrafoList[idx] == referenceList[idx]);
+        }
     }
 
     SUBCASE("Ranking complete the graph") {
         pgm_tap::RankedTransformerGroups order = pgm_tap::rank_transformers(state);
-        pgm_tap::RankedTransformerGroups ref_order{Idx2D{3, 0}, Idx2D{3, 1}, Idx2D{4, 0},
-                                                   Idx2D{3, 3}, Idx2D{3, 2}, Idx2D{3, 4}};
+        pgm_tap::RankedTransformerGroups const ref_order{
+            {Idx2D{3, 0}, Idx2D{3, 1}, Idx2D{4, 0}}, {Idx2D{3, 3}, Idx2D{3, 2}}, {Idx2D{3, 4}}};
         CHECK(order == ref_order);
     }
 }

--- a/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
+++ b/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
@@ -244,14 +244,14 @@ TEST_CASE("Test Transformer ranking") {
     }
 
     SUBCASE("Sorting transformer edges") {
-        pgm_tap::TrafoGraphEdgeProperties trafoList{
+        pgm_tap::TrafoGraphEdgeProperties const trafoList{
             {Idx2D{1, 1}, pgm_tap::infty}, {Idx2D{1, 2}, 5}, {Idx2D{1, 3}, 4}, {Idx2D{2, 1}, 4}};
 
         pgm_tap::RankedTransformerGroups const referenceList{{Idx2D{1, 3}, Idx2D{2, 1}}, {Idx2D{1, 2}}, {Idx2D{1, 1}}};
 
         pgm_tap::RankedTransformerGroups const sortedTrafoList = pgm_tap::rank_transformers(trafoList);
         REQUIRE(sortedTrafoList.size() == referenceList.size());
-        for (Idx idx = 0; idx < sortedTrafoList.size(); ++idx) {
+        for (Idx idx = 0; idx < static_cast<Idx>(sortedTrafoList.size()); ++idx) {
             CAPTURE(idx);
             CHECK(sortedTrafoList[idx] == referenceList[idx]);
         }


### PR DESCRIPTION
If you have a number of transformers like the following grid then `Trafo_1` and `Trafo_2` should be assigned equivalent rank.
```
      /-- Trafo_1 -- Trafo_3
Source
      \-- Trafo_2
```

The current `main` after #562 only has support for a linear ranking and therefore assigns order `[1, 2, 3]`

This PR introduces the transformer ranking output as a nested vector, resulting in `[[1, 2], 3]`, such that `1` and `2` are treated equivalently, while `3` is ranked differently because it has higher rank.