### PR TITLE
Reconfigure cmake preset

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,7 +38,6 @@ jobs:
 
     env:
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      CLANG_TIDY: clang-tidy-15
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
       TARGET: nonexistent  # will be overwritten later in this action
 
@@ -51,6 +50,7 @@ jobs:
           sudo apt-get install -y ninja-build clang-15 clang-tidy-15
           sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,8 +38,6 @@ jobs:
 
     env:
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      CC: clang-15
-      CXX: clang++-15
       CLANG_TIDY: clang-tidy-15
       PRESET: ci-clang-tidy-${{ matrix.build-option }}
       TARGET: nonexistent  # will be overwritten later in this action
@@ -51,6 +49,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build clang-15 clang-tidy-15
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
 
       - name: Enable brew
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,16 +68,10 @@ jobs:
         compiler: [gcc, clang]
         include:
           - compiler: gcc
-            cc: gcc-12
-            cxx: g++-12
           - compiler: clang
-            cc: clang-15
-            cxx: clang++-15
 
     env:
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
       PRESET: ci-${{ matrix.compiler }}-${{ matrix.build-option }}
 
     steps:
@@ -86,6 +80,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build gcc-12 g++-12 clang-15
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
+
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
@@ -151,8 +150,6 @@ jobs:
         build-option: [ debug, release ]
     env:
       CMAKE_PREFIX_PATH: /usr/local
-      CC: clang
-      CXX: clang++
       PRESET: ci-clang-${{ matrix.build-option }}
 
     steps:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,8 +27,6 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
       LLVM_COV: llvm-cov-15
-      CC: clang-15
-      CXX: clang++-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +35,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build clang-15 lcov gcovr
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,17 @@ endif()
 # add C library
 add_subdirectory("power_grid_model_c")
 
-# get tests
-if(${PGM_ENABLE_TESTING})
+# dev build
+if(${PGM_ENABLE_DEV_BUILD})
   include(CTest)
   enable_testing()
-
+# get tests
   add_subdirectory("tests")
+  # get c api example
+add_subdirectory("power_grid_model_c_example")
 endif()
 
-# get c api example
-add_subdirectory("power_grid_model_c_example")
+
 
 # export the power grid model
 include("cmake/export_power_grid_model.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,10 @@ add_subdirectory("power_grid_model_c")
 if(${PGM_ENABLE_DEV_BUILD})
   include(CTest)
   enable_testing()
-# get tests
+  # get tests
   add_subdirectory("tests")
   # get c api example
-add_subdirectory("power_grid_model_c_example")
+  add_subdirectory("power_grid_model_c_example")
 endif()
 
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -165,31 +165,40 @@
       ]
     },
     {
+      "name": "clang-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "inherits": "unix-sanitizer",
+      "hidden": true
+    },
+    {
       "name": "clang-debug",
       "inherits": [
         "debug",
-        "unix-sanitizer"
+        "clang-base"
       ]
     },
     {
       "name": "clang-release",
       "inherits": [
         "release",
-        "unix-sanitizer"
+        "clang-base"
       ]
     },
     {
       "name": "clang-tidy-debug",
       "inherits": [
         "debug",
-        "clang-tidy-unix-base"
+        "clang-base"
       ]
     },
     {
       "name": "clang-tidy-release",
       "inherits": [
         "release",
-        "clang-tidy-unix-base"
+        "clang-base"
       ]
     },
     {
@@ -265,7 +274,7 @@
     {
       "name": "ci-sonar",
       "inherits": [
-        "unix-coverage",
+        "clang-base",
         "debug"
       ]
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -127,7 +127,9 @@
       "name": "clang-tidy-unix-base",
       "cacheVariables": {
         "CMAKE_C_CLANG_TIDY": "$env{CLANG_TIDY}",
-        "CMAKE_CXX_CLANG_TIDY": "$env{CLANG_TIDY}"
+        "CMAKE_CXX_CLANG_TIDY": "$env{CLANG_TIDY}",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
       },
       "inherits": "unix-base",
       "hidden": true
@@ -191,14 +193,14 @@
       "name": "clang-tidy-debug",
       "inherits": [
         "debug",
-        "clang-base"
+        "clang-tidy-unix-base"
       ]
     },
     {
       "name": "clang-tidy-release",
       "inherits": [
         "release",
-        "clang-base"
+        "clang-tidy-unix-base"
       ]
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -126,8 +126,8 @@
     {
       "name": "clang-tidy-unix-base",
       "cacheVariables": {
-        "CMAKE_C_CLANG_TIDY": "$env{CLANG_TIDY}",
-        "CMAKE_CXX_CLANG_TIDY": "$env{CLANG_TIDY}",
+        "CMAKE_C_CLANG_TIDY": "clang-tidy",
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++"
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
       "binaryDir": "${sourceDir}/cpp_build/${presetName}",
       "installDir": "${sourceDir}/install/${presetName}",
       "cacheVariables": {
-        "PGM_ENABLE_TESTING": "ON"
+        "PGM_ENABLE_DEV_BUILD": "ON"
       },
       "environment": {
         "PLATFORM_C_FLAGS": "",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,9 +79,9 @@
       "name": "msvc-base",
       "description": "Target Windows using the MSVC compiler.",
       "hidden": true,
-      "environment": {
-        "CC": "cl.exe",
-        "CXX": "cl.exe"
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
       },
       "inherits": "windows-base"
     },
@@ -90,9 +90,11 @@
       "description": "Target Windows using Clang with CL-like command line.",
       "hidden": true,
       "environment": {
-        "CC": "clang-cl.exe",
-        "CXX": "clang-cl.exe",
         "CXXFLAGS": "$penv{CXXFLAGS} -Wno-uninitialized-const-reference -Wno-unknown-attributes"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl.exe",
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
       },
       "inherits": "windows-base"
     },
@@ -210,6 +212,10 @@
       "name": "gcc-base",
       "environment": {
         "COMPILER_CXX_FLAGS": "$env{COMPILER_C_FLAGS} -Wno-maybe-uninitialized"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
       },
       "inherits": "unix-sanitizer",
       "hidden": true

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -128,9 +128,9 @@ In principle, you can use any C++ IDE with cmake and ninja support to develop th
 the bare CMake CLI to set up the project. For ease of use, several presets are available (CMake 3.23+). Supported presets
 for your development platform can be listed using `cmake --list-presets`.
 
-In Linux/macOS, the presets will use command `clang++`/`clang` or `gcc`/`g++` to find the relevant `gcc` or `clang` compiler. It is the developer's reponsiblity to proper define some symbolic link (which should be findable through `PATH` environment) of your actual `clang` or `gcc` compiler in your system. If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` program of your system.
+On Linux/macOS, the presets will use command `clang`/`clang++` or `gcc`/`g++` to find the relevant `clang` or `gcc` compiler. It is the developer's reponsiblity to properly define symbolic links (which should be discoverable through `PATH` environment variable) of `clang` or `gcc` compiler in your system. If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` executable of your system.
 
-Similar also applies for Windows, the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are findable in the `PATH`. For x64 Windows native development using MSVC or Clang CL, use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set the appropriate build environment.
+Similar also applies to Windows: the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are discoverable in `PATH`. For x64 Windows native development using MSVC or Clang CL, please use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set up the appropriate build environment.
 
 ## Visual Studio Code Support
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -128,9 +128,9 @@ In principle, you can use any C++ IDE with cmake and ninja support to develop th
 the bare CMake CLI to set up the project. For ease of use, several presets are available (CMake 3.23+). Supported presets
 for your development platform can be listed using `cmake --list-presets`.
 
-In Linux/macOS, the presets will use command `clang++`/`clang` or `gcc`/`g++` to find the relevant `gcc` or `clang` compiler. It is the developer's reponsiblity to proper define some symbolic link (which should be findable through `PATH` environment) of your actual `clang` or `gcc` compiler in your system.
+In Linux/macOS, the presets will use command `clang++`/`clang` or `gcc`/`g++` to find the relevant `gcc` or `clang` compiler. It is the developer's reponsiblity to proper define some symbolic link (which should be findable through `PATH` environment) of your actual `clang` or `gcc` compiler in your system. If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` program of your system.
 
-Similar also applies for Windows, the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are findable in the `PATH`. The easy way to do this is to launch your IDE from the Visual Studio command prompt.
+Similar also applies for Windows, the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are findable in the `PATH`. For x64 Windows native development using MSVC or Clang CL, use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set the appropriate build environment.
 
 ## Visual Studio Code Support
 
@@ -138,11 +138,7 @@ You can use any IDE to develop this project. As a popular cross-platform IDE, th
 
 ```{note}
 VSCode (as well as some other IDEs) does not set its own build environment itself. For optimal usage, open the folder
-using `cmake <project_dir>` from a terminal that has the environment set up. E.g.:
-
-* For x64 Windows native development using MSVC or Clang CL, use the `x64 Native Command Prompt`, which uses
-  `vcvarsall.bat` to set the appropriate build environment.
-* For Linux/WSL using the LLVM-15 `clang`, `source` or `export` `CC=clang-15`, `CXX=clang++-15` and `LLVM_COV=llvm-cov-15`. Optionally, you can `export` `CLANG_TIDY=clang-tidy-15`.
+using `cmake <project_dir>` from a terminal that has the environment set up. See above section for tips.
 ```
 
 ## Build Script for Linux/macOS

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -128,6 +128,10 @@ In principle, you can use any C++ IDE with cmake and ninja support to develop th
 the bare CMake CLI to set up the project. For ease of use, several presets are available (CMake 3.23+). Supported presets
 for your development platform can be listed using `cmake --list-presets`.
 
+In Linux/macOS, the presets will use command `clang++`/`clang` or `gcc`/`g++` to find the relevant `gcc` or `clang` compiler. It is the developer's reponsiblity to proper define some symbolic link (which should be findable through `PATH` environment) of your actual `clang` or `gcc` compiler in your system.
+
+Similar also applies for Windows, the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are findable in the `PATH`. The easy way to do this is to launch your IDE from the Visual Studio command prompt.
+
 ## Visual Studio Code Support
 
 You can use any IDE to develop this project. As a popular cross-platform IDE, the settings for Visual Studio Code is preconfigured in the folder `.vscode`. You can open the repository folder with VSCode and the configuration will be loaded automatically. 

--- a/tests/package_tests/CMakePresets.json
+++ b/tests/package_tests/CMakePresets.json
@@ -62,7 +62,7 @@
       "inherits": "base"
     },
     {
-      "name": "ci-unix",
+      "name": "unix-sanitizer",
       "environment": {
         "SANITIZER_FLAGS": "-fsanitize=address"
       },
@@ -73,9 +73,9 @@
       "name": "msvc-base",
       "description": "Target Windows using the MSVC compiler.",
       "hidden": true,
-      "environment": {
-        "CC": "cl.exe",
-        "CXX": "cl.exe"
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
       },
       "inherits": "windows-base"
     },
@@ -83,9 +83,9 @@
       "name": "clang-cl-base",
       "description": "Target Windows using Clang with CL-like command line.",
       "hidden": true,
-      "environment": {
-        "CC": "clang-cl.exe",
-        "CXX": "clang-cl.exe"
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl.exe",
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
       },
       "inherits": "windows-base"
     },
@@ -122,30 +122,50 @@
       ]
     },
     {
+      "name": "clang-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "hidden": true
+    },
+    {
+      "name": "gcc-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "hidden": true
+    },
+    {
       "name": "ci-clang-debug",
       "inherits": [
-        "ci-unix",
+        "unix-sanitizer",
+        "clang-base",
         "debug"
       ]
     },
     {
       "name": "ci-clang-release",
       "inherits": [
-        "ci-unix",
+        "unix-sanitizer",
+        "clang-base",
         "release"
       ]
     },
     {
       "name": "ci-gcc-debug",
       "inherits": [
-        "ci-unix",
+        "unix-sanitizer",
+        "gcc-base",
         "debug"
       ]
     },
     {
       "name": "ci-gcc-release",
       "inherits": [
-        "ci-unix",
+        "unix-sanitizer",
+        "gcc-base",
         "release"
       ]
     },
@@ -153,6 +173,7 @@
       "name": "ci-sonar",
       "inherits": [
         "unix-base",
+        "clang-base",
         "debug"
       ]
     }


### PR DESCRIPTION
Let Cmake presets to choose the compiler `gcc` and `clang` automatically.