### PR TITLE
[FEATURE] migrate to miniforge

### DIFF
--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: conda-pgm-env
-channels:
-  - conda-forge
 dependencies:
   # build env
   - python=3.11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,6 +234,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest  # use miniforge instead of miniconda
           activate-environment: conda-pgm-env
           environment-file: .github/conda_pgm_env.yml
           auto-activate-base: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,8 +109,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Activate conda
-        run: |
-          & "$env:CONDA\condabin\conda" init
+        uses: conda-incubator/setup-miniconda@v3  # install miniforge instead
+        with:
+          miniforge-version: latest
 
       - name: Install conda environment
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,11 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3  # install miniforge instead
         with:
           miniforge-version: latest
+      
+      - name: List conda
+        run: |
+          conda info
+          conda list
 
       - name: Install conda environment
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MPL-2.0
 
 [![PyPI version](https://badge.fury.io/py/power-grid-model.svg?no-cache)](https://badge.fury.io/py/power-grid-model)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/power-grid-model/badges/version.svg?no-cache)](https://anaconda.org/conda-forge/power-grid-model)
-[![License: MIT](https://img.shields.io/badge/License-MPL2.0-informational.svg)](https://github.com/PowerGridModel/power-grid-model/blob/main/LICENSE)
+[![License: MPL2.0](https://img.shields.io/badge/License-MPL2.0-informational.svg)](https://github.com/PowerGridModel/power-grid-model/blob/main/LICENSE)
 [![Build and Test C++ and Python](https://github.com/PowerGridModel/power-grid-model/actions/workflows/main.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model/actions/workflows/main.yml)
 [![Check Code Quality](https://github.com/PowerGridModel/power-grid-model/actions/workflows/check-code-quality.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model/actions/workflows/check-code-quality.yml)
 [![Clang Tidy](https://github.com/PowerGridModel/power-grid-model/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/PowerGridModel/power-grid-model/actions/workflows/clang-tidy.yml)

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -270,8 +270,17 @@ You need to install the MSVC compiler. You can either install the whole Visual S
 
 Other toolchains:
 
-* [Miniconda](https://docs.conda.io/en/latest/miniconda.html), install Python 3 64-bit under user wide.
+* [Miniforge](https://github.com/conda-forge/miniforge), install Python 3 64-bit under user wide.
 * [Git](https://git-scm.com/downloads)
+
+```{note}
+It is also possible to use any other `conda` provider like [Miniconda](https://docs.conda.io/en/latest/miniconda.html). However, we recommend using [Miniforge](https://github.com/conda-forge/miniforge), because it is published under BSD License and by default does not have any references to commercially licensed software.
+```
+
+```{note}
+Long paths for (dependencies in) the installation environment might exceed the `maximum path length limitation` set by Windows, causing the installation to fail.
+It is possible to enable long paths in Windows by following the steps in the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
+```
 
 ### C++ packages
 
@@ -291,7 +300,7 @@ Go to a root folder you prefer to save the repositories, open a Git Bash Console
 git clone https://github.com/PowerGridModel/power-grid-model.git
 ```
 
-Then open a Miniconda PowerShell Prompt, go to the repository folder.
+Then open a Miniforge PowerShell Prompt (or equivalent if you use a different `conda` provider), go to the repository folder.
 
 ```shell
 conda create -n power-grid-env python=3.10
@@ -304,8 +313,9 @@ Install from source in develop mode, and run `pytest`.
 pip install -e .[dev]
 pytest
 ```
+
 ```{note}
-Long paths for (dependencies in) the miniconda installation environment might exceed the `maximum path length limitation` set by Windows, causing the installation to fail.
+Long paths for (dependencies in) the conda installation environment might exceed the `maximum path length limitation` set by Windows, causing the installation to fail.
 It is possible to enable long paths in Windows by following the steps in the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
 ```
 


### PR DESCRIPTION
Do not use miniconda but use miniforge instead

## logs or it didn't happen

the logs are quite difficult to interpret but it is clear that `miniforge` is installed to `/runners/miniconda3/` which is interesting but i guess to the best of our effort

before: taken from https://github.com/PowerGridModel/power-grid-model/actions/runs/8896817941/job/24430327994
after: taken from https://github.com/PowerGridModel/power-grid-model/actions/runs/8909980841/job/24468327997
[logs.zip](https://github.com/PowerGridModel/power-grid-model/files/15177560/logs.zip)