### PR TITLE
temporarily remove clang cl from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         build-option: [ debug, release ]
-        compiler: [msvc, clang-cl]
+        compiler: [msvc]  # , clang-cl] TODO(mgovers): reenable Clang CL when https://github.com/actions/runner-images/issues/10001 is fixed
 
     env:
       PRESET: ${{ matrix.compiler }}-${{ matrix.build-option }}


### PR DESCRIPTION
Temporary workaround due to https://github.com/actions/runner-images/issues/10001

cfr. discussion: we're not working on C++ currently, so the risk is low.
Follow-up ticket to re-enable in #630 