### PR TITLE
[Feature] migrate gcc-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install packages
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
           sudo apt-get install -y ninja-build gcc-13 clang-15
       - name: Enable brew

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15
+          sudo apt-get install -y ninja-build gcc-13 clang-15
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-13 clang-15
+          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-15
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH


### PR DESCRIPTION
Install GCC-13 explicitly according to https://github.com/actions/runner-images/issues/9679

I propose migrating to Ubuntu 24.04 [beta] in a few weeks (after PGM meetup?)
