### PR TITLE
[Feature] tap regulator output data declaration

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_tap_regulator.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_tap_regulator.hpp
@@ -19,6 +19,8 @@ class TransformerTapRegulator : public Regulator {
   public:
     using InputType = TransformerTapRegulatorInput;
     using UpdateType = TransformerTapRegulatorUpdate;
+    template <symmetry_tag sym> using OutputType = TransformerTapRegulatorOutput;
+
     static constexpr char const* name = "transformer_tap_regulator";
 
     explicit TransformerTapRegulator(TransformerTapRegulatorInput const& transformer_tap_regulator_input,


### PR DESCRIPTION
## Before

```py
>>> from power_grid_model import initialize_array
>>> initialize_array("sym_output", "node", 1)
array([(-2147483648, -128, nan, nan, nan, nan, nan)],
      dtype={'names': ['id', 'energized', 'u_pu', 'u', 'u_angle', 'p', 'q'], 'formats': ['<i4', 'i1', '<f8', '<f8', '<f8', '<f8', '<f8'], 'offsets': [0, 4, 8, 16, 24, 32, 40], 'itemsize': 48, 'aligned': True})
>>> initialize_array("sym_output", "transformer_tap_regulator", 1) 
array([(-2147483648, -128)],
      dtype={'names': ['id', 'energized'], 'formats': ['<i4', 'i1'], 'offsets': [0, 4], 'itemsize': 8, 'aligned': True})
```

## After

```py
>>> from power_grid_model import initialize_array
>>> initialize_array("sym_output", "transformer_tap_regulator", 1)
array([(-2147483648, -128, -128)],
      dtype={'names': ['id', 'energized', 'tap_pos'], 'formats': ['<i4', 'i1', 'i1'], 'offsets': [0, 4, 5], 'itemsize': 8, 'aligned': True})
```