### PR TITLE
Renaming `MathOutput` to `SolverOutput`

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
@@ -125,7 +125,7 @@ struct TransformerTapRegulatorCalcParam {
     DoubleComplex z_compensation{};
     IntS status{};
 };
-template <symmetry_tag sym_type> struct TransformerTapRegulatorSolverOutput {
+template <symmetry_tag sym_type> struct TransformerTapRegulatorOptimizerOutput {
     using sym = sym_type;
 
     IntS tap_pos{na_IntS};
@@ -270,7 +270,7 @@ template <symmetry_tag sym_type> struct SolverOutput {
     std::vector<ApplianceSolverOutput<sym>> source;
     std::vector<ApplianceSolverOutput<sym>> shunt;
     std::vector<ApplianceSolverOutput<sym>> load_gen;
-    std::vector<TransformerTapRegulatorSolverOutput<sym>> transformer_tap_regulator;
+    std::vector<TransformerTapRegulatorOptimizerOutput<sym>> transformer_tap_regulator;
 };
 
 template <symmetry_tag sym_type> struct ShortCircuitSolverOutput {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
@@ -35,7 +35,7 @@ template <symmetry_tag sym_type> struct BranchCalcParam {
     ComplexTensor<sym> const& ytt() const { return value[3]; }
 };
 
-template <symmetry_tag sym_type> struct BranchMathOutput {
+template <symmetry_tag sym_type> struct BranchSolverOutput {
     using sym = sym_type;
 
     ComplexValue<sym> s_f{};
@@ -44,7 +44,7 @@ template <symmetry_tag sym_type> struct BranchMathOutput {
     ComplexValue<sym> i_t{};
 };
 
-template <symmetry_tag sym_type> struct BranchShortCircuitMathOutput {
+template <symmetry_tag sym_type> struct BranchShortCircuitSolverOutput {
     using sym = sym_type;
 
     ComplexValue<sym> i_f{};
@@ -58,7 +58,7 @@ struct FaultCalcParam {
     FaultPhase fault_phase{};
 };
 
-template <symmetry_tag sym_type> struct FaultShortCircuitMathOutput {
+template <symmetry_tag sym_type> struct FaultShortCircuitSolverOutput {
     using sym = sym_type;
 
     ComplexValue<sym> i_fault{};
@@ -66,13 +66,13 @@ template <symmetry_tag sym_type> struct FaultShortCircuitMathOutput {
 
 // appliance math output, always injection direction
 // s > 0, energy appliance -> node
-template <symmetry_tag sym_type> struct ApplianceMathOutput {
+template <symmetry_tag sym_type> struct ApplianceSolverOutput {
     using sym = sym_type;
 
     ComplexValue<sym> s{};
     ComplexValue<sym> i{};
 };
-template <symmetry_tag sym_type> struct ApplianceShortCircuitMathOutput {
+template <symmetry_tag sym_type> struct ApplianceShortCircuitSolverOutput {
     using sym = sym_type;
 
     ComplexValue<sym> i{};
@@ -125,7 +125,7 @@ struct TransformerTapRegulatorCalcParam {
     DoubleComplex z_compensation{};
     IntS status{};
 };
-template <symmetry_tag sym_type> struct TransformerTapRegulatorMathOutput {
+template <symmetry_tag sym_type> struct TransformerTapRegulatorSolverOutput {
     using sym = sym_type;
 
     IntS tap_pos{na_IntS};
@@ -258,72 +258,72 @@ static_assert(calculation_input_type<PowerFlowInput<asymmetric_t>>);
 static_assert(calculation_input_type<StateEstimationInput<asymmetric_t>>);
 static_assert(calculation_input_type<ShortCircuitInput>);
 
-struct math_output_t {};
+struct solver_output_t {};
 
-template <symmetry_tag sym_type> struct MathOutput {
-    using type = math_output_t;
+template <symmetry_tag sym_type> struct SolverOutput {
+    using type = solver_output_t;
     using sym = sym_type;
 
     std::vector<ComplexValue<sym>> u;
     std::vector<ComplexValue<sym>> bus_injection;
-    std::vector<BranchMathOutput<sym>> branch;
-    std::vector<ApplianceMathOutput<sym>> source;
-    std::vector<ApplianceMathOutput<sym>> shunt;
-    std::vector<ApplianceMathOutput<sym>> load_gen;
-    std::vector<TransformerTapRegulatorMathOutput<sym>> transformer_tap_regulator;
+    std::vector<BranchSolverOutput<sym>> branch;
+    std::vector<ApplianceSolverOutput<sym>> source;
+    std::vector<ApplianceSolverOutput<sym>> shunt;
+    std::vector<ApplianceSolverOutput<sym>> load_gen;
+    std::vector<TransformerTapRegulatorSolverOutput<sym>> transformer_tap_regulator;
 };
 
-template <symmetry_tag sym_type> struct ShortCircuitMathOutput {
-    using type = math_output_t;
+template <symmetry_tag sym_type> struct ShortCircuitSolverOutput {
+    using type = solver_output_t;
     using sym = sym_type;
 
     std::vector<ComplexValue<sym>> u_bus;
-    std::vector<FaultShortCircuitMathOutput<sym>> fault;
-    std::vector<BranchShortCircuitMathOutput<sym>> branch;
-    std::vector<ApplianceShortCircuitMathOutput<sym>> source;
-    std::vector<ApplianceShortCircuitMathOutput<sym>> shunt;
+    std::vector<FaultShortCircuitSolverOutput<sym>> fault;
+    std::vector<BranchShortCircuitSolverOutput<sym>> branch;
+    std::vector<ApplianceShortCircuitSolverOutput<sym>> source;
+    std::vector<ApplianceShortCircuitSolverOutput<sym>> shunt;
 };
 
 template <typename T>
-concept math_output_type = std::derived_from<typename T::type, math_output_t>;
+concept solver_output_type = std::derived_from<typename T::type, solver_output_t>;
 
-static_assert(math_output_type<MathOutput<symmetric_t>>);
-static_assert(math_output_type<MathOutput<asymmetric_t>>);
-static_assert(math_output_type<ShortCircuitMathOutput<symmetric_t>>);
-static_assert(math_output_type<ShortCircuitMathOutput<asymmetric_t>>);
-
-template <typename T>
-concept symmetric_math_output_type = math_output_type<T> && is_symmetric_v<typename T::sym>;
-
-static_assert(symmetric_math_output_type<MathOutput<symmetric_t>>);
-static_assert(!symmetric_math_output_type<MathOutput<asymmetric_t>>);
-static_assert(symmetric_math_output_type<ShortCircuitMathOutput<symmetric_t>>);
-static_assert(!symmetric_math_output_type<ShortCircuitMathOutput<asymmetric_t>>);
+static_assert(solver_output_type<SolverOutput<symmetric_t>>);
+static_assert(solver_output_type<SolverOutput<asymmetric_t>>);
+static_assert(solver_output_type<ShortCircuitSolverOutput<symmetric_t>>);
+static_assert(solver_output_type<ShortCircuitSolverOutput<asymmetric_t>>);
 
 template <typename T>
-concept asymmetric_math_output_type = math_output_type<T> && is_asymmetric_v<typename T::sym>;
+concept symmetric_solver_output_type = solver_output_type<T> && is_symmetric_v<typename T::sym>;
 
-static_assert(!asymmetric_math_output_type<MathOutput<symmetric_t>>);
-static_assert(asymmetric_math_output_type<MathOutput<asymmetric_t>>);
-static_assert(!asymmetric_math_output_type<ShortCircuitMathOutput<symmetric_t>>);
-static_assert(asymmetric_math_output_type<ShortCircuitMathOutput<asymmetric_t>>);
-
-template <typename T>
-concept steady_state_math_output_type = math_output_type<T> && std::derived_from<T, MathOutput<typename T::sym>>;
-
-static_assert(steady_state_math_output_type<MathOutput<symmetric_t>>);
-static_assert(steady_state_math_output_type<MathOutput<asymmetric_t>>);
-static_assert(!steady_state_math_output_type<ShortCircuitMathOutput<symmetric_t>>);
-static_assert(!steady_state_math_output_type<ShortCircuitMathOutput<asymmetric_t>>);
+static_assert(symmetric_solver_output_type<SolverOutput<symmetric_t>>);
+static_assert(!symmetric_solver_output_type<SolverOutput<asymmetric_t>>);
+static_assert(symmetric_solver_output_type<ShortCircuitSolverOutput<symmetric_t>>);
+static_assert(!symmetric_solver_output_type<ShortCircuitSolverOutput<asymmetric_t>>);
 
 template <typename T>
-concept short_circuit_math_output_type =
-    math_output_type<T> && std::derived_from<T, ShortCircuitMathOutput<typename T::sym>>;
+concept asymmetric_solver_output_type = solver_output_type<T> && is_asymmetric_v<typename T::sym>;
 
-static_assert(!short_circuit_math_output_type<MathOutput<symmetric_t>>);
-static_assert(!short_circuit_math_output_type<MathOutput<asymmetric_t>>);
-static_assert(short_circuit_math_output_type<ShortCircuitMathOutput<symmetric_t>>);
-static_assert(short_circuit_math_output_type<ShortCircuitMathOutput<asymmetric_t>>);
+static_assert(!asymmetric_solver_output_type<SolverOutput<symmetric_t>>);
+static_assert(asymmetric_solver_output_type<SolverOutput<asymmetric_t>>);
+static_assert(!asymmetric_solver_output_type<ShortCircuitSolverOutput<symmetric_t>>);
+static_assert(asymmetric_solver_output_type<ShortCircuitSolverOutput<asymmetric_t>>);
+
+template <typename T>
+concept steady_state_solver_output_type = solver_output_type<T> && std::derived_from<T, SolverOutput<typename T::sym>>;
+
+static_assert(steady_state_solver_output_type<SolverOutput<symmetric_t>>);
+static_assert(steady_state_solver_output_type<SolverOutput<asymmetric_t>>);
+static_assert(!steady_state_solver_output_type<ShortCircuitSolverOutput<symmetric_t>>);
+static_assert(!steady_state_solver_output_type<ShortCircuitSolverOutput<asymmetric_t>>);
+
+template <typename T>
+concept short_circuit_solver_output_type =
+    solver_output_type<T> && std::derived_from<T, ShortCircuitSolverOutput<typename T::sym>>;
+
+static_assert(!short_circuit_solver_output_type<SolverOutput<symmetric_t>>);
+static_assert(!short_circuit_solver_output_type<SolverOutput<asymmetric_t>>);
+static_assert(short_circuit_solver_output_type<ShortCircuitSolverOutput<symmetric_t>>);
+static_assert(short_circuit_solver_output_type<ShortCircuitSolverOutput<asymmetric_t>>);
 
 // component indices at physical model side
 // from, to node indices for branches

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
@@ -60,13 +60,13 @@ class Appliance : public Base {
     }
 
     template <symmetry_tag sym>
-    ApplianceOutput<sym> get_output(ApplianceMathOutput<sym> const& appliance_math_output) const {
+    ApplianceOutput<sym> get_output(ApplianceSolverOutput<sym> const& appliance_solver_output) const {
         ApplianceOutput<sym> output{};
         static_cast<BaseOutput&>(output) = base_output(energized(true));
-        output.p = base_power<sym> * real(appliance_math_output.s) * injection_direction();
-        output.q = base_power<sym> * imag(appliance_math_output.s) * injection_direction();
-        output.s = base_power<sym> * cabs(appliance_math_output.s);
-        output.i = base_i_ * cabs(appliance_math_output.i);
+        output.p = base_power<sym> * real(appliance_solver_output.s) * injection_direction();
+        output.q = base_power<sym> * imag(appliance_solver_output.s) * injection_direction();
+        output.s = base_power<sym> * cabs(appliance_solver_output.s);
+        output.i = base_i_ * cabs(appliance_solver_output.i);
         // pf
         if constexpr (is_symmetric_v<sym>) {
             if (output.s < numerical_tolerance) {
@@ -104,8 +104,9 @@ class Appliance : public Base {
         }
     }
     template <symmetry_tag sym>
-    ApplianceShortCircuitOutput get_sc_output(ApplianceShortCircuitMathOutput<sym> const& appliance_math_output) const {
-        return get_sc_output(appliance_math_output.i);
+    ApplianceShortCircuitOutput
+    get_sc_output(ApplianceShortCircuitSolverOutput<sym> const& appliance_solver_output) const {
+        return get_sc_output(appliance_solver_output.i);
     }
 
   private:
@@ -114,8 +115,8 @@ class Appliance : public Base {
     double base_i_;
 
     // pure virtual functions for translate from u to s/i
-    virtual ApplianceMathOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const = 0;
-    virtual ApplianceMathOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const = 0;
+    virtual ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const = 0;
+    virtual ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const = 0;
 
     virtual double injection_direction() const = 0;
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
@@ -89,28 +89,29 @@ class Branch : public Base {
     BranchOutput<sym> get_output(ComplexValue<sym> const& u_f, ComplexValue<sym> const& u_t) const {
         // calculate flow
         BranchCalcParam<sym> const param = calc_param<sym>();
-        BranchMathOutput<sym> branch_math_output{};
-        branch_math_output.i_f = dot(param.yff(), u_f) + dot(param.yft(), u_t);
-        branch_math_output.i_t = dot(param.ytf(), u_f) + dot(param.ytt(), u_t);
-        branch_math_output.s_f = u_f * conj(branch_math_output.i_f);
-        branch_math_output.s_t = u_t * conj(branch_math_output.i_t);
+        BranchSolverOutput<sym> branch_solver_output{};
+        branch_solver_output.i_f = dot(param.yff(), u_f) + dot(param.yft(), u_t);
+        branch_solver_output.i_t = dot(param.ytf(), u_f) + dot(param.ytt(), u_t);
+        branch_solver_output.s_f = u_f * conj(branch_solver_output.i_f);
+        branch_solver_output.s_t = u_t * conj(branch_solver_output.i_t);
         // calculate result
-        return get_output<sym>(branch_math_output);
+        return get_output<sym>(branch_solver_output);
     }
 
-    template <symmetry_tag sym> BranchOutput<sym> get_output(BranchMathOutput<sym> const& branch_math_output) const {
+    template <symmetry_tag sym>
+    BranchOutput<sym> get_output(BranchSolverOutput<sym> const& branch_solver_output) const {
         // result object
         BranchOutput<sym> output{};
         static_cast<BaseOutput&>(output) = base_output(true);
         // calculate result
-        output.p_from = base_power<sym> * real(branch_math_output.s_f);
-        output.q_from = base_power<sym> * imag(branch_math_output.s_f);
-        output.i_from = base_i_from() * cabs(branch_math_output.i_f);
-        output.s_from = base_power<sym> * cabs(branch_math_output.s_f);
-        output.p_to = base_power<sym> * real(branch_math_output.s_t);
-        output.q_to = base_power<sym> * imag(branch_math_output.s_t);
-        output.i_to = base_i_to() * cabs(branch_math_output.i_t);
-        output.s_to = base_power<sym> * cabs(branch_math_output.s_t);
+        output.p_from = base_power<sym> * real(branch_solver_output.s_f);
+        output.q_from = base_power<sym> * imag(branch_solver_output.s_f);
+        output.i_from = base_i_from() * cabs(branch_solver_output.i_f);
+        output.s_from = base_power<sym> * cabs(branch_solver_output.s_f);
+        output.p_to = base_power<sym> * real(branch_solver_output.s_t);
+        output.q_to = base_power<sym> * imag(branch_solver_output.s_t);
+        output.i_to = base_i_to() * cabs(branch_solver_output.i_t);
+        output.s_to = base_power<sym> * cabs(branch_solver_output.s_t);
         double const max_s = std::max(sum_val(output.s_from), sum_val(output.s_to));
         double const max_i = std::max(max_val(output.i_from), max_val(output.i_to));
         output.loading = loading(max_s, max_i);
@@ -119,28 +120,30 @@ class Branch : public Base {
 
     BranchShortCircuitOutput get_sc_output(ComplexValue<symmetric_t> const& i_f,
                                            ComplexValue<symmetric_t> const& i_t) const {
-        return get_sc_output(BranchShortCircuitMathOutput<symmetric_t>{.i_f = i_f, .i_t = i_t});
+        return get_sc_output(BranchShortCircuitSolverOutput<symmetric_t>{.i_f = i_f, .i_t = i_t});
     }
     BranchShortCircuitOutput get_sc_output(ComplexValue<asymmetric_t> const& i_f,
                                            ComplexValue<asymmetric_t> const& i_t) const {
-        return get_sc_output(BranchShortCircuitMathOutput<asymmetric_t>{.i_f = i_f, .i_t = i_t});
+        return get_sc_output(BranchShortCircuitSolverOutput<asymmetric_t>{.i_f = i_f, .i_t = i_t});
     }
 
-    BranchShortCircuitOutput get_sc_output(BranchShortCircuitMathOutput<asymmetric_t> const& branch_math_output) const {
+    BranchShortCircuitOutput
+    get_sc_output(BranchShortCircuitSolverOutput<asymmetric_t> const& branch_solver_output) const {
         BranchShortCircuitOutput output{};
         static_cast<BaseOutput&>(output) = base_output(true);
         // calculate result
-        output.i_from = base_i_from() * cabs(branch_math_output.i_f);
-        output.i_to = base_i_to() * cabs(branch_math_output.i_t);
-        output.i_from_angle = arg(branch_math_output.i_f);
-        output.i_to_angle = arg(branch_math_output.i_t);
+        output.i_from = base_i_from() * cabs(branch_solver_output.i_f);
+        output.i_to = base_i_to() * cabs(branch_solver_output.i_t);
+        output.i_from_angle = arg(branch_solver_output.i_f);
+        output.i_to_angle = arg(branch_solver_output.i_t);
         return output;
     }
 
-    BranchShortCircuitOutput get_sc_output(BranchShortCircuitMathOutput<symmetric_t> const& branch_math_output) const {
+    BranchShortCircuitOutput
+    get_sc_output(BranchShortCircuitSolverOutput<symmetric_t> const& branch_solver_output) const {
         return get_sc_output(
-            BranchShortCircuitMathOutput<asymmetric_t>{.i_f = ComplexValue<asymmetric_t>{branch_math_output.i_f},
-                                                       .i_t = ComplexValue<asymmetric_t>{branch_math_output.i_t}});
+            BranchShortCircuitSolverOutput<asymmetric_t>{.i_f = ComplexValue<asymmetric_t>{branch_solver_output.i_f},
+                                                         .i_t = ComplexValue<asymmetric_t>{branch_solver_output.i_t}});
     }
 
     template <symmetry_tag sym> BranchOutput<sym> get_null_output() const {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch3.hpp
@@ -100,27 +100,27 @@ class Branch3 : public Base {
     }
 
     template <symmetry_tag sym>
-    Branch3Output<sym> get_output(BranchMathOutput<sym> const& branch_math_output1,
-                                  BranchMathOutput<sym> const& branch_math_output2,
-                                  BranchMathOutput<sym> const& branch_math_output3) const {
+    Branch3Output<sym> get_output(BranchSolverOutput<sym> const& branch_solver_output1,
+                                  BranchSolverOutput<sym> const& branch_solver_output2,
+                                  BranchSolverOutput<sym> const& branch_solver_output3) const {
         // result object
         Branch3Output<sym> output{};
         static_cast<BaseOutput&>(output) = base_output(true);
         // calculate result
-        output.p_1 = base_power<sym> * real(branch_math_output1.s_f);
-        output.q_1 = base_power<sym> * imag(branch_math_output1.s_f);
-        output.i_1 = base_i_1() * cabs(branch_math_output1.i_f);
-        output.s_1 = base_power<sym> * cabs(branch_math_output1.s_f);
+        output.p_1 = base_power<sym> * real(branch_solver_output1.s_f);
+        output.q_1 = base_power<sym> * imag(branch_solver_output1.s_f);
+        output.i_1 = base_i_1() * cabs(branch_solver_output1.i_f);
+        output.s_1 = base_power<sym> * cabs(branch_solver_output1.s_f);
 
-        output.p_2 = base_power<sym> * real(branch_math_output2.s_f);
-        output.q_2 = base_power<sym> * imag(branch_math_output2.s_f);
-        output.i_2 = base_i_2() * cabs(branch_math_output2.i_f);
-        output.s_2 = base_power<sym> * cabs(branch_math_output2.s_f);
+        output.p_2 = base_power<sym> * real(branch_solver_output2.s_f);
+        output.q_2 = base_power<sym> * imag(branch_solver_output2.s_f);
+        output.i_2 = base_i_2() * cabs(branch_solver_output2.i_f);
+        output.s_2 = base_power<sym> * cabs(branch_solver_output2.s_f);
 
-        output.p_3 = base_power<sym> * real(branch_math_output3.s_f);
-        output.q_3 = base_power<sym> * imag(branch_math_output3.s_f);
-        output.i_3 = base_i_3() * cabs(branch_math_output3.i_f);
-        output.s_3 = base_power<sym> * cabs(branch_math_output3.s_f);
+        output.p_3 = base_power<sym> * real(branch_solver_output3.s_f);
+        output.q_3 = base_power<sym> * imag(branch_solver_output3.s_f);
+        output.i_3 = base_i_3() * cabs(branch_solver_output3.i_f);
+        output.s_3 = base_power<sym> * cabs(branch_solver_output3.s_f);
 
         output.loading = loading(sum_val(output.s_1), sum_val(output.s_2), sum_val(output.s_3));
 
@@ -150,10 +150,10 @@ class Branch3 : public Base {
         return get_sc_output(iabc_1, iabc_2, iabc_3);
     }
     template <symmetry_tag sym>
-    Branch3ShortCircuitOutput get_sc_output(BranchShortCircuitMathOutput<sym> const& branch_math_output1,
-                                            BranchShortCircuitMathOutput<sym> const& branch_math_output2,
-                                            BranchShortCircuitMathOutput<sym> const& branch_math_output3) const {
-        return get_sc_output(branch_math_output1.i_f, branch_math_output2.i_f, branch_math_output3.i_f);
+    Branch3ShortCircuitOutput get_sc_output(BranchShortCircuitSolverOutput<sym> const& branch_solver_output1,
+                                            BranchShortCircuitSolverOutput<sym> const& branch_solver_output2,
+                                            BranchShortCircuitSolverOutput<sym> const& branch_solver_output3) const {
+        return get_sc_output(branch_solver_output1.i_f, branch_solver_output2.i_f, branch_solver_output3.i_f);
     }
 
     template <symmetry_tag sym> Branch3Output<sym> get_null_output() const {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
@@ -89,9 +89,9 @@ class Fault final : public Base {
     }
 
     template <symmetry_tag sym>
-    FaultShortCircuitOutput get_sc_output(FaultShortCircuitMathOutput<sym> const& math_output,
+    FaultShortCircuitOutput get_sc_output(FaultShortCircuitSolverOutput<sym> const& solver_output,
                                           double const u_rated) const {
-        return get_sc_output(math_output.i_fault, u_rated);
+        return get_sc_output(solver_output.i_fault, u_rated);
     }
 
     // update faulted object

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
@@ -145,16 +145,16 @@ class LoadGen final : public std::conditional_t<is_generator_v<appliance_type_>,
         return piecewise_complex_value(s_specified_);
     }
     template <symmetry_tag calculation_symmetry>
-    ApplianceMathOutput<calculation_symmetry> u2si(ComplexValue<calculation_symmetry> const& u) const {
-        ApplianceMathOutput<calculation_symmetry> appliance_math_output;
-        appliance_math_output.s = scale_power<calculation_symmetry>(u);
-        appliance_math_output.i = conj(appliance_math_output.s / u);
-        return appliance_math_output;
+    ApplianceSolverOutput<calculation_symmetry> u2si(ComplexValue<calculation_symmetry> const& u) const {
+        ApplianceSolverOutput<calculation_symmetry> appliance_solver_output;
+        appliance_solver_output.s = scale_power<calculation_symmetry>(u);
+        appliance_solver_output.i = conj(appliance_solver_output.s / u);
+        return appliance_solver_output;
     }
-    ApplianceMathOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const override {
+    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const override {
         return u2si<symmetric_t>(u);
     }
-    ApplianceMathOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const override {
+    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const override {
         return u2si<asymmetric_t>(u);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
@@ -101,18 +101,18 @@ class Shunt : public Appliance {
         return true;
     }
 
-    template <symmetry_tag sym_calc> ApplianceMathOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
-        ApplianceMathOutput<sym_calc> appliance_math_output;
+    template <symmetry_tag sym_calc> ApplianceSolverOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
+        ApplianceSolverOutput<sym_calc> appliance_solver_output;
         ComplexTensor<sym_calc> const param = calc_param<sym_calc>();
         // return value should be injection direction, therefore a negative sign for i
-        appliance_math_output.i = -dot(param, u);
-        appliance_math_output.s = u * conj(appliance_math_output.i);
-        return appliance_math_output;
+        appliance_solver_output.i = -dot(param, u);
+        appliance_solver_output.s = u * conj(appliance_solver_output.i);
+        return appliance_solver_output;
     }
-    ApplianceMathOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
+    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
         return u2si<symmetric_t>(u);
     }
-    ApplianceMathOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
+    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
         return u2si<asymmetric_t>(u);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
@@ -120,19 +120,19 @@ class Source : public Appliance {
     DoubleComplex y1_ref_{};
     DoubleComplex y0_ref_{};
 
-    template <symmetry_tag sym_calc> ApplianceMathOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
-        ApplianceMathOutput<sym_calc> appliance_math_output;
+    template <symmetry_tag sym_calc> ApplianceSolverOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
+        ApplianceSolverOutput<sym_calc> appliance_solver_output;
         ComplexValue<sym_calc> const u_ref{u_ref_};
         ComplexTensor<sym_calc> const y_ref = math_param<sym_calc>();
-        appliance_math_output.i = dot(y_ref, u_ref - u);
-        appliance_math_output.s = u * conj(appliance_math_output.i);
-        return appliance_math_output;
+        appliance_solver_output.i = dot(y_ref, u_ref - u);
+        appliance_solver_output.s = u * conj(appliance_solver_output.i);
+        return appliance_solver_output;
     }
 
-    ApplianceMathOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
+    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
         return u2si<symmetric_t>(u);
     }
-    ApplianceMathOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
+    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
         return u2si<asymmetric_t>(u);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
@@ -91,153 +91,154 @@ constexpr ResIt produce_output(MainModelState<ComponentContainer> const& state, 
 } // namespace detail
 
 // output node
-template <std::derived_from<Node> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Node const& node, std::vector<MathOutputType> const& math_output, Idx2D math_id) {
-    using sym = typename MathOutputType::sym;
+template <std::derived_from<Node> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Node const& node, std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return node.get_null_output<sym>();
     }
-    return node.get_output<sym>(math_output[math_id.group].u[math_id.pos],
-                                math_output[math_id.group].bus_injection[math_id.pos]);
+    return node.get_output<sym>(solver_output[math_id.group].u[math_id.pos],
+                                solver_output[math_id.group].bus_injection[math_id.pos]);
 }
-template <std::derived_from<Node> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& node, std::vector<MathOutputType> const& math_output, Idx2D math_id) {
+template <std::derived_from<Node> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& node, std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
     if (math_id.group == -1) {
         return node.get_null_sc_output();
     }
-    return node.get_sc_output(math_output[math_id.group].u_bus[math_id.pos]);
+    return node.get_sc_output(solver_output[math_id.group].u_bus[math_id.pos]);
 }
 
 // output branch
-template <std::derived_from<Branch> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Component const& branch, std::vector<MathOutputType> const& math_output, Idx2D math_id) {
-    using sym = typename MathOutputType::sym;
+template <std::derived_from<Branch> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Component const& branch, std::vector<SolverOutputType> const& solver_output,
+                             Idx2D math_id) {
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return branch.template get_null_output<sym>();
     }
-    return branch.template get_output<sym>(math_output[math_id.group].branch[math_id.pos]);
+    return branch.template get_output<sym>(solver_output[math_id.group].branch[math_id.pos]);
 }
-template <std::derived_from<Branch> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& branch, std::vector<MathOutputType> const& math_output, Idx2D math_id) {
+template <std::derived_from<Branch> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& branch, std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
     if (math_id.group == -1) {
         return branch.get_null_sc_output();
     }
-    return branch.get_sc_output(math_output[math_id.group].branch[math_id.pos]);
+    return branch.get_sc_output(solver_output[math_id.group].branch[math_id.pos]);
 }
 
 // output branch3
-template <std::derived_from<Branch3> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Component const& branch3, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Branch3> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Component const& branch3, std::vector<SolverOutputType> const& solver_output,
                              Idx2DBranch3 const& math_id) {
-    using sym = typename MathOutputType::sym;
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return branch3.template get_null_output<sym>();
     }
 
-    auto const& branches = math_output[math_id.group].branch;
+    auto const& branches = solver_output[math_id.group].branch;
     return branch3.template get_output<sym>(branches[math_id.pos[0]], branches[math_id.pos[1]],
                                             branches[math_id.pos[2]]);
 }
-template <std::derived_from<Branch3> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& branch3, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Branch3> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& branch3, std::vector<SolverOutputType> const& solver_output,
                           Idx2DBranch3 const& math_id) {
     if (math_id.group == -1) {
         return branch3.get_null_sc_output();
     }
 
-    auto const& branches = math_output[math_id.group].branch;
+    auto const& branches = solver_output[math_id.group].branch;
     return branch3.get_sc_output(branches[math_id.pos[0]], branches[math_id.pos[1]], branches[math_id.pos[2]]);
 }
 
 // output source
-template <std::derived_from<Source> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Component const& source, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Source> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Component const& source, std::vector<SolverOutputType> const& solver_output,
                              Idx2D const& math_id) {
-    using sym = typename MathOutputType::sym;
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return source.template get_null_output<sym>();
     }
-    return source.template get_output<sym>(math_output[math_id.group].source[math_id.pos]);
+    return source.template get_output<sym>(solver_output[math_id.group].source[math_id.pos]);
 }
-template <std::derived_from<Source> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& source, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Source> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& source, std::vector<SolverOutputType> const& solver_output,
                           Idx2D const& math_id) {
     if (math_id.group == -1) {
         return source.get_null_sc_output();
     }
-    return source.get_sc_output(math_output[math_id.group].source[math_id.pos]);
+    return source.get_sc_output(solver_output[math_id.group].source[math_id.pos]);
 }
 
 // output load gen
-template <std::derived_from<GenericLoadGen> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Component const& load_gen, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<GenericLoadGen> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Component const& load_gen, std::vector<SolverOutputType> const& solver_output,
                              Idx2D const& math_id) {
-    using sym = typename MathOutputType::sym;
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return load_gen.template get_null_output<sym>();
     }
-    return load_gen.template get_output<sym>(math_output[math_id.group].load_gen[math_id.pos]);
+    return load_gen.template get_output<sym>(solver_output[math_id.group].load_gen[math_id.pos]);
 }
-template <std::derived_from<GenericLoadGen> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& load_gen, std::vector<MathOutputType> const& /*math_output*/,
+template <std::derived_from<GenericLoadGen> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& load_gen, std::vector<SolverOutputType> const& /*solver_output*/,
                           Idx2D const& /*math_id*/) {
     return load_gen.get_null_sc_output();
 }
 
 // output shunt
-template <std::derived_from<Shunt> Component, steady_state_math_output_type MathOutputType>
-constexpr auto output_result(Component const& shunt, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Shunt> Component, steady_state_solver_output_type SolverOutputType>
+constexpr auto output_result(Component const& shunt, std::vector<SolverOutputType> const& solver_output,
                              Idx2D const& math_id) {
-    using sym = typename MathOutputType::sym;
+    using sym = typename SolverOutputType::sym;
 
     if (math_id.group == -1) {
         return shunt.template get_null_output<sym>();
     }
-    return shunt.template get_output<sym>(math_output[math_id.group].shunt[math_id.pos]);
+    return shunt.template get_output<sym>(solver_output[math_id.group].shunt[math_id.pos]);
 }
-template <std::derived_from<Shunt> Component, short_circuit_math_output_type MathOutputType>
-inline auto output_result(Component const& shunt, std::vector<MathOutputType> const& math_output,
+template <std::derived_from<Shunt> Component, short_circuit_solver_output_type SolverOutputType>
+inline auto output_result(Component const& shunt, std::vector<SolverOutputType> const& solver_output,
                           Idx2D const& math_id) {
     if (math_id.group == -1) {
         return shunt.get_null_sc_output();
     }
-    return shunt.get_sc_output(math_output[math_id.group].shunt[math_id.pos]);
+    return shunt.get_sc_output(solver_output[math_id.group].shunt[math_id.pos]);
 }
 
 // output voltage sensor
 template <std::derived_from<GenericVoltageSensor> Component, class ComponentContainer,
-          steady_state_math_output_type MathOutputType>
+          steady_state_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto output_result(Component const& voltage_sensor, MainModelState<ComponentContainer> const& state,
-                             std::vector<MathOutputType> const& math_output, Idx const node_seq) {
-    using sym = typename MathOutputType::sym;
+                             std::vector<SolverOutputType> const& solver_output, Idx const node_seq) {
+    using sym = typename SolverOutputType::sym;
 
     Idx2D const node_math_id = state.topo_comp_coup->node[node_seq];
     if (node_math_id.group == -1) {
         return voltage_sensor.template get_null_output<sym>();
     }
-    return voltage_sensor.template get_output<sym>(math_output[node_math_id.group].u[node_math_id.pos]);
+    return voltage_sensor.template get_output<sym>(solver_output[node_math_id.group].u[node_math_id.pos]);
 }
 template <std::derived_from<GenericVoltageSensor> Component, class ComponentContainer,
-          short_circuit_math_output_type MathOutputType>
+          short_circuit_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 inline auto output_result(Component const& voltage_sensor, MainModelState<ComponentContainer> const& /* state */,
-                          std::vector<MathOutputType> const& /* math_output */, Idx const /* node_seq */) {
+                          std::vector<SolverOutputType> const& /* solver_output */, Idx const /* node_seq */) {
     return voltage_sensor.get_null_sc_output();
 }
 
 // output power sensor
 template <std::derived_from<GenericPowerSensor> Component, class ComponentContainer,
-          steady_state_math_output_type MathOutputType>
+          steady_state_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto output_result(Component const& power_sensor, MainModelState<ComponentContainer> const& state,
-                             std::vector<MathOutputType> const& math_output, Idx const obj_seq) {
-    using sym = typename MathOutputType::sym;
+                             std::vector<SolverOutputType> const& solver_output, Idx const obj_seq) {
+    using sym = typename SolverOutputType::sym;
 
     auto const terminal_type = power_sensor.get_terminal_type();
     Idx2D const obj_math_id = [&]() {
@@ -282,146 +283,148 @@ constexpr auto output_result(Component const& power_sensor, MainModelState<Compo
     case branch3_1:
     case branch3_2:
     case branch3_3:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].branch[obj_math_id.pos].s_f);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].branch[obj_math_id.pos].s_f);
     case branch_to:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].branch[obj_math_id.pos].s_t);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].branch[obj_math_id.pos].s_t);
     case source:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].source[obj_math_id.pos].s);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].source[obj_math_id.pos].s);
     case shunt:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].shunt[obj_math_id.pos].s);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].shunt[obj_math_id.pos].s);
     case load:
         [[fallthrough]];
     case generator:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].load_gen[obj_math_id.pos].s);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].load_gen[obj_math_id.pos].s);
     case node:
-        return power_sensor.template get_output<sym>(math_output[obj_math_id.group].bus_injection[obj_math_id.pos]);
+        return power_sensor.template get_output<sym>(solver_output[obj_math_id.group].bus_injection[obj_math_id.pos]);
     default:
         throw MissingCaseForEnumError(std::string(GenericPowerSensor::name) + " output_result()", terminal_type);
     }
 }
 template <std::derived_from<GenericPowerSensor> Component, class ComponentContainer,
-          short_circuit_math_output_type MathOutputType>
+          short_circuit_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto output_result(Component const& power_sensor, MainModelState<ComponentContainer> const& /* state */,
-                             std::vector<MathOutputType> const& /* math_output */, Idx const /* obj_seq */) {
+                             std::vector<SolverOutputType> const& /* solver_output */, Idx const /* obj_seq */) {
     return power_sensor.get_null_sc_output();
 }
 
 // output fault
-template <std::derived_from<Fault> Component, class ComponentContainer, steady_state_math_output_type MathOutputType>
+template <std::derived_from<Fault> Component, class ComponentContainer,
+          steady_state_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
              model_component_state_c<MainModelState, ComponentContainer, Node>
 constexpr auto output_result(Component const& fault, MainModelState<ComponentContainer> const& /* state */,
-                             std::vector<MathOutputType> const& /* math_output */, Idx2D /* math_id */) {
+                             std::vector<SolverOutputType> const& /* solver_output */, Idx2D /* math_id */) {
     return fault.get_output();
 }
-template <std::derived_from<Fault> Component, class ComponentContainer, short_circuit_math_output_type MathOutputType>
+template <std::derived_from<Fault> Component, class ComponentContainer,
+          short_circuit_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
              model_component_state_c<MainModelState, ComponentContainer, Node>
 inline auto output_result(Component const& fault, MainModelState<ComponentContainer> const& state,
-                          std::vector<MathOutputType> const& math_output, Idx2D math_id) {
+                          std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
     if (math_id.group == -1) {
         return fault.get_null_sc_output();
     }
 
     auto const u_rated = get_component<Node>(state, fault.get_fault_object()).u_rated();
-    return fault.get_sc_output(math_output[math_id.group].fault[math_id.pos], u_rated);
+    return fault.get_sc_output(solver_output[math_id.group].fault[math_id.pos], u_rated);
 }
 
 // output transformer tap regulator
 template <std::derived_from<TransformerTapRegulator> Component, class ComponentContainer,
-          steady_state_math_output_type MathOutputType>
+          steady_state_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr auto output_result(Component const& /* transformer_tap_regulator */,
                              MainModelState<ComponentContainer> const& /* state */,
-                             std::vector<MathOutputType> const& /* math_output */, Idx const /* obj_seq */) {
+                             std::vector<SolverOutputType> const& /* solver_output */, Idx const /* obj_seq */) {
     // TODO: this function is not implemented
-    using sym = typename MathOutputType::sym;
+    using sym = typename SolverOutputType::sym;
     return typename TransformerTapRegulator::OutputType<sym>{};
 }
 template <std::derived_from<TransformerTapRegulator> Component, class ComponentContainer,
-          short_circuit_math_output_type MathOutputType>
+          short_circuit_solver_output_type SolverOutputType>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 inline auto output_result(Component const& transformer_tap_regulator,
                           MainModelState<ComponentContainer> const& /* state */,
-                          std::vector<MathOutputType> const& /* math_output */, Idx const /* obj_seq */) {
+                          std::vector<SolverOutputType> const& /* solver_output */, Idx const /* obj_seq */) {
     return transformer_tap_regulator.get_null_sc_output();
 }
 
 // output base component
-template <std::derived_from<Base> Component, class ComponentContainer, math_output_type MathOutputType,
+template <std::derived_from<Base> Component, class ComponentContainer, solver_output_type SolverOutputType,
           std::forward_iterator ResIt>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
-             requires(Component const& component, std::vector<MathOutputType> const& math_output, Idx2D math_id) {
+             requires(Component const& component, std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
                  {
-                     output_result<Component>(component, math_output, math_id)
+                     output_result<Component>(component, solver_output, math_id)
                      } -> std::convertible_to<std::iter_value_t<ResIt>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
-                              std::vector<MathOutputType> const& math_output, ResIt res_it) {
+                              std::vector<SolverOutputType> const& solver_output, ResIt res_it) {
     return detail::produce_output<Component, Idx2D>(
-        state, res_it, [&math_output](Component const& component, Idx2D math_id) {
-            return output_result<Component>(component, math_output, math_id);
+        state, res_it, [&solver_output](Component const& component, Idx2D math_id) {
+            return output_result<Component>(component, solver_output, math_id);
         });
 }
-template <std::derived_from<Base> Component, class ComponentContainer, math_output_type MathOutputType,
+template <std::derived_from<Base> Component, class ComponentContainer, solver_output_type SolverOutputType,
           std::forward_iterator ResIt>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
              requires(Component const& component, MainModelState<ComponentContainer> const& state,
-                      std::vector<MathOutputType> const& math_output, Idx2D math_id) {
+                      std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
                  {
-                     output_result<Component>(component, state, math_output, math_id)
+                     output_result<Component>(component, state, solver_output, math_id)
                      } -> std::convertible_to<std::iter_value_t<ResIt>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
-                              std::vector<MathOutputType> const& math_output, ResIt res_it) {
+                              std::vector<SolverOutputType> const& solver_output, ResIt res_it) {
     return detail::produce_output<Component, Idx2D>(
-        state, res_it, [&state, &math_output](Component const& component, Idx2D const math_id) {
-            return output_result<Component>(component, state, math_output, math_id);
+        state, res_it, [&state, &solver_output](Component const& component, Idx2D const math_id) {
+            return output_result<Component>(component, state, solver_output, math_id);
         });
 }
-template <std::derived_from<Base> Component, class ComponentContainer, math_output_type MathOutputType,
+template <std::derived_from<Base> Component, class ComponentContainer, solver_output_type SolverOutputType,
           std::forward_iterator ResIt>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
              requires(Component const& component, MainModelState<ComponentContainer> const& state,
-                      std::vector<MathOutputType> const& math_output, Idx obj_seq) {
+                      std::vector<SolverOutputType> const& solver_output, Idx obj_seq) {
                  {
-                     output_result<Component>(component, state, math_output, obj_seq)
+                     output_result<Component>(component, state, solver_output, obj_seq)
                      } -> std::convertible_to<std::iter_value_t<ResIt>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
-                              std::vector<MathOutputType> const& math_output, ResIt res_it) {
+                              std::vector<SolverOutputType> const& solver_output, ResIt res_it) {
     return detail::produce_output<Component, Idx>(
-        state, res_it, [&state, &math_output](Component const& component, Idx const obj_seq) {
-            return output_result<Component, ComponentContainer>(component, state, math_output, obj_seq);
+        state, res_it, [&state, &solver_output](Component const& component, Idx const obj_seq) {
+            return output_result<Component, ComponentContainer>(component, state, solver_output, obj_seq);
         });
 }
-template <std::derived_from<Base> Component, class ComponentContainer, math_output_type MathOutputType,
+template <std::derived_from<Base> Component, class ComponentContainer, solver_output_type SolverOutputType,
           std::forward_iterator ResIt>
     requires model_component_state_c<MainModelState, ComponentContainer, Component> &&
-             requires(Component const& component, std::vector<MathOutputType> const& math_output,
+             requires(Component const& component, std::vector<SolverOutputType> const& solver_output,
                       Idx2DBranch3 const& math_id) {
                  {
-                     output_result<Component>(component, math_output, math_id)
+                     output_result<Component>(component, solver_output, math_id)
                      } -> std::convertible_to<std::iter_value_t<ResIt>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
-                              std::vector<MathOutputType> const& math_output, ResIt res_it) {
+                              std::vector<SolverOutputType> const& solver_output, ResIt res_it) {
     return detail::produce_output<Component, Idx2DBranch3>(
-        state, res_it, [&math_output](Component const& component, Idx2DBranch3 const& math_id) {
-            return output_result<Component>(component, math_output, math_id);
+        state, res_it, [&solver_output](Component const& component, Idx2DBranch3 const& math_id) {
+            return output_result<Component>(component, solver_output, math_id);
         });
 }
 
 // output source, load_gen, shunt individually
-template <std::same_as<Appliance> Component, class ComponentContainer, math_output_type MathOutputType,
+template <std::same_as<Appliance> Component, class ComponentContainer, solver_output_type SolverOutputType,
           std::forward_iterator ResIt>
     requires model_component_state_c<MainModelState, ComponentContainer, Component>
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
-                              std::vector<MathOutputType> const& math_output, ResIt res_it) {
-    res_it = output_result<Source>(state, math_output, res_it);
-    res_it = output_result<GenericLoadGen>(state, math_output, res_it);
-    res_it = output_result<Shunt>(state, math_output, res_it);
+                              std::vector<SolverOutputType> const& solver_output, ResIt res_it) {
+    res_it = output_result<Source>(state, solver_output, res_it);
+    res_it = output_result<GenericLoadGen>(state, solver_output, res_it);
+    res_it = output_result<Shunt>(state, solver_output, res_it);
     return res_it;
 }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_current_pf_solver.hpp
@@ -82,7 +82,8 @@ class IterativeCurrentPFSolver : public IterativePFSolver<sym, IterativeCurrentP
           sparse_solver_{y_bus.shared_indptr_lu(), y_bus.shared_indices_lu(), y_bus.shared_diag_lu()} {}
 
     // Add source admittance to Y bus and set variable for prepared y bus to true
-    void initialize_derived_solver(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, MathOutput<sym>& output) {
+    void initialize_derived_solver(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input,
+                                   SolverOutput<sym>& output) {
         make_flat_start(input, output.u);
 
         auto const& sources_per_bus = *this->sources_per_bus_;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -74,12 +74,12 @@ template <symmetry_tag sym> class IterativeLinearSESolver {
           sparse_solver_{y_bus.shared_indptr_lu(), y_bus.shared_indices_lu(), y_bus.shared_diag_lu()},
           perm_(y_bus.size()) {}
 
-    MathOutput<sym> run_state_estimation(YBus<sym> const& y_bus, StateEstimationInput<sym> const& input, double err_tol,
-                                         Idx max_iter, CalculationInfo& calculation_info) {
+    SolverOutput<sym> run_state_estimation(YBus<sym> const& y_bus, StateEstimationInput<sym> const& input,
+                                           double err_tol, Idx max_iter, CalculationInfo& calculation_info) {
         // prepare
         Timer main_timer;
         Timer sub_timer;
-        MathOutput<sym> output;
+        SolverOutput<sym> output;
         output.u.resize(n_bus_);
         output.bus_injection.resize(n_bus_);
         double max_dev = std::numeric_limits<double>::max();

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
@@ -24,13 +24,13 @@ namespace power_grid_model::math_solver {
 template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
   public:
     friend DerivedSolver;
-    MathOutput<sym> run_power_flow(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, double err_tol,
-                                   Idx max_iter, CalculationInfo& calculation_info) {
+    SolverOutput<sym> run_power_flow(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, double err_tol,
+                                     Idx max_iter, CalculationInfo& calculation_info) {
         // get derived reference for derived solver class
         auto derived_solver = static_cast<DerivedSolver&>(*this);
 
         // prepare
-        MathOutput<sym> output;
+        SolverOutput<sym> output;
         output.u.resize(n_bus_);
         double max_dev = std::numeric_limits<double>::infinity();
 
@@ -81,7 +81,7 @@ template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
         return output;
     }
 
-    void calculate_result(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, MathOutput<sym>& output) {
+    void calculate_result(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, SolverOutput<sym>& output) {
         detail::calculate_pf_result(y_bus, input, *sources_per_bus_, *load_gens_per_bus_, output,
                                     [this](Idx i) { return (*load_gen_type_)[i]; });
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/linear_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/linear_pf_solver.hpp
@@ -57,10 +57,10 @@ template <symmetry_tag sym> class LinearPFSolver {
           sparse_solver_{y_bus.shared_indptr_lu(), y_bus.shared_indices_lu(), y_bus.shared_diag_lu()},
           perm_(n_bus_) {}
 
-    MathOutput<sym> run_power_flow(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input,
-                                   CalculationInfo& calculation_info) {
+    SolverOutput<sym> run_power_flow(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input,
+                                     CalculationInfo& calculation_info) {
         // output
-        MathOutput<sym> output;
+        SolverOutput<sym> output;
         output.u.resize(n_bus_);
 
         Timer const main_timer(calculation_info, 2220, "Math solver");
@@ -94,11 +94,11 @@ template <symmetry_tag sym> class LinearPFSolver {
     SparseSolverType sparse_solver_;
     BlockPermArray perm_;
 
-    void prepare_matrix_and_rhs(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, MathOutput<sym>& output) {
+    void prepare_matrix_and_rhs(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, SolverOutput<sym>& output) {
         detail::prepare_linear_matrix_and_rhs(y_bus, input, *load_gens_per_bus_, *sources_per_bus_, output, mat_data_);
     }
 
-    void calculate_result(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, MathOutput<sym>& output) {
+    void calculate_result(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, SolverOutput<sym>& output) {
         detail::calculate_pf_result(y_bus, input, *sources_per_bus_, *load_gens_per_bus_, output,
                                     [](Idx /*i*/) { return LoadGenType::const_y; });
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
@@ -31,9 +31,9 @@ template <symmetry_tag sym> class MathSolver {
           all_const_y_{std::all_of(topo_ptr->load_gen_type.cbegin(), topo_ptr->load_gen_type.cend(),
                                    [](LoadGenType x) { return x == LoadGenType::const_y; })} {}
 
-    MathOutput<sym> run_power_flow(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
-                                   CalculationInfo& calculation_info, CalculationMethod calculation_method,
-                                   YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_power_flow(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
+                                     CalculationInfo& calculation_info, CalculationMethod calculation_method,
+                                     YBus<sym> const& y_bus) {
         using enum CalculationMethod;
 
         // set method to always linear if all load_gens have const_y
@@ -55,9 +55,9 @@ template <symmetry_tag sym> class MathSolver {
         }
     }
 
-    MathOutput<sym> run_state_estimation(StateEstimationInput<sym> const& input, double err_tol, Idx max_iter,
-                                         CalculationInfo& calculation_info, CalculationMethod calculation_method,
-                                         YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_state_estimation(StateEstimationInput<sym> const& input, double err_tol, Idx max_iter,
+                                           CalculationInfo& calculation_info, CalculationMethod calculation_method,
+                                           YBus<sym> const& y_bus) {
         using enum CalculationMethod;
 
         switch (calculation_method) {
@@ -72,8 +72,8 @@ template <symmetry_tag sym> class MathSolver {
         }
     }
 
-    ShortCircuitMathOutput<sym> run_short_circuit(ShortCircuitInput const& input, CalculationInfo& calculation_info,
-                                                  CalculationMethod calculation_method, YBus<sym> const& y_bus) {
+    ShortCircuitSolverOutput<sym> run_short_circuit(ShortCircuitInput const& input, CalculationInfo& calculation_info,
+                                                    CalculationMethod calculation_method, YBus<sym> const& y_bus) {
         if (calculation_method != CalculationMethod::default_method &&
             calculation_method != CalculationMethod::iec60909) {
             throw InvalidCalculationMethod{};
@@ -112,8 +112,8 @@ template <symmetry_tag sym> class MathSolver {
     std::optional<NewtonRaphsonSESolver<sym>> newton_raphson_se_solver_;
     std::optional<ShortCircuitSolver<sym>> iec60909_sc_solver_;
 
-    MathOutput<sym> run_power_flow_newton_raphson(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
-                                                  CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_power_flow_newton_raphson(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
+                                                    CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!newton_raphson_pf_solver_.has_value()) {
             Timer const timer(calculation_info, 2210, "Create math solver");
             newton_raphson_pf_solver_.emplace(y_bus, topo_ptr_);
@@ -121,8 +121,8 @@ template <symmetry_tag sym> class MathSolver {
         return newton_raphson_pf_solver_.value().run_power_flow(y_bus, input, err_tol, max_iter, calculation_info);
     }
 
-    MathOutput<sym> run_power_flow_linear(PowerFlowInput<sym> const& input, double /* err_tol */, Idx /* max_iter */,
-                                          CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_power_flow_linear(PowerFlowInput<sym> const& input, double /* err_tol */, Idx /* max_iter */,
+                                            CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!linear_pf_solver_.has_value()) {
             Timer const timer(calculation_info, 2210, "Create math solver");
             linear_pf_solver_.emplace(y_bus, topo_ptr_);
@@ -130,8 +130,8 @@ template <symmetry_tag sym> class MathSolver {
         return linear_pf_solver_.value().run_power_flow(y_bus, input, calculation_info);
     }
 
-    MathOutput<sym> run_power_flow_iterative_current(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
-                                                     CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_power_flow_iterative_current(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
+                                                       CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!iterative_current_pf_solver_.has_value()) {
             Timer const timer(calculation_info, 2210, "Create math solver");
             iterative_current_pf_solver_.emplace(y_bus, topo_ptr_);
@@ -139,16 +139,16 @@ template <symmetry_tag sym> class MathSolver {
         return iterative_current_pf_solver_.value().run_power_flow(y_bus, input, err_tol, max_iter, calculation_info);
     }
 
-    MathOutput<sym> run_power_flow_linear_current(PowerFlowInput<sym> const& input, double /* err_tol */,
-                                                  Idx /* max_iter */, CalculationInfo& calculation_info,
-                                                  YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_power_flow_linear_current(PowerFlowInput<sym> const& input, double /* err_tol */,
+                                                    Idx /* max_iter */, CalculationInfo& calculation_info,
+                                                    YBus<sym> const& y_bus) {
         return run_power_flow_iterative_current(input, std::numeric_limits<double>::infinity(), 1, calculation_info,
                                                 y_bus);
     }
 
-    MathOutput<sym> run_state_estimation_iterative_linear(StateEstimationInput<sym> const& input, double err_tol,
-                                                          Idx max_iter, CalculationInfo& calculation_info,
-                                                          YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_state_estimation_iterative_linear(StateEstimationInput<sym> const& input, double err_tol,
+                                                            Idx max_iter, CalculationInfo& calculation_info,
+                                                            YBus<sym> const& y_bus) {
         // construct model if needed
         if (!iterative_linear_se_solver_.has_value()) {
             Timer const timer(calculation_info, 2210, "Create math solver");
@@ -160,9 +160,9 @@ template <symmetry_tag sym> class MathSolver {
                                                                         calculation_info);
     }
 
-    MathOutput<sym> run_state_estimation_newton_raphson(StateEstimationInput<sym> const& input, double err_tol,
-                                                        Idx max_iter, CalculationInfo& calculation_info,
-                                                        YBus<sym> const& y_bus) {
+    SolverOutput<sym> run_state_estimation_newton_raphson(StateEstimationInput<sym> const& input, double err_tol,
+                                                          Idx max_iter, CalculationInfo& calculation_info,
+                                                          YBus<sym> const& y_bus) {
         // construct model if needed
         if (!newton_raphson_se_solver_.has_value()) {
             Timer const timer(calculation_info, 2210, "Create math solver");

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
@@ -105,13 +105,13 @@ template <symmetry_tag sym> class MeasuredValues {
 
     // calculate load_gen and source flow
     // with given bus voltage and bus current injection
-    using FlowVector = std::vector<ApplianceMathOutput<sym>>;
+    using FlowVector = std::vector<ApplianceSolverOutput<sym>>;
     using LoadGenSourceFlow = std::pair<FlowVector, FlowVector>;
 
     LoadGenSourceFlow calculate_load_gen_source(ComplexValueVector<sym> const& u,
                                                 ComplexValueVector<sym> const& s) const {
-        std::vector<ApplianceMathOutput<sym>> load_gen_flow(math_topology_->n_load_gen());
-        std::vector<ApplianceMathOutput<sym>> source_flow(math_topology_->n_source());
+        std::vector<ApplianceSolverOutput<sym>> load_gen_flow(math_topology_->n_load_gen());
+        std::vector<ApplianceSolverOutput<sym>> source_flow(math_topology_->n_source());
 
         // loop all buses
         for (auto const& [bus, load_gens, sources] :

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_pf_solver.hpp
@@ -215,7 +215,8 @@ template <symmetry_tag sym> class NewtonRaphsonPFSolver : public IterativePFSolv
           perm_(y_bus.size()) {}
 
     // Initilize the unknown variable in polar form
-    void initialize_derived_solver(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input, MathOutput<sym>& output) {
+    void initialize_derived_solver(YBus<sym> const& y_bus, PowerFlowInput<sym> const& input,
+                                   SolverOutput<sym>& output) {
         using LinearSparseSolverType = SparseLUSolver<ComplexTensor<sym>, ComplexValue<sym>, ComplexValue<sym>>;
 
         ComplexTensorVector<sym> linear_mat_data(y_bus.nnz_lu());

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -138,12 +138,12 @@ template <symmetry_tag sym> class NewtonRaphsonSESolver {
           sparse_solver_{y_bus.shared_indptr_lu(), y_bus.shared_indices_lu(), y_bus.shared_diag_lu()},
           perm_(y_bus.size()) {}
 
-    MathOutput<sym> run_state_estimation(YBus<sym> const& y_bus, StateEstimationInput<sym> const& input, double err_tol,
-                                         Idx max_iter, CalculationInfo& calculation_info) {
+    SolverOutput<sym> run_state_estimation(YBus<sym> const& y_bus, StateEstimationInput<sym> const& input,
+                                           double err_tol, Idx max_iter, CalculationInfo& calculation_info) {
         // prepare
         Timer main_timer;
         Timer sub_timer;
-        MathOutput<sym> output;
+        SolverOutput<sym> output;
         output.u.resize(n_bus_);
         output.bus_injection.resize(n_bus_);
         double max_dev = std::numeric_limits<double>::max();

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/short_circuit_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/short_circuit_solver.hpp
@@ -31,7 +31,7 @@ template <symmetry_tag sym> class ShortCircuitSolver {
           sparse_solver_{y_bus.shared_indptr_lu(), y_bus.shared_indices_lu(), y_bus.shared_diag_lu()},
           perm_{static_cast<BlockPermArray>(n_bus_)} {}
 
-    ShortCircuitMathOutput<sym> run_short_circuit(YBus<sym> const& y_bus, ShortCircuitInput const& input) {
+    ShortCircuitSolverOutput<sym> run_short_circuit(YBus<sym> const& y_bus, ShortCircuitInput const& input) {
         check_input_valid(input);
 
         auto const [fault_type, fault_phase] = extract_fault_type_phase(input.faults);
@@ -40,7 +40,7 @@ template <symmetry_tag sym> class ShortCircuitSolver {
         auto const [phase_1, phase_2] = set_phase_index(fault_phase);
 
         // output
-        ShortCircuitMathOutput<sym> output;
+        ShortCircuitSolverOutput<sym> output;
         output.u_bus.resize(n_bus_);
         output.fault.resize(input.faults.size());
         output.source.resize(n_source_);
@@ -73,7 +73,7 @@ template <symmetry_tag sym> class ShortCircuitSolver {
     BlockPermArray perm_;
 
     void prepare_matrix_and_rhs(YBus<sym> const& y_bus, ShortCircuitInput const& input,
-                                ShortCircuitMathOutput<sym>& output, IdxVector& infinite_admittance_fault_counter,
+                                ShortCircuitSolverOutput<sym>& output, IdxVector& infinite_admittance_fault_counter,
                                 FaultType const& fault_type, IntS phase_1, IntS phase_2) {
         IdxVector const& bus_entry = y_bus.lu_diag();
 
@@ -221,7 +221,7 @@ template <symmetry_tag sym> class ShortCircuitSolver {
         }
     }
 
-    void calculate_result(YBus<sym> const& y_bus, ShortCircuitInput const& input, ShortCircuitMathOutput<sym>& output,
+    void calculate_result(YBus<sym> const& y_bus, ShortCircuitInput const& input, ShortCircuitSolverOutput<sym>& output,
                           IdxVector const& infinite_admittance_fault_counter, FaultType const fault_type,
                           int const phase_1, int const phase_2) const {
         using enum FaultType;
@@ -354,8 +354,8 @@ template <symmetry_tag sym> class ShortCircuitSolver {
             }
         }
 
-        output.branch = y_bus.template calculate_branch_flow<BranchShortCircuitMathOutput<sym>>(output.u_bus);
-        output.shunt = y_bus.template calculate_shunt_flow<ApplianceShortCircuitMathOutput<sym>>(output.u_bus);
+        output.branch = y_bus.template calculate_branch_flow<BranchShortCircuitSolverOutput<sym>>(output.u_bus);
+        output.shunt = y_bus.template calculate_shunt_flow<ApplianceShortCircuitSolverOutput<sym>>(output.u_bus);
     }
 
     static constexpr auto set_phase_index(FaultPhase fault_phase) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -443,7 +443,7 @@ template <symmetry_tag sym> class YBus {
 
     // calculate branch flow based on voltage
     template <typename T>
-        requires std::same_as<T, BranchMathOutput<sym>> || std::same_as<T, BranchShortCircuitMathOutput<sym>>
+        requires std::same_as<T, BranchSolverOutput<sym>> || std::same_as<T, BranchShortCircuitSolverOutput<sym>>
     std::vector<T> calculate_branch_flow(ComplexValueVector<sym> const& u) const {
         std::vector<T> branch_flow(math_topology_->branch_bus_idx.size());
         std::transform(math_topology_->branch_bus_idx.cbegin(), math_topology_->branch_bus_idx.cend(),
@@ -459,7 +459,7 @@ template <symmetry_tag sym> class YBus {
                            output.i_f = dot(param.yff(), uf) + dot(param.yft(), ut);
                            output.i_t = dot(param.ytf(), uf) + dot(param.ytt(), ut);
 
-                           if constexpr (std::same_as<T, BranchMathOutput<sym>>) {
+                           if constexpr (std::same_as<T, BranchSolverOutput<sym>>) {
                                // See "Shunt Injection Flow Calculation" in "State Estimation Alliander"
                                output.s_f = uf * conj(output.i_f);
                                output.s_t = ut * conj(output.i_t);
@@ -471,18 +471,18 @@ template <symmetry_tag sym> class YBus {
     }
 
     // calculate shunt flow based on voltage, injection direction
-    template <typename MathOutputType>
-        requires std::same_as<MathOutputType, ApplianceMathOutput<sym>> ||
-                 std::same_as<MathOutputType, ApplianceShortCircuitMathOutput<sym>>
-    std::vector<MathOutputType> calculate_shunt_flow(ComplexValueVector<sym> const& u) const {
-        std::vector<MathOutputType> shunt_flow(math_topology_->n_shunt());
+    template <typename SolverOutputType>
+        requires std::same_as<SolverOutputType, ApplianceSolverOutput<sym>> ||
+                 std::same_as<SolverOutputType, ApplianceShortCircuitSolverOutput<sym>>
+    std::vector<SolverOutputType> calculate_shunt_flow(ComplexValueVector<sym> const& u) const {
+        std::vector<SolverOutputType> shunt_flow(math_topology_->n_shunt());
         for (auto const [bus, shunts] : enumerated_zip_sequence(math_topology_->shunts_per_bus)) {
             for (Idx const shunt : shunts) {
                 // See "Branch/Shunt Power Flow" in "State Estimation Alliander"
                 // NOTE: the negative sign for injection direction!
                 shunt_flow[shunt].i = -dot(math_model_param_->shunt_param[shunt], u[bus]);
 
-                if constexpr (std::same_as<MathOutputType, ApplianceMathOutput<sym>>) {
+                if constexpr (std::same_as<SolverOutputType, ApplianceSolverOutput<sym>>) {
                     // See "Branch/Shunt Power Flow" in "State Estimation Alliander"
                     shunt_flow[shunt].s = u[bus] * conj(shunt_flow[shunt].i);
                 }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/base_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/base_optimizer.hpp
@@ -29,7 +29,7 @@ using state_calculator_result_t = typename state_calculator_type<StateCalculator
 
 template <typename StateCalculator, typename State>
 concept steady_state_calculator_c =
-    steady_state_math_output_type<typename detail::state_calculator_result_t<StateCalculator, State>::value_type> &&
+    steady_state_solver_output_type<typename detail::state_calculator_result_t<StateCalculator, State>::value_type> &&
     std::same_as<detail::state_calculator_result_t<StateCalculator, State>,
                  std::vector<typename detail::state_calculator_result_t<StateCalculator, State>::value_type>>;
 

--- a/tests/cpp_integration_tests/test_main_model.cpp
+++ b/tests/cpp_integration_tests/test_main_model.cpp
@@ -238,10 +238,10 @@ TEST_CASE("Test main model - power flow") {
     }
 
     SUBCASE("Test calculate power flow") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
     }
 }
 
@@ -251,10 +251,10 @@ TEST_CASE("Test copy main model") {
     MainModel model_2{main_model};
 
     SUBCASE("Copied - Symmetrical") {
-        auto const math_output = model_2.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        model_2.output_result<Node>(math_output, state.sym_node.begin());
-        model_2.output_result<Branch>(math_output, state.sym_branch.begin());
-        model_2.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = model_2.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        model_2.output_result<Node>(solver_output, state.sym_node.begin());
+        model_2.output_result<Branch>(solver_output, state.sym_branch.begin());
+        model_2.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -266,10 +266,10 @@ TEST_CASE("Test copy main model") {
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Copied - Asymmetrical") {
-        auto const math_output = model_2.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        model_2.output_result<Node>(math_output, state.asym_node.begin());
-        model_2.output_result<Branch>(math_output, state.asym_branch.begin());
-        model_2.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = model_2.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        model_2.output_result<Node>(solver_output, state.asym_node.begin());
+        model_2.output_result<Branch>(solver_output, state.asym_branch.begin());
+        model_2.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -282,10 +282,10 @@ TEST_CASE("Test copy main model") {
     }
     model_2 = main_model;
     SUBCASE("Assigned - Symmetrical") {
-        auto const math_output = model_2.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        model_2.output_result<Node>(math_output, state.sym_node.begin());
-        model_2.output_result<Branch>(math_output, state.sym_branch.begin());
-        model_2.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = model_2.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        model_2.output_result<Node>(solver_output, state.sym_node.begin());
+        model_2.output_result<Branch>(solver_output, state.sym_branch.begin());
+        model_2.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         // TODO: check voltage angle
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
@@ -298,10 +298,10 @@ TEST_CASE("Test copy main model") {
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Assigned - Asymmetrical") {
-        auto const math_output = model_2.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        model_2.output_result<Node>(math_output, state.asym_node.begin());
-        model_2.output_result<Branch>(math_output, state.asym_branch.begin());
-        model_2.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = model_2.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        model_2.output_result<Node>(solver_output, state.asym_node.begin());
+        model_2.output_result<Branch>(solver_output, state.asym_branch.begin());
+        model_2.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -313,10 +313,10 @@ TEST_CASE("Test copy main model") {
         CHECK(state.asym_appliance[4].i(2) == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Original - Symmetrical") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -328,10 +328,10 @@ TEST_CASE("Test copy main model") {
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Original - Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -349,11 +349,11 @@ TEST_CASE("Test main model - iterative calculation") {
     auto main_model = default_model(state);
 
     SUBCASE("Symmetrical") {
-        auto const math_output =
+        auto const solver_output =
             main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::newton_raphson);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -365,11 +365,11 @@ TEST_CASE("Test main model - iterative calculation") {
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output =
+        auto const solver_output =
             main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::newton_raphson);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -735,10 +735,10 @@ TEST_CASE("Test main model - linear calculation") {
     auto main_model = default_model(state);
 
     SUBCASE("Symmetrical") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -750,10 +750,10 @@ TEST_CASE("Test main model - linear calculation") {
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -787,10 +787,10 @@ TEST_CASE_TEMPLATE("Test main model - update only load", settings, regular_updat
     main_model.update_component<typename settings::update_type>(update_data);
 
     SUBCASE("Symmetrical") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -802,10 +802,10 @@ TEST_CASE_TEMPLATE("Test main model - update only load", settings, regular_updat
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -831,10 +831,10 @@ TEST_CASE_TEMPLATE("Test main model - update load and shunt param", settings, re
     main_model.update_component<typename settings::update_type>(update_data);
 
     SUBCASE("Symmetrical") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -846,10 +846,10 @@ TEST_CASE_TEMPLATE("Test main model - update load and shunt param", settings, re
         CHECK(state.sym_appliance[4].i == doctest::Approx(0.0));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -879,10 +879,10 @@ TEST_CASE_TEMPLATE("Test main model - all updates", settings, regular_update, ca
     main_model.update_component<typename settings::update_type>(update_data);
 
     SUBCASE("Symmetrical") {
-        auto const math_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.sym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.sym_appliance.begin());
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[2].u_pu == doctest::Approx(test::u1));
@@ -894,10 +894,10 @@ TEST_CASE_TEMPLATE("Test main model - all updates", settings, regular_update, ca
         CHECK(state.sym_appliance[4].i == doctest::Approx(0.0));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(1.05));
         CHECK(state.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -914,7 +914,7 @@ TEST_CASE_TEMPLATE("Test main model - restore components", settings, regular_upd
     State state;
     auto main_model = default_model(state);
 
-    auto const math_output_orig = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+    auto const solver_output_orig = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
 
     ConstDataset const update_data{
         {"sym_load", ConstDataPointer{state.sym_load_update.data(), static_cast<Idx>(state.sym_load_update.size())}},
@@ -925,11 +925,11 @@ TEST_CASE_TEMPLATE("Test main model - restore components", settings, regular_upd
     main_model.restore_components(main_model.get_sequence_idx_map(update_data));
 
     SUBCASE("Symmetrical") {
-        auto const math_output_result =
+        auto const solver_output_result =
             main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output_result, state.sym_node.begin());
-        main_model.output_result<Branch>(math_output_result, state.sym_branch.begin());
-        main_model.output_result<Appliance>(math_output_result, state.sym_appliance.begin());
+        main_model.output_result<Node>(solver_output_result, state.sym_node.begin());
+        main_model.output_result<Branch>(solver_output_result, state.sym_branch.begin());
+        main_model.output_result<Appliance>(solver_output_result, state.sym_appliance.begin());
 
         CHECK(state.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state.sym_node[1].u_pu == doctest::Approx(test::u1));
@@ -947,10 +947,10 @@ TEST_CASE_TEMPLATE("Test main model - restore components", settings, regular_upd
         CHECK(state.sym_appliance[4].i == doctest::Approx(test::i_shunt));
     }
     SUBCASE("Asymmetrical") {
-        auto const math_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-        main_model.output_result<Node>(math_output, state.asym_node.begin());
-        main_model.output_result<Branch>(math_output, state.asym_branch.begin());
-        main_model.output_result<Appliance>(math_output, state.asym_appliance.begin());
+        auto const solver_output = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+        main_model.output_result<Node>(solver_output, state.asym_node.begin());
+        main_model.output_result<Branch>(solver_output, state.asym_branch.begin());
+        main_model.output_result<Appliance>(solver_output, state.asym_appliance.begin());
 
         CHECK(state.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
@@ -970,11 +970,12 @@ TEST_CASE_TEMPLATE("Test main model - restore components", settings, regular_upd
 }
 
 TEST_CASE_TEMPLATE("Test main model - updates w/ alternating compute mode", settings, regular_update, cached_update) {
-    constexpr auto check_sym = [](MainModel const& model_, std::vector<MathOutput<symmetric_t>> const& math_output_) {
+    constexpr auto check_sym = [](MainModel const& model_,
+                                  std::vector<SolverOutput<symmetric_t>> const& solver_output_) {
         State state_;
-        model_.output_result<Node>(math_output_, state_.sym_node.begin());
-        model_.output_result<Branch>(math_output_, state_.sym_branch.begin());
-        model_.output_result<Appliance>(math_output_, state_.sym_appliance.begin());
+        model_.output_result<Node>(solver_output_, state_.sym_node.begin());
+        model_.output_result<Branch>(solver_output_, state_.sym_branch.begin());
+        model_.output_result<Appliance>(solver_output_, state_.sym_appliance.begin());
 
         CHECK(state_.sym_node[0].u_pu == doctest::Approx(1.05));
         CHECK(state_.sym_node[1].u_pu == doctest::Approx(test::u1));
@@ -986,11 +987,12 @@ TEST_CASE_TEMPLATE("Test main model - updates w/ alternating compute mode", sett
         CHECK(state_.sym_appliance[3].i == doctest::Approx(0.0));
         CHECK(state_.sym_appliance[4].i == doctest::Approx(0.0));
     };
-    constexpr auto check_asym = [](MainModel const& model_, std::vector<MathOutput<asymmetric_t>> const& math_output_) {
+    constexpr auto check_asym = [](MainModel const& model_,
+                                   std::vector<SolverOutput<asymmetric_t>> const& solver_output_) {
         State state_;
-        model_.output_result<Node>(math_output_, state_.asym_node.begin());
-        model_.output_result<Branch>(math_output_, state_.asym_branch.begin());
-        model_.output_result<Appliance>(math_output_, state_.asym_appliance.begin());
+        model_.output_result<Node>(solver_output_, state_.asym_node.begin());
+        model_.output_result<Branch>(solver_output_, state_.asym_branch.begin());
+        model_.output_result<Appliance>(solver_output_, state_.asym_appliance.begin());
         CHECK(state_.asym_node[0].u_pu(0) == doctest::Approx(1.05));
         CHECK(state_.asym_node[1].u_pu(1) == doctest::Approx(test::u1));
         CHECK(state_.asym_node[2].u_pu(2) == doctest::Approx(test::u1));
@@ -1015,11 +1017,12 @@ TEST_CASE_TEMPLATE("Test main model - updates w/ alternating compute mode", sett
     // This will lead to no topo change but param change
     main_model.update_component<typename settings::update_type>(update_data);
 
-    auto const math_output_sym_1 = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-    check_sym(main_model, math_output_sym_1);
+    auto const solver_output_sym_1 = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+    check_sym(main_model, solver_output_sym_1);
 
-    auto const math_output_asym_1 = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-    check_asym(main_model, math_output_asym_1);
+    auto const solver_output_asym_1 =
+        main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+    check_asym(main_model, solver_output_asym_1);
 
     SUBCASE("No new update") {
         // Math state may be fully cached
@@ -1036,11 +1039,12 @@ TEST_CASE_TEMPLATE("Test main model - updates w/ alternating compute mode", sett
         main_model.update_component<typename settings::update_type>(update_data);
     }
 
-    auto const math_output_asym_2 = main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
-    check_asym(main_model, math_output_asym_2);
+    auto const solver_output_asym_2 =
+        main_model.calculate_power_flow<asymmetric_t>(1e-8, 20, CalculationMethod::linear);
+    check_asym(main_model, solver_output_asym_2);
 
-    auto const math_output_sym_2 = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
-    check_sym(main_model, math_output_sym_2);
+    auto const solver_output_sym_2 = main_model.calculate_power_flow<symmetric_t>(1e-8, 20, CalculationMethod::linear);
+    check_sym(main_model, solver_output_sym_2);
 
     main_model.restore_components(main_model.get_sequence_idx_map(update_data));
 }

--- a/tests/cpp_integration_tests/test_main_model_sc.cpp
+++ b/tests/cpp_integration_tests/test_main_model_sc.cpp
@@ -40,29 +40,29 @@ TEST_CASE("Test main model - short circuit") {
             double const u_node_abs_pu = u_node_abs / (u_rated / sqrt3);
 
             SUBCASE("Symmetric Calculation") {
-                std::vector<ShortCircuitMathOutput<symmetric_t>> const math_output =
+                std::vector<ShortCircuitSolverOutput<symmetric_t>> const solver_output =
                     main_model.calculate_short_circuit<symmetric_t>(voltage_scaling, CalculationMethod::iec60909);
 
                 std::vector<FaultShortCircuitOutput> fault_output(1);
-                main_model.output_result<Fault>(math_output, fault_output.begin());
+                main_model.output_result<Fault>(solver_output, fault_output.begin());
 
                 CHECK(fault_output[0].i_f(0) == doctest::Approx(i_f_abs));
 
                 std::vector<NodeShortCircuitOutput> node_output(1);
-                main_model.output_result<Node>(math_output, node_output.begin());
+                main_model.output_result<Node>(solver_output, node_output.begin());
                 CHECK(node_output[0].u_pu(0) == doctest::Approx(u_node_abs_pu));
             }
 
             SUBCASE("Asymmetric Calculation") {
-                std::vector<ShortCircuitMathOutput<asymmetric_t>> const math_output =
+                std::vector<ShortCircuitSolverOutput<asymmetric_t>> const solver_output =
                     main_model.calculate_short_circuit<asymmetric_t>(voltage_scaling, CalculationMethod::iec60909);
 
                 std::vector<FaultShortCircuitOutput> fault_output(1);
-                main_model.output_result<Fault>(math_output, fault_output.begin());
+                main_model.output_result<Fault>(solver_output, fault_output.begin());
                 CHECK(fault_output[0].i_f(0) == doctest::Approx(i_f_abs));
 
                 std::vector<NodeShortCircuitOutput> node_output(1);
-                main_model.output_result<Node>(math_output, node_output.begin());
+                main_model.output_result<Node>(solver_output, node_output.begin());
                 CHECK(node_output[0].u_pu(0) == doctest::Approx(u_node_abs_pu));
             }
         }
@@ -80,29 +80,29 @@ TEST_CASE("Test main model - short circuit") {
             double const u_node_abs_pu = u_node_abs / (u_rated / sqrt3);
 
             SUBCASE("Symmetric Calculation") {
-                std::vector<ShortCircuitMathOutput<symmetric_t>> const math_output =
+                std::vector<ShortCircuitSolverOutput<symmetric_t>> const solver_output =
                     main_model.calculate_short_circuit<symmetric_t>(voltage_scaling, CalculationMethod::iec60909);
 
                 std::vector<FaultShortCircuitOutput> fault_output(1);
-                main_model.output_result<Fault>(math_output, fault_output.begin());
+                main_model.output_result<Fault>(solver_output, fault_output.begin());
 
                 CHECK(fault_output[0].i_f(0) == doctest::Approx(i_f_abs));
 
                 std::vector<NodeShortCircuitOutput> node_output(1);
-                main_model.output_result<Node>(math_output, node_output.begin());
+                main_model.output_result<Node>(solver_output, node_output.begin());
                 CHECK(node_output[0].u_pu(0) == doctest::Approx(u_node_abs_pu));
             }
 
             SUBCASE("Asymmetric Calculation") {
-                std::vector<ShortCircuitMathOutput<asymmetric_t>> const math_output =
+                std::vector<ShortCircuitSolverOutput<asymmetric_t>> const solver_output =
                     main_model.calculate_short_circuit<asymmetric_t>(voltage_scaling, CalculationMethod::iec60909);
 
                 std::vector<FaultShortCircuitOutput> fault_output(1);
-                main_model.output_result<Fault>(math_output, fault_output.begin());
+                main_model.output_result<Fault>(solver_output, fault_output.begin());
                 CHECK(fault_output[0].i_f(0) == doctest::Approx(i_f_abs));
 
                 std::vector<NodeShortCircuitOutput> node_output(1);
-                main_model.output_result<Node>(math_output, node_output.begin());
+                main_model.output_result<Node>(solver_output, node_output.begin());
                 CHECK(node_output[0].u_pu(0) == doctest::Approx(u_node_abs_pu));
             }
         }
@@ -121,15 +121,15 @@ TEST_CASE("Test main model - short circuit") {
                 {{5, 2, FaultType::single_phase_to_ground, FaultPhase::default_value, 1, nan, nan}});
             main_model.set_construction_complete();
 
-            std::vector<ShortCircuitMathOutput<asymmetric_t>> const math_output =
+            std::vector<ShortCircuitSolverOutput<asymmetric_t>> const solver_output =
                 main_model.calculate_short_circuit<asymmetric_t>(voltage_scaling, CalculationMethod::iec60909);
 
             std::vector<FaultShortCircuitOutput> fault_output(1);
-            main_model.output_result<Fault>(math_output, fault_output.begin());
+            main_model.output_result<Fault>(solver_output, fault_output.begin());
             CHECK(fault_output[0].i_f(0) == doctest::Approx(voltage_scaling_c * 10e4 / sqrt3));
 
             std::vector<NodeShortCircuitOutput> node_output(2);
-            main_model.output_result<Node>(math_output, node_output.begin());
+            main_model.output_result<Node>(solver_output, node_output.begin());
             CHECK(node_output[0].u_pu(0) != doctest::Approx(voltage_scaling_c)); // influenced by fault
             CHECK(node_output[1].u_pu(0) == doctest::Approx(0.0));               // fault location
 

--- a/tests/cpp_integration_tests/test_main_model_se.cpp
+++ b/tests/cpp_integration_tests/test_main_model_se.cpp
@@ -33,18 +33,18 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                 main_model.add_component<SymVoltageSensor>({{3, 1, 1e2, 12.345e3, 0.1}});
                 main_model.set_construction_complete();
                 SUBCASE("Symmetric Calculation") {
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<symmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u == doctest::Approx(12.345e3));
                     CHECK(node_output[0].u_angle == doctest::Approx(0.1));
                 }
                 SUBCASE("Asymmetric Calculation") {
-                    std::vector<MathOutput<asymmetric_t>> const math_output =
+                    std::vector<SolverOutput<asymmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<asymmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<asymmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u.x() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.y() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.z() == doctest::Approx(12.345e3 / s3));
@@ -57,18 +57,18 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                 main_model.add_component<SymVoltageSensor>({{3, 1, 1e2, 12.345e3, nan}});
                 main_model.set_construction_complete();
                 SUBCASE("Symmetric Calculation") {
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<symmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u == doctest::Approx(12.345e3));
                     CHECK(node_output[0].u_angle == doctest::Approx(0.0));
                 }
                 SUBCASE("Asymmetric Calculation") {
-                    std::vector<MathOutput<asymmetric_t>> const math_output =
+                    std::vector<SolverOutput<asymmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<asymmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<asymmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u.x() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.y() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.z() == doctest::Approx(12.345e3 / s3));
@@ -82,10 +82,10 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                     {{3, 1, 1e2, {12.345e3 / s3, 12.345e3 / s3, 12.345e3 / s3}, {0.1, 0.2 - ph, 0.3 + ph}}});
                 main_model.set_construction_complete();
                 SUBCASE("Symmetric Calculation") {
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<symmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     double const u = (std::cos(0.1) + std::cos(0.2) + std::cos(0.3)) * 12.345e3;
                     double const v = (std::sin(0.1) + std::sin(0.2) + std::sin(0.3)) * 12.345e3;
                     double const expected_u = std::sqrt(u * u + v * v) / 3.0;
@@ -93,10 +93,10 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                     CHECK(node_output[0].u_angle == doctest::Approx(0.2));
                 }
                 SUBCASE("Asymmetric Calculation") {
-                    std::vector<MathOutput<asymmetric_t>> const math_output =
+                    std::vector<SolverOutput<asymmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<asymmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<asymmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u.x() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.y() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.z() == doctest::Approx(12.345e3 / s3));
@@ -110,18 +110,18 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                     {{3, 1, 1e2, {12.345e3 / s3, 12.345e3 / s3, 12.345e3 / s3}, {nan, nan, nan}}});
                 main_model.set_construction_complete();
                 SUBCASE("Symmetric Calculation") {
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<symmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u == doctest::Approx(12.345e3));
                     CHECK(node_output[0].u_angle == doctest::Approx(0.0));
                 }
                 SUBCASE("Asymmetric Calculation") {
-                    std::vector<MathOutput<asymmetric_t>> const math_output =
+                    std::vector<SolverOutput<asymmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<asymmetric_t>(1e-8, 20, calculation_method);
                     std::vector<NodeOutput<asymmetric_t>> node_output(1);
-                    main_model.output_result<Node>(math_output, node_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
                     CHECK(node_output[0].u.x() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.y() == doctest::Approx(12.345e3 / s3));
                     CHECK(node_output[0].u.z() == doctest::Approx(12.345e3 / s3));
@@ -146,17 +146,17 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                      {16, 6, MeasuredTerminalType::load, 1e2, 1800.0, 180.0, nan, nan}});
                 SUBCASE("Without Injection Sensor") {
                     main_model.set_construction_complete();
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
 
                     std::vector<SymApplianceOutput> gen_output(1);
                     std::vector<SymApplianceOutput> load_output(1);
                     std::vector<SymNodeOutput> node_output(2);
                     std::vector<SymPowerSensorOutput> power_sensor_output(2);
-                    main_model.output_result<AsymGenerator>(math_output, gen_output.begin());
-                    main_model.output_result<AsymLoad>(math_output, load_output.begin());
-                    main_model.output_result<Node>(math_output, node_output.begin());
-                    main_model.output_result<SymPowerSensor>(math_output, power_sensor_output.begin());
+                    main_model.output_result<AsymGenerator>(solver_output, gen_output.begin());
+                    main_model.output_result<AsymLoad>(solver_output, load_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
+                    main_model.output_result<SymPowerSensor>(solver_output, power_sensor_output.begin());
 
                     CHECK(gen_output[0].p == doctest::Approx(900.0).scale(1e3));
                     CHECK(gen_output[0].q == doctest::Approx(90.0).scale(1e3));
@@ -179,17 +179,17 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                         {{12, 2, MeasuredTerminalType::node, 2e2, -1200.0, -120.0, nan, nan}});
                     main_model.set_construction_complete();
 
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
 
                     std::vector<SymApplianceOutput> gen_output(1);
                     std::vector<SymApplianceOutput> load_output(1);
                     std::vector<SymNodeOutput> node_output(2);
                     std::vector<SymPowerSensorOutput> power_sensor_output(3);
-                    main_model.output_result<AsymGenerator>(math_output, gen_output.begin());
-                    main_model.output_result<AsymLoad>(math_output, load_output.begin());
-                    main_model.output_result<Node>(math_output, node_output.begin());
-                    main_model.output_result<SymPowerSensor>(math_output, power_sensor_output.begin());
+                    main_model.output_result<AsymGenerator>(solver_output, gen_output.begin());
+                    main_model.output_result<AsymLoad>(solver_output, load_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
+                    main_model.output_result<SymPowerSensor>(solver_output, power_sensor_output.begin());
 
                     CHECK(gen_output[0].p == doctest::Approx(850.0).scale(1e3));
                     CHECK(gen_output[0].q == doctest::Approx(85.0).scale(1e3));
@@ -224,17 +224,17 @@ TEST_CASE_TEMPLATE("Test main model - state estimation", CalculationMethod, Iter
                      {16, 6, MeasuredTerminalType::shunt, 1e2, 1800.0, 180.0, nan, nan}});
                 SUBCASE("Line flow") {
                     main_model.set_construction_complete();
-                    std::vector<MathOutput<symmetric_t>> const math_output =
+                    std::vector<SolverOutput<symmetric_t>> const solver_output =
                         main_model.calculate_state_estimation<symmetric_t>(1e-8, 20, calculation_method);
 
                     std::vector<SymApplianceOutput> shunt_output(1);
                     std::vector<SymNodeOutput> node_output(2);
                     std::vector<SymPowerSensorOutput> power_sensor_output(3);
                     std::vector<BranchOutput<symmetric_t>> line_output(1);
-                    main_model.output_result<Shunt>(math_output, shunt_output.begin());
-                    main_model.output_result<Node>(math_output, node_output.begin());
-                    main_model.output_result<Line>(math_output, line_output.begin());
-                    main_model.output_result<SymPowerSensor>(math_output, power_sensor_output.begin());
+                    main_model.output_result<Shunt>(solver_output, shunt_output.begin());
+                    main_model.output_result<Node>(solver_output, node_output.begin());
+                    main_model.output_result<Line>(solver_output, line_output.begin());
+                    main_model.output_result<SymPowerSensor>(solver_output, power_sensor_output.begin());
 
                     CHECK(shunt_output[0].p == doctest::Approx(1800.0).epsilon(0.01));
                     CHECK(shunt_output[0].q == doctest::Approx(180.0).epsilon(0.01));

--- a/tests/cpp_integration_tests/test_math_solver.cpp
+++ b/tests/cpp_integration_tests/test_math_solver.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Test block") {
 namespace {
 
 template <symmetry_tag sym>
-void assert_output(MathOutput<sym> const& output, MathOutput<sym> const& output_ref, bool normalize_phase = false,
+void assert_output(SolverOutput<sym> const& output, SolverOutput<sym> const& output_ref, bool normalize_phase = false,
                    double tolerance = numerical_tolerance) {
     DoubleComplex const phase_offset = normalize_phase ? std::exp(1.0i / 180.0 * pi) : 1.0;
     for (size_t i = 0; i != output.u.size(); ++i) {
@@ -101,7 +101,7 @@ void assert_output(MathOutput<sym> const& output, MathOutput<sym> const& output_
 }
 
 template <symmetry_tag sym>
-void assert_sc_output(ShortCircuitMathOutput<sym> const& output, ShortCircuitMathOutput<sym> const& output_ref,
+void assert_sc_output(ShortCircuitSolverOutput<sym> const& output, ShortCircuitSolverOutput<sym> const& output_ref,
                       double tolerance = numerical_tolerance) {
     for (size_t i = 0; i != output.u_bus.size(); ++i) {
         check_close<sym>(output.u_bus[i], output_ref.u_bus[i], tolerance);
@@ -164,7 +164,7 @@ TEST_CASE("Test math solver") {
     // build param, pf input, output, backwards
     MathModelParam<symmetric_t> param;
     PowerFlowInput<symmetric_t> pf_input;
-    MathOutput<symmetric_t> output_ref;
+    SolverOutput<symmetric_t> output_ref;
     // voltage
     double const vref = 1.1;
     double const v0 = 1.08;
@@ -231,7 +231,7 @@ TEST_CASE("Test math solver") {
 
     // const z
     PowerFlowInput<symmetric_t> pf_input_z = pf_input;
-    MathOutput<symmetric_t> output_ref_z = output_ref;
+    SolverOutput<symmetric_t> output_ref_z = output_ref;
     for (size_t i = 0; i < 6; i++) {
         if (i % 3 == 2) {
             pf_input_z.s_injection[i] *= 3.0;
@@ -276,7 +276,7 @@ TEST_CASE("Test math solver") {
     }
 
     // output
-    MathOutput<asymmetric_t> output_ref_asym;
+    SolverOutput<asymmetric_t> output_ref_asym;
     output_ref_asym.u.resize(output_ref.u.size());
     for (size_t i = 0; i != output_ref.u.size(); ++i) {
         output_ref_asym.u[i] = ComplexValue<asymmetric_t>{output_ref.u[i]};
@@ -310,7 +310,7 @@ TEST_CASE("Test math solver") {
 
     // const z
     PowerFlowInput<asymmetric_t> pf_input_asym_z = pf_input_asym;
-    MathOutput<asymmetric_t> output_ref_asym_z = output_ref_asym;
+    SolverOutput<asymmetric_t> output_ref_asym_z = output_ref_asym;
     for (size_t i = 0; i < 6; i++) {
         if (i % 3 == 2) {
             pf_input_asym_z.s_injection[i] *= 3.0;
@@ -432,7 +432,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test symmetric pf solver") {
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> output = solver.run_power_flow(pf_input, 1e-12, 20, info, newton_raphson, y_bus_sym);
+        SolverOutput<symmetric_t> output = solver.run_power_flow(pf_input, 1e-12, 20, info, newton_raphson, y_bus_sym);
         assert_output(output, output_ref);
         // copy
         MathSolver<symmetric_t> solver2{solver};
@@ -448,7 +448,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test symmetric iterative current pf solver") {
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> const output =
+        SolverOutput<symmetric_t> const output =
             solver.run_power_flow(pf_input, 1e-12, 20, info, iterative_current, y_bus_sym);
         assert_output(output, output_ref);
     }
@@ -460,7 +460,7 @@ TEST_CASE("Test math solver") {
 
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> const output =
+        SolverOutput<symmetric_t> const output =
             solver.run_power_flow(pf_input, error_tolerance, 20, info, linear_current, y_bus_sym);
         assert_output(output, output_ref, false, result_tolerance);
     }
@@ -479,7 +479,7 @@ TEST_CASE("Test math solver") {
         CalculationInfo info;
 
         // const z
-        MathOutput<symmetric_t> const output = solver.run_power_flow(pf_input_z, 1e-12, 20, info, linear, y_bus_sym);
+        SolverOutput<symmetric_t> const output = solver.run_power_flow(pf_input_z, 1e-12, 20, info, linear, y_bus_sym);
         assert_output(output, output_ref_z);
     }
 
@@ -509,7 +509,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test asymmetric pf solver") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<asymmetric_t> const output =
+        SolverOutput<asymmetric_t> const output =
             solver.run_power_flow(pf_input_asym, 1e-12, 20, info, newton_raphson, y_bus_asym);
         assert_output(output, output_ref_asym);
     }
@@ -517,7 +517,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test iterative current asymmetric pf solver") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<asymmetric_t> const output =
+        SolverOutput<asymmetric_t> const output =
             solver.run_power_flow(pf_input_asym, 1e-12, 20, info, iterative_current, y_bus_asym);
         assert_output(output, output_ref_asym);
     }
@@ -526,7 +526,7 @@ TEST_CASE("Test math solver") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
         // const z
-        MathOutput<asymmetric_t> const output =
+        SolverOutput<asymmetric_t> const output =
             solver.run_power_flow(pf_input_asym_z, 1e-12, 20, info, linear, y_bus_asym);
         assert_output(output, output_ref_asym_z);
     }
@@ -534,7 +534,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test sym se with angle") {
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> output;
+        SolverOutput<symmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_angle, 1e-10, 20, info, iterative_linear, y_bus_sym);
@@ -549,7 +549,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test sym se without angle") {
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> output;
+        SolverOutput<symmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_no_angle, 1e-10, 20, info, iterative_linear, y_bus_sym);
@@ -564,7 +564,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test sym se with angle, const z") {
         MathSolver<symmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<symmetric_t> output;
+        SolverOutput<symmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_angle_const_z, 1e-10, 20, info, iterative_linear, y_bus_sym);
@@ -582,7 +582,7 @@ TEST_CASE("Test math solver") {
         auto& branch_from_power = se_input_angle.measured_branch_from_power.front();
         branch_from_power.p_variance = 0.25;
         branch_from_power.q_variance = 0.75;
-        MathOutput<symmetric_t> output;
+        SolverOutput<symmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_angle, 1e-10, 20, info, iterative_linear, y_bus_sym);
@@ -597,7 +597,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test asym se with angle") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<asymmetric_t> output;
+        SolverOutput<asymmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_asym_angle, 1e-10, 20, info, iterative_linear, y_bus_asym);
@@ -612,7 +612,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test asym se without angle") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<asymmetric_t> output;
+        SolverOutput<asymmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_asym_no_angle, 1e-10, 20, info, iterative_linear, y_bus_asym);
@@ -627,7 +627,7 @@ TEST_CASE("Test math solver") {
     SUBCASE("Test asym se with angle, const z") {
         MathSolver<asymmetric_t> solver{topo_ptr};
         CalculationInfo info;
-        MathOutput<asymmetric_t> output;
+        SolverOutput<asymmetric_t> output;
 
         SUBCASE("iterative linear") {
             output =
@@ -647,7 +647,7 @@ TEST_CASE("Test math solver") {
         auto& branch_from_power = se_input_asym_angle.measured_branch_from_power.front();
         branch_from_power.p_variance = RealValue<asymmetric_t>{0.25};
         branch_from_power.q_variance = RealValue<asymmetric_t>{0.75};
-        MathOutput<asymmetric_t> output;
+        SolverOutput<asymmetric_t> output;
 
         SUBCASE("iterative linear") {
             output = solver.run_state_estimation(se_input_asym_angle, 1e-10, 20, info, iterative_linear, y_bus_asym);
@@ -671,30 +671,31 @@ ShortCircuitInput create_sc_test_input(FaultType fault_type, FaultPhase fault_ph
     return sc_input;
 }
 
-template <symmetry_tag sym> constexpr ShortCircuitMathOutput<sym> blank_sc_output(DoubleComplex vref) {
-    ShortCircuitMathOutput<sym> sc_output;
+template <symmetry_tag sym> constexpr ShortCircuitSolverOutput<sym> blank_sc_output(DoubleComplex vref) {
+    ShortCircuitSolverOutput<sym> sc_output;
     sc_output.u_bus = {ComplexValue<sym>(vref), ComplexValue<sym>(vref)};
     sc_output.fault = {{ComplexValue<sym>{}}};
-    sc_output.branch = {BranchShortCircuitMathOutput<sym>{.i_f = {ComplexValue<sym>{}}, .i_t = {ComplexValue<sym>{}}}};
+    sc_output.branch = {
+        BranchShortCircuitSolverOutput<sym>{.i_f = {ComplexValue<sym>{}}, .i_t = {ComplexValue<sym>{}}}};
     sc_output.source = {{ComplexValue<sym>{}}};
     return sc_output;
 }
 
 template <symmetry_tag sym>
-constexpr ShortCircuitMathOutput<sym> create_math_sc_output(ComplexValue<sym> u0, ComplexValue<sym> u1,
-                                                            ComplexValue<sym> if_abc) {
-    ShortCircuitMathOutput<sym> sc_output;
+constexpr ShortCircuitSolverOutput<sym> create_math_sc_output(ComplexValue<sym> u0, ComplexValue<sym> u1,
+                                                              ComplexValue<sym> if_abc) {
+    ShortCircuitSolverOutput<sym> sc_output;
     sc_output.u_bus = {u0, u1};
     sc_output.fault = {{if_abc}};
-    sc_output.branch = {BranchShortCircuitMathOutput<sym>{.i_f = if_abc, .i_t = -if_abc}};
+    sc_output.branch = {BranchShortCircuitSolverOutput<sym>{.i_f = if_abc, .i_t = -if_abc}};
     sc_output.source = {{if_abc}};
     return sc_output;
 }
 
 template <symmetry_tag sym>
-ShortCircuitMathOutput<sym> create_sc_test_output(FaultType fault_type, DoubleComplex const& z_fault,
-                                                  DoubleComplex const& z0, DoubleComplex const& z0_0, double const vref,
-                                                  DoubleComplex const& zref) {
+ShortCircuitSolverOutput<sym> create_sc_test_output(FaultType fault_type, DoubleComplex const& z_fault,
+                                                    DoubleComplex const& z0, DoubleComplex const& z0_0,
+                                                    double const vref, DoubleComplex const& zref) {
 
     if constexpr (is_symmetric_v<sym>) {
         DoubleComplex const if_abc = vref / (z0 + zref + z_fault);
@@ -985,7 +986,7 @@ TEST_CASE("Short circuit solver") {
         DoubleComplex const if_c_2phg_solid = vref * a / zref;
 
         SUBCASE("Source on 3ph sym fault") {
-            ShortCircuitMathOutput<symmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<symmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {uf_comp};
             sc_output_ref.fault = {{if_comp}};
             sc_output_ref.branch = {};
@@ -998,7 +999,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 3ph sym solid fault") {
-            ShortCircuitMathOutput<symmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<symmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {DoubleComplex{uf_comp_solid}};
             sc_output_ref.fault = {{if_comp_solid}};
             sc_output_ref.branch = {};
@@ -1011,7 +1012,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 3ph fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{uf_comp}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{if_comp}}};
             sc_output_ref.branch = {};
@@ -1024,7 +1025,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 1phg fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{uf_comp, vref * a * a, vref * a}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{if_comp, 0, 0}}};
             sc_output_ref.branch = {};
@@ -1037,7 +1038,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 1phg solid fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{uf_comp_solid, vref * a * a, vref * a}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{if_comp_solid, 0, 0}}};
             sc_output_ref.branch = {};
@@ -1051,7 +1052,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 2ph fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{vref, uf_b_comp, uf_c_comp}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{0.0, if_b_comp, -if_b_comp}}};
             sc_output_ref.branch = {};
@@ -1064,7 +1065,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 2ph solid fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{vref, uf_b_comp_solid, uf_c_comp_solid}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{0.0, if_b_comp_solid, -if_b_comp_solid}}};
             sc_output_ref.branch = {};
@@ -1077,7 +1078,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 2phg fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{vref, uf_b_2phg, uf_b_2phg}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{0.0, if_b_2phg, if_c_2phg}}};
             sc_output_ref.branch = {};
@@ -1090,7 +1091,7 @@ TEST_CASE("Short circuit solver") {
         }
 
         SUBCASE("Source on 2phg solid fault") {
-            ShortCircuitMathOutput<asymmetric_t> sc_output_ref;
+            ShortCircuitSolverOutput<asymmetric_t> sc_output_ref;
             sc_output_ref.u_bus = {ComplexValue<asymmetric_t>{vref, uf_b_2phg_solid, uf_b_2phg_solid}};
             sc_output_ref.fault = {{ComplexValue<asymmetric_t>{0.0, if_b_2phg_solid, if_c_2phg_solid}}};
             sc_output_ref.branch = {};
@@ -1139,7 +1140,7 @@ TEST_CASE("Math solver, zero variance test") {
 
     MathSolver<symmetric_t> solver{topo_ptr};
     CalculationInfo info;
-    MathOutput<symmetric_t> output;
+    SolverOutput<symmetric_t> output;
 
     SUBCASE("iterative linear") {
         output = solver.run_state_estimation(se_input, 1e-10, 20, info, iterative_linear, y_bus_sym);
@@ -1187,7 +1188,7 @@ TEST_CASE("Math solver, measurements") {
     se_input.measured_voltage = {{1.0, 0.1}};
 
     CalculationInfo info;
-    MathOutput<symmetric_t> output;
+    SolverOutput<symmetric_t> output;
 
     SUBCASE("Source and branch") {
         /*

--- a/tests/cpp_unit_tests/test_line.cpp
+++ b/tests/cpp_unit_tests/test_line.cpp
@@ -149,12 +149,12 @@ TEST_CASE("Test line") {
     }
 
     SUBCASE("Symmetric results with direct power and current output") {
-        BranchMathOutput<symmetric_t> branch_math_output{};
-        branch_math_output.i_f = 1.0 - 2.0i;
-        branch_math_output.i_t = 2.0 - 1.0i;
-        branch_math_output.s_f = 1.0 - 1.5i;
-        branch_math_output.s_t = 1.5 - 1.5i;
-        BranchOutput<symmetric_t> output = branch.get_output<symmetric_t>(branch_math_output);
+        BranchSolverOutput<symmetric_t> branch_solver_output{};
+        branch_solver_output.i_f = 1.0 - 2.0i;
+        branch_solver_output.i_t = 2.0 - 1.0i;
+        branch_solver_output.s_f = 1.0 - 1.5i;
+        branch_solver_output.s_t = 1.5 - 1.5i;
+        BranchOutput<symmetric_t> output = branch.get_output<symmetric_t>(branch_solver_output);
         CHECK(output.id == 1);
         CHECK(output.energized);
         CHECK(output.loading == doctest::Approx(cabs(2.0 - 1.0i) * base_i / input.i_n));

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -58,19 +58,19 @@ TEST_CASE("Test load generator") {
     double const i_i = s_i / (1.1 * 10e3) / sqrt3;
     double const p_pu = 3e6 / base_power_3p;
 
-    ApplianceMathOutput<symmetric_t> appliance_math_output_sym;
-    appliance_math_output_sym.i = 1.0 + 2.0i;
-    appliance_math_output_sym.s = 3.0 + 4.0i;
+    ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
+    appliance_solver_output_sym.i = 1.0 + 2.0i;
+    appliance_solver_output_sym.s = 3.0 + 4.0i;
 
-    ApplianceMathOutput<symmetric_t> appliance_math_output_sym_reverse;
-    appliance_math_output_sym_reverse.i = -1.0 - 2.0i;
-    appliance_math_output_sym_reverse.s = -3.0 - 4.0i;
+    ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym_reverse;
+    appliance_solver_output_sym_reverse.i = -1.0 - 2.0i;
+    appliance_solver_output_sym_reverse.s = -3.0 - 4.0i;
 
-    ApplianceMathOutput<asymmetric_t> appliance_math_output_asym;
+    ApplianceSolverOutput<asymmetric_t> appliance_solver_output_asym;
     ComplexValue<asymmetric_t> const i_a{1.0 + 2.0i};
     ComplexValue<asymmetric_t> const s_a{3.0 + 4.0i, 3.0 + 4.0i, 3.0 + 4.0i};
-    appliance_math_output_asym.i = i_a;
-    appliance_math_output_asym.s = s_a;
+    appliance_solver_output_asym.i = i_a;
+    appliance_solver_output_asym.s = s_a;
 
     CHECK(sym_gen_pq.math_model_type() == ComponentType::generic_load_gen);
 
@@ -114,7 +114,7 @@ TEST_CASE("Test load generator") {
     SUBCASE("Test symmetric generator with constant power; s,i as input") {
         GenericLoadGen const& load_gen = sym_gen_pq;
         // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(3.0 * base_power<symmetric_t>));
@@ -123,7 +123,8 @@ TEST_CASE("Test load generator") {
         CHECK(sym_result.i == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(sym_result.pf == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
         // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(appliance_math_output_asym);
+        ApplianceOutput<asymmetric_t> const asym_result =
+            load_gen.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.p(0) == doctest::Approx(3.0 * base_power<asymmetric_t>));
         CHECK(asym_result.q(1) == doctest::Approx(4.0 * base_power<asymmetric_t>));
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));
@@ -131,7 +132,7 @@ TEST_CASE("Test load generator") {
         CHECK(asym_result.pf(1) == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
         // reverse result
         ApplianceOutput<symmetric_t> const reverse_result =
-            load_gen.get_output<symmetric_t>(appliance_math_output_sym_reverse);
+            load_gen.get_output<symmetric_t>(appliance_solver_output_sym_reverse);
         CHECK(reverse_result.id == 1);
         CHECK(reverse_result.energized);
         CHECK(reverse_result.p == doctest::Approx(-3.0 * base_power<symmetric_t>));
@@ -171,7 +172,7 @@ TEST_CASE("Test load generator") {
     SUBCASE("Test asymmetric load with constant power; s, i as input") {
         GenericLoadGen const& load_gen = asym_load_pq;
         // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(-3.0 * base_power<symmetric_t>));
@@ -180,7 +181,8 @@ TEST_CASE("Test load generator") {
         CHECK(sym_result.i == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(sym_result.pf == doctest::Approx(-3.0 / cabs(3.0 + 4.0i)));
         // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(appliance_math_output_asym);
+        ApplianceOutput<asymmetric_t> const asym_result =
+            load_gen.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.p(0) == doctest::Approx(-3.0 * base_power<asymmetric_t>));
         CHECK(asym_result.q(1) == doctest::Approx(-4.0 * base_power<asymmetric_t>));
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));
@@ -211,7 +213,7 @@ TEST_CASE("Test load generator") {
     SUBCASE("Test symmetric load with constant current; s, i as input") {
         GenericLoadGen const& load_gen = sym_load_i;
         // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(-3.0 * base_power<symmetric_t>));
@@ -220,7 +222,8 @@ TEST_CASE("Test load generator") {
         CHECK(sym_result.i == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(sym_result.pf == doctest::Approx(-3.0 / cabs(3.0 + 4.0i)));
         // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(appliance_math_output_asym);
+        ApplianceOutput<asymmetric_t> const asym_result =
+            load_gen.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.p(0) == doctest::Approx(-3.0 * base_power<asymmetric_t>));
         CHECK(asym_result.q(1) == doctest::Approx(-4.0 * base_power<asymmetric_t>));
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));
@@ -228,7 +231,7 @@ TEST_CASE("Test load generator") {
         CHECK(asym_result.pf(1) == doctest::Approx(-3.0 / cabs(3.0 + 4.0i)));
         // reverse direction
         ApplianceOutput<symmetric_t> const reverse_result =
-            load_gen.get_output<symmetric_t>(appliance_math_output_sym_reverse);
+            load_gen.get_output<symmetric_t>(appliance_solver_output_sym_reverse);
         CHECK(reverse_result.id == 1);
         CHECK(reverse_result.energized);
         CHECK(reverse_result.p == doctest::Approx(3.0 * base_power<symmetric_t>));
@@ -261,7 +264,7 @@ TEST_CASE("Test load generator") {
     SUBCASE("Test asymmetric generator with constant addmittance; s, i as input") {
         GenericLoadGen const& load_gen = asym_gen_y;
         // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(3.0 * base_power<symmetric_t>));
@@ -270,7 +273,8 @@ TEST_CASE("Test load generator") {
         CHECK(sym_result.i == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(sym_result.pf == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
         // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(appliance_math_output_asym);
+        ApplianceOutput<asymmetric_t> const asym_result =
+            load_gen.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.p(0) == doctest::Approx(3.0 * base_power<asymmetric_t>));
         CHECK(asym_result.q(1) == doctest::Approx(4.0 * base_power<asymmetric_t>));
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));

--- a/tests/cpp_unit_tests/test_optimizer.hpp
+++ b/tests/cpp_unit_tests/test_optimizer.hpp
@@ -57,18 +57,18 @@ constexpr auto get_math_id(State const& /* state */, Idx /* topology_sequence_id
     return StubTransformerMathIdType{};
 }
 
-template <std::derived_from<StubTransformer> ComponentType, steady_state_math_output_type MathOutputType>
-inline auto i_pu(std::vector<MathOutputType> const& /* math_output */, StubTransformerMathIdType const& /* math_id */,
-                 ControlSide /* side */) {
-    return ComplexValue<typename MathOutputType::sym>{};
+template <std::derived_from<StubTransformer> ComponentType, steady_state_solver_output_type SolverOutputType>
+inline auto i_pu(std::vector<SolverOutputType> const& /* solver_output */,
+                 StubTransformerMathIdType const& /* math_id */, ControlSide /* side */) {
+    return ComplexValue<typename SolverOutputType::sym>{};
 }
 
 template <std::derived_from<StubTransformer> ComponentType, typename State,
-          steady_state_math_output_type MathOutputType>
+          steady_state_solver_output_type SolverOutputType>
     requires main_core::component_container_c<typename State::ComponentContainer, ComponentType>
-inline auto u_pu(State const& /* state */, std::vector<MathOutputType> const& /* math_output */,
+inline auto u_pu(State const& /* state */, std::vector<SolverOutputType> const& /* solver_output */,
                  Idx /* topology_index */, ControlSide /* control_side */) {
-    return ComplexValue<typename MathOutputType::sym>{};
+    return ComplexValue<typename SolverOutputType::sym>{};
 }
 
 // TODO(mgovers) revert
@@ -89,10 +89,10 @@ struct StubUpdateType {};
 
 using StubStateCalculator = StubStateCalculatorResultType (*)(StubState const& /* state */,
                                                               CalculationMethod /* method */);
-using SymStubSteadyStateCalculator = std::vector<MathOutput<symmetric_t>> (*)(StubState const& /* state */,
-                                                                              CalculationMethod /* method */);
-using AsymStubSteadyStateCalculator = std::vector<MathOutput<asymmetric_t>> (*)(StubState const& /* state */,
+using SymStubSteadyStateCalculator = std::vector<SolverOutput<symmetric_t>> (*)(StubState const& /* state */,
                                                                                 CalculationMethod /* method */);
+using AsymStubSteadyStateCalculator = std::vector<SolverOutput<asymmetric_t>> (*)(StubState const& /* state */,
+                                                                                  CalculationMethod /* method */);
 using StubUpdate = void (*)(StubUpdateType const& /* update_data */);
 using ConstDatasetUpdate = void (*)(ConstDataset const& /* update_data */);
 
@@ -101,10 +101,10 @@ static_assert(std::same_as<std::invoke_result_t<StubStateCalculator, StubState c
                            StubStateCalculatorResultType>);
 static_assert(std::invocable<SymStubSteadyStateCalculator, StubState const&, CalculationMethod>);
 static_assert(std::same_as<std::invoke_result_t<SymStubSteadyStateCalculator, StubState const&, CalculationMethod>,
-                           std::vector<MathOutput<symmetric_t>>>);
+                           std::vector<SolverOutput<symmetric_t>>>);
 static_assert(std::invocable<SymStubSteadyStateCalculator, StubState const&, CalculationMethod>);
 static_assert(std::same_as<std::invoke_result_t<AsymStubSteadyStateCalculator, StubState const&, CalculationMethod>,
-                           std::vector<MathOutput<asymmetric_t>>>);
+                           std::vector<SolverOutput<asymmetric_t>>>);
 static_assert(std::invocable<StubUpdate, StubUpdateType const&>);
 static_assert(std::invocable<ConstDatasetUpdate, ConstDataset const&>);
 
@@ -119,7 +119,7 @@ static_assert(std::convertible_to<decltype(mock_state_calculator), StubStateCalc
 
 template <symmetry_tag sym>
 constexpr auto stub_steady_state_state_calculator(StubState const& /* state */, CalculationMethod /* method */) {
-    return std::vector<MathOutput<sym>>{};
+    return std::vector<SolverOutput<sym>>{};
 }
 static_assert(
     std::convertible_to<decltype(stub_steady_state_state_calculator<symmetric_t>), SymStubSteadyStateCalculator>);

--- a/tests/cpp_unit_tests/test_shunt.cpp
+++ b/tests/cpp_unit_tests/test_shunt.cpp
@@ -64,10 +64,10 @@ TEST_CASE("Test shunt") {
     }
 
     SUBCASE("Symmetric test results; s, i as input") {
-        ApplianceMathOutput<symmetric_t> appliance_math_output_sym;
-        appliance_math_output_sym.i = 1.0 + 2.0i;
-        appliance_math_output_sym.s = 3.0 + 4.0i;
-        ApplianceOutput<symmetric_t> sym_result = shunt.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
+        appliance_solver_output_sym.i = 1.0 + 2.0i;
+        appliance_solver_output_sym.s = 3.0 + 4.0i;
+        ApplianceOutput<symmetric_t> sym_result = shunt.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(-3.0 * base_power<symmetric_t>));
@@ -78,12 +78,12 @@ TEST_CASE("Test shunt") {
     }
 
     SUBCASE("Asymmetric test results; s, i as input") {
-        ApplianceMathOutput<asymmetric_t> appliance_math_output_asym;
+        ApplianceSolverOutput<asymmetric_t> appliance_solver_output_asym;
         ComplexValue<asymmetric_t> const i_a{1.0 + 2.0i};
         ComplexValue<asymmetric_t> const s_a{3.0 + 4.0i, 3.0 + 4.0i, 3.0 + 4.0i};
-        appliance_math_output_asym.i = i_a;
-        appliance_math_output_asym.s = s_a;
-        ApplianceOutput<asymmetric_t> asym_result = shunt.get_output<asymmetric_t>(appliance_math_output_asym);
+        appliance_solver_output_asym.i = i_a;
+        appliance_solver_output_asym.s = s_a;
+        ApplianceOutput<asymmetric_t> asym_result = shunt.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.id == 1);
         CHECK(asym_result.energized);
         CHECK(asym_result.p(0) == doctest::Approx(-3.0 * base_power<asymmetric_t>));

--- a/tests/cpp_unit_tests/test_source.cpp
+++ b/tests/cpp_unit_tests/test_source.cpp
@@ -104,10 +104,10 @@ TEST_CASE("Test source") {
     }
 
     SUBCASE("test source sym results; s, i as input") {
-        ApplianceMathOutput<symmetric_t> appliance_math_output_sym;
-        appliance_math_output_sym.i = 1.0 + 2.0i;
-        appliance_math_output_sym.s = 3.0 + 4.0i;
-        ApplianceOutput<symmetric_t> const sym_result = source.get_output<symmetric_t>(appliance_math_output_sym);
+        ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
+        appliance_solver_output_sym.i = 1.0 + 2.0i;
+        appliance_solver_output_sym.s = 3.0 + 4.0i;
+        ApplianceOutput<symmetric_t> const sym_result = source.get_output<symmetric_t>(appliance_solver_output_sym);
         CHECK(sym_result.id == 1);
         CHECK(sym_result.energized);
         CHECK(sym_result.p == doctest::Approx(3.0 * base_power<symmetric_t>));
@@ -126,12 +126,12 @@ TEST_CASE("Test source") {
     }
 
     SUBCASE("test source asym results; s, i as input") {
-        ApplianceMathOutput<asymmetric_t> appliance_math_output_asym;
+        ApplianceSolverOutput<asymmetric_t> appliance_solver_output_asym;
         ComplexValue<asymmetric_t> const i_a{1.0 + 2.0i};
         ComplexValue<asymmetric_t> const s_a{3.0 + 4.0i, 3.0 + 4.0i, 3.0 + 4.0i};
-        appliance_math_output_asym.i = i_a;
-        appliance_math_output_asym.s = s_a;
-        ApplianceOutput<asymmetric_t> const asym_result = source.get_output<asymmetric_t>(appliance_math_output_asym);
+        appliance_solver_output_asym.i = i_a;
+        appliance_solver_output_asym.s = s_a;
+        ApplianceOutput<asymmetric_t> const asym_result = source.get_output<asymmetric_t>(appliance_solver_output_asym);
         CHECK(asym_result.id == 1);
         CHECK(asym_result.energized);
         CHECK(asym_result.p(0) == doctest::Approx(3.0 * base_power<asymmetric_t>));
@@ -144,7 +144,7 @@ TEST_CASE("Test source") {
     SUBCASE("test asym source short circuit results") {
         ComplexValue<asymmetric_t> const i_asym{1.0 + 2.0i};
         ApplianceShortCircuitOutput const asym_sc_result =
-            source.get_sc_output(ApplianceShortCircuitMathOutput<asymmetric_t>{i_asym});
+            source.get_sc_output(ApplianceShortCircuitSolverOutput<asymmetric_t>{i_asym});
         CHECK(asym_sc_result.id == 1);
         CHECK(asym_sc_result.energized == 1);
         CHECK(asym_sc_result.i(0) == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
@@ -158,9 +158,9 @@ TEST_CASE("Test source") {
         DoubleComplex const i_sym = 1.0 + 2.0i;
         ComplexValue<asymmetric_t> const i_asym{1.0 + 2.0i};
         ApplianceShortCircuitOutput const sym_sc_result =
-            source.get_sc_output(ApplianceShortCircuitMathOutput<symmetric_t>{i_sym});
+            source.get_sc_output(ApplianceShortCircuitSolverOutput<symmetric_t>{i_sym});
         ApplianceShortCircuitOutput const asym_sc_result =
-            source.get_sc_output(ApplianceShortCircuitMathOutput<asymmetric_t>{i_asym});
+            source.get_sc_output(ApplianceShortCircuitSolverOutput<asymmetric_t>{i_asym});
         CHECK(sym_sc_result.id == asym_sc_result.id);
         CHECK(sym_sc_result.energized == asym_sc_result.energized);
         CHECK(sym_sc_result.i(0) == doctest::Approx(asym_sc_result.i(0)));

--- a/tests/cpp_unit_tests/test_three_winding_transformer.cpp
+++ b/tests/cpp_unit_tests/test_three_winding_transformer.cpp
@@ -319,9 +319,9 @@ TEST_CASE("Test three winding transformer") {
     SUBCASE("Check output of branch 3") {
         // TODO asym output check
         // Branch initialization: s_f, s_t, i_f, i_t
-        BranchMathOutput<symmetric_t> const b1_output{(1.0 - 2.0i), (2.0 - 3.0i), (1.5 - 2.5i), (2.5 - 3.5i)};
-        BranchMathOutput<symmetric_t> const b2_output{(2.0 - 3.0i), (-3.0 + 2.0i), (1.5 - 2.5i), (-4.0 + 1.5i)};
-        BranchMathOutput<symmetric_t> const b3_output{(3.0 + 1.0i), (1.0 + 1.0i), (1.5 - 2.5i), (1.5 + 2.0i)};
+        BranchSolverOutput<symmetric_t> const b1_output{(1.0 - 2.0i), (2.0 - 3.0i), (1.5 - 2.5i), (2.5 - 3.5i)};
+        BranchSolverOutput<symmetric_t> const b2_output{(2.0 - 3.0i), (-3.0 + 2.0i), (1.5 - 2.5i), (-4.0 + 1.5i)};
+        BranchSolverOutput<symmetric_t> const b3_output{(3.0 + 1.0i), (1.0 + 1.0i), (1.5 - 2.5i), (1.5 + 2.0i)};
 
         Branch3Output<symmetric_t> sym_output = vec[0].get_output(b1_output, b2_output, b3_output);
 
@@ -358,18 +358,18 @@ TEST_CASE("Test three winding transformer") {
         CHECK(sym_output.s_3 == doctest::Approx(out_s_3));
         CHECK(sym_output.loading == doctest::Approx(out_loading));
 
-        BranchMathOutput<asymmetric_t> const asym_b1_output{{(1.0 - 2.0i), (1.0 - 2.0i), (1.0 - 2.0i)},
-                                                            {(2.0 - 3.0i), (2.0 - 3.0i), (2.0 - 3.0i)},
-                                                            {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
-                                                            {(2.5 - 3.5i), (2.5 - 3.5i), (2.5 - 3.5i)}};
-        BranchMathOutput<asymmetric_t> const asym_b2_output{{(2.0 - 3.0i), (2.0 - 3.0i), (2.0 - 3.0i)},
-                                                            {(-3.0 + 2.0i), (-3.0 + 2.0i), (-3.0 + 2.0i)},
-                                                            {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
-                                                            {(-4.0 + 1.5i), (-4.0 + 1.5i), (-4.0 + 1.5i)}};
-        BranchMathOutput<asymmetric_t> const asym_b3_output{{(3.0 + 1.0i), (3.0 + 1.0i), (3.0 + 1.0i)},
-                                                            {(1.0 + 1.0i), (1.0 + 1.0i), (1.0 + 1.0i)},
-                                                            {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
-                                                            {(1.5 + 2.0i), (1.5 + 2.0i), (1.5 + 2.0i)}};
+        BranchSolverOutput<asymmetric_t> const asym_b1_output{{(1.0 - 2.0i), (1.0 - 2.0i), (1.0 - 2.0i)},
+                                                              {(2.0 - 3.0i), (2.0 - 3.0i), (2.0 - 3.0i)},
+                                                              {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
+                                                              {(2.5 - 3.5i), (2.5 - 3.5i), (2.5 - 3.5i)}};
+        BranchSolverOutput<asymmetric_t> const asym_b2_output{{(2.0 - 3.0i), (2.0 - 3.0i), (2.0 - 3.0i)},
+                                                              {(-3.0 + 2.0i), (-3.0 + 2.0i), (-3.0 + 2.0i)},
+                                                              {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
+                                                              {(-4.0 + 1.5i), (-4.0 + 1.5i), (-4.0 + 1.5i)}};
+        BranchSolverOutput<asymmetric_t> const asym_b3_output{{(3.0 + 1.0i), (3.0 + 1.0i), (3.0 + 1.0i)},
+                                                              {(1.0 + 1.0i), (1.0 + 1.0i), (1.0 + 1.0i)},
+                                                              {(1.5 - 2.5i), (1.5 - 2.5i), (1.5 - 2.5i)},
+                                                              {(1.5 + 2.0i), (1.5 + 2.0i), (1.5 + 2.0i)}};
 
         Branch3Output<asymmetric_t> asym_output = vec[0].get_output(asym_b1_output, asym_b2_output, asym_b3_output);
 
@@ -415,9 +415,9 @@ TEST_CASE("Test three winding transformer") {
         ComplexValue<symmetric_t> const i_2{1.0 - 2.2i};
         ComplexValue<symmetric_t> const i_3{1.3 - 2.1i};
 
-        BranchShortCircuitMathOutput<symmetric_t> const sym_b1_output{i_1, ComplexValue<symmetric_t>{}};
-        BranchShortCircuitMathOutput<symmetric_t> const sym_b2_output{i_2, ComplexValue<symmetric_t>{}};
-        BranchShortCircuitMathOutput<symmetric_t> const sym_b3_output{i_3, ComplexValue<symmetric_t>{}};
+        BranchShortCircuitSolverOutput<symmetric_t> const sym_b1_output{i_1, ComplexValue<symmetric_t>{}};
+        BranchShortCircuitSolverOutput<symmetric_t> const sym_b2_output{i_2, ComplexValue<symmetric_t>{}};
+        BranchShortCircuitSolverOutput<symmetric_t> const sym_b3_output{i_3, ComplexValue<symmetric_t>{}};
 
         Branch3ShortCircuitOutput sym_sc_output = vec[0].get_sc_output(sym_b1_output, sym_b2_output, sym_b3_output);
 
@@ -425,9 +425,9 @@ TEST_CASE("Test three winding transformer") {
         ComplexValue<asymmetric_t> const i_2_asym{1.0 - 2.2i};
         ComplexValue<asymmetric_t> const i_3_asym{1.3 - 2.1i};
 
-        BranchShortCircuitMathOutput<asymmetric_t> const asym_b1_output{i_1_asym, ComplexValue<asymmetric_t>{}};
-        BranchShortCircuitMathOutput<asymmetric_t> const asym_b2_output{i_2_asym, ComplexValue<asymmetric_t>{}};
-        BranchShortCircuitMathOutput<asymmetric_t> const asym_b3_output{i_3_asym, ComplexValue<asymmetric_t>{}};
+        BranchShortCircuitSolverOutput<asymmetric_t> const asym_b1_output{i_1_asym, ComplexValue<asymmetric_t>{}};
+        BranchShortCircuitSolverOutput<asymmetric_t> const asym_b2_output{i_2_asym, ComplexValue<asymmetric_t>{}};
+        BranchShortCircuitSolverOutput<asymmetric_t> const asym_b3_output{i_3_asym, ComplexValue<asymmetric_t>{}};
 
         Branch3ShortCircuitOutput asym_sc_output = vec[0].get_sc_output(asym_b1_output, asym_b2_output, asym_b3_output);
 

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -176,7 +176,7 @@ TEST_CASE("Test y bus") {
     SUBCASE("Test branch flow calculation") {
         YBus<symmetric_t> const ybus{topo_ptr, std::make_shared<MathModelParam<symmetric_t> const>(param_sym)};
         ComplexVector const u{1.0, 2.0, 3.0, 4.0};
-        auto branch_flow = ybus.calculate_branch_flow<BranchMathOutput<symmetric_t>>(u);
+        auto branch_flow = ybus.calculate_branch_flow<BranchSolverOutput<symmetric_t>>(u);
 
         // branch 2, bus 2->3
         // if = 3 * 9i + 4 * 10i = 67i
@@ -192,7 +192,7 @@ TEST_CASE("Test y bus") {
     SUBCASE("Test shunt flow calculation") {
         YBus<symmetric_t> const ybus{topo_ptr, std::make_shared<MathModelParam<symmetric_t> const>(param_sym)};
         ComplexVector const u{1.0, 2.0, 3.0, 4.0};
-        auto shunt_flow = ybus.template calculate_shunt_flow<ApplianceMathOutput<symmetric_t>>(u);
+        auto shunt_flow = ybus.template calculate_shunt_flow<ApplianceSolverOutput<symmetric_t>>(u);
 
         // shunt 1
         // i = -4 * 200i


### PR DESCRIPTION
Step 1 of the MathOutput transformation. Necessary for tap changer.