### PR TITLE
Feature/columnar dataset

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -56,9 +56,6 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
     class iterator;
 
     class Proxy {
-      private:
-        using ConstProxy = ColumnarAttributeRange<T, const_dataset_t>::Proxy;
-
       public:
         using value_type = T;
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -119,7 +119,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         iterator(Idx idx, std::span<AttributeBuffer<Data> const> attribute_buffers)
             : current_{idx, attribute_buffers}, idx_{idx} {}
 
-        Idx const get_idx() const { return idx_; }
+        Idx get_idx() const { return idx_; }
 
       private:
         friend class boost::iterator_core_access;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -140,7 +140,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         : size_{size}, attribute_buffers_{std::move(attribute_buffers)} {}
     ColumnarAttributeRange(ColumnarAttributeRange::iterator begin, ColumnarAttributeRange::iterator end)
         : size_{std::distance(begin, end)},
-          start_{std::distance(get(0), begin)},
+          start_{begin->idx_},
           attribute_buffers_{begin->attribute_buffers_.begin(), begin->attribute_buffers_.end()} {
         assert(begin + std::distance(begin, end) == end);
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -69,7 +69,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         Proxy& operator=(value_type const& value)
             requires is_data_mutable_v<dataset_type>
         {
-            for (Idx attribute_idx = 0; attribute_idx < meta_attributes_.size(); ++attribute_idx) {
+            for (Idx attribute_idx = 0; attribute_idx < static_cast<Idx>(meta_attributes_.size()); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
                 char* buffer_ptr = reinterpret_cast<char*>(data_[attribute_idx]) + meta_attribute.size * idx_;
                 meta_attribute.get_value(&value, buffer_ptr, 0);
@@ -79,7 +79,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         operator value_type() const { return get(); }
         value_type get() const {
             std::remove_const_t<value_type> result{};
-            for (Idx attribute_idx = 0; attribute_idx < meta_attributes_.size(); ++attribute_idx) {
+            for (Idx attribute_idx = 0; attribute_idx < static_cast<Idx>(meta_attributes_.size()); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
                 char const* buffer_ptr =
                     reinterpret_cast<char const*>(data_[attribute_idx]) + meta_attribute.size * idx_;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -74,7 +74,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         {
             for (Idx attribute_idx = 0; attribute_idx < static_cast<Idx>(meta_attributes_.size()); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
-                char* buffer_ptr = reinterpret_cast<char*>(data_[attribute_idx]) + meta_attribute.size * idx_;
+                std::byte* buffer_ptr = reinterpret_cast<std::byte*>(data_[attribute_idx]) + meta_attribute.size * idx_;
                 meta_attribute.get_value(&value, buffer_ptr, 0);
             }
             return *this;
@@ -84,8 +84,8 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
             std::remove_const_t<value_type> result{};
             for (Idx attribute_idx = 0; attribute_idx < static_cast<Idx>(meta_attributes_.size()); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
-                char const* buffer_ptr =
-                    reinterpret_cast<char const*>(data_[attribute_idx]) + meta_attribute.size * idx_;
+                std::byte const* buffer_ptr =
+                    reinterpret_cast<std::byte const*>(data_[attribute_idx]) + meta_attribute.size * idx_;
                 meta_attribute.set_value(&result, buffer_ptr, 0);
             }
             return result;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -422,7 +422,6 @@ template <dataset_type_tag dataset_type_> class Dataset {
         ComponentInfo const& info = dataset_info_.component_info[component_idx];
         Buffer const& buffer = buffers_[component_idx];
         auto const ptr = reinterpret_cast<StructType*>(buffer.data);
-        // std::span<StructType> const total_range{ptr, ptr + info.total_elements};
         if (scenario < 0) {
             return std::span<StructType>{ptr, ptr + info.total_elements};
         }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -221,8 +221,9 @@ template <dataset_type_tag dataset_type_> class Dataset {
     Buffer const& get_buffer(Idx i) const { return buffers_[i]; }
 
     bool is_columnar(std::string_view component) const {
-        return buffers_[find_component(component, true)].data == nullptr; } 
-    bool is_columnar(Idx const i) const { return buffers_[i].data == nullptr; } 
+        return buffers_[find_component(component, true)].data == nullptr;
+    }
+    bool is_columnar(Idx const i) const { return buffers_[i].data == nullptr; }
     bool is_columnar(Buffer const& buffer) const { return buffer.data == nullptr; }
 
     Idx find_component(std::string_view component, bool required = false) const {
@@ -442,7 +443,7 @@ template <dataset_type_tag dataset_type_> class Dataset {
         // return span based on uniform or non-uniform buffer
         ComponentInfo const& info = dataset_info_.component_info[component_idx];
         Buffer const& buffer = buffers_[component_idx];
-        assert(buffer.data == nullptr);
+        assert(is_columnar(buffer));
         RangeObject<StructType> const total_range{info.total_elements, buffer.attributes};
         if (scenario < 0) {
             return total_range;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -45,7 +45,7 @@ struct ComponentInfo {
 
 struct DatasetInfo {
     bool is_batch{false};
-    Idx batch_size{0}; // for single dataset, the batch size is one
+    Idx batch_size{1}; // for single dataset, the batch size is one
     MetaDataset const* dataset{nullptr};
     std::vector<ComponentInfo> component_info;
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -109,7 +109,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         friend class iterator;
 
         MetaAttribute const& get_meta_attribute(Idx attribute_idx) const {
-            return meta_attributes_[attribute_idx].get();
+            return meta_attributes_[attribute_idx].meta_attribute.get();
         }
 
         Idx idx_{};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -117,9 +117,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
 
         iterator() = default;
         iterator(Idx idx, std::span<AttributeBuffer<Data> const> attribute_buffers)
-            : idx_{idx}, current_{idx, attribute_buffers} {}
-
-        Idx get_idx() const { return idx_; }
+            : current_{idx, attribute_buffers} {}
 
       private:
         friend class boost::iterator_core_access;
@@ -131,7 +129,6 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         constexpr void decrement() { --current_.idx_; }
         constexpr void advance(Idx n) { current_.idx_ += n; }
 
-        Idx idx_{};
         Proxy current_;
     };
 
@@ -225,11 +222,11 @@ template <dataset_type_tag dataset_type_> class Dataset {
     Buffer const& get_buffer(std::string_view component) const { return get_buffer(find_component(component, true)); }
     Buffer const& get_buffer(Idx i) const { return buffers_[i]; }
 
-    bool is_columnar(std::string_view component) const {
-        return buffers_[find_component(component, true)].data == nullptr;
+    constexpr bool is_columnar(std::string_view component) const {
+        return is_columnar(find_component(component, true));
     }
-    bool is_columnar(Idx const i) const { return buffers_[i].data == nullptr; }
-    bool is_columnar(Buffer const& buffer) const { return buffer.data == nullptr; }
+    constexpr bool is_columnar(Idx const i) const { return is_columnar(buffers_[i]); }
+    constexpr bool is_columnar(Buffer const& buffer) const { return buffer.data == nullptr; }
 
     Idx find_component(std::string_view component, bool required = false) const {
         auto const found = std::ranges::find_if(dataset_info_.component_info, [component](ComponentInfo const& x) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -136,7 +136,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
     };
 
     ColumnarAttributeRange() = default;
-    ColumnarAttributeRange(Idx size, std::vector<AttributeBuffer<Data>> attribute_buffers)
+    ColumnarAttributeRange(Idx size, std::span<AttributeBuffer<Data> const> attribute_buffers)
         : size_{size}, attribute_buffers_{std::move(attribute_buffers)} {}
     ColumnarAttributeRange(ColumnarAttributeRange::iterator begin, ColumnarAttributeRange::iterator end)
         : size_{std::distance(begin, end)},
@@ -157,7 +157,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
 
     Idx size_{};
     Idx start_{};
-    std::vector<AttributeBuffer<Data>> attribute_buffers_;
+    std::span<AttributeBuffer<Data> const> attribute_buffers_;
 };
 
 template <typename T> using const_range_object = ColumnarAttributeRange<T, const_dataset_t>;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -57,7 +57,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
 
     class Proxy {
       public:
-        using value_type = T;
+        using value_type = std::remove_const_t<T>;
 
         Proxy() = default;
         Proxy(Idx idx, std::span<Data* const> data,
@@ -84,7 +84,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
         }
         operator value_type() const { return get(); }
         value_type get() const {
-            std::remove_const_t<value_type> result{};
+            value_type result{};
             for (Idx attribute_idx = 0; attribute_idx < static_cast<Idx>(meta_attributes_.size()); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
                 Data* attribute_buffer = data_[attribute_idx];

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -117,7 +117,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
 
         iterator() = default;
         iterator(Idx idx, std::span<AttributeBuffer<Data> const> attribute_buffers)
-            : current_{idx, attribute_buffers}, idx_{idx} {}
+            : idx_{idx}, current_{idx, attribute_buffers} {}
 
         Idx get_idx() const { return idx_; }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -113,7 +113,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
       private:
         friend class boost::iterator_core_access;
 
-        constexpr auto dereference() const -> value_type const { return *&current_; }
+        constexpr auto dereference() const -> value_type { return *&current_; }
         constexpr auto dereference() -> value_type { return *&current_; }
         constexpr auto equal(iterator const& other) const {
             return current_.idx_ == other.current_.idx_ &&

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -48,7 +48,7 @@ struct DatasetInfo {
     MetaDataset const* dataset{nullptr};
     std::vector<ComponentInfo> component_info;
 };
-template <typename Data> struct AttributeBuffer {
+template <class Data> struct AttributeBuffer {
     Data* data{nullptr};
     MetaAttribute const* meta_attribute{nullptr};
     bool is_c_order{true};
@@ -223,7 +223,11 @@ template <dataset_type_tag dataset_type_> class Dataset {
     Buffer const& get_buffer(Idx i) const { return buffers_[i]; }
 
     constexpr bool is_columnar(std::string_view component) const {
-        return is_columnar(find_component(component, true));
+        Idx const idx = find_component(component, false);
+        if (idx == invalid_index) {
+            return false;
+        }
+        return is_columnar(idx);
     }
     constexpr bool is_columnar(Idx const i) const { return is_columnar(buffers_[i]); }
     constexpr bool is_columnar(Buffer const& buffer) const { return buffer.data == nullptr; }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -130,15 +130,19 @@ template <typename T> class mutable_range_object {
         Proxy& operator=(value_type const& value) {
             for (Idx attribute_idx = 0; attribute_idx < meta_attributes_.size(); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
-                meta_attribute.get_value(&value, attribute_ptr(attribute_idx, meta_attribute.size), 0);
+                char* buffer_ptr = reinterpret_cast<char*>(data_[attribute_idx]) + meta_attribute.size * idx_;
+                meta_attribute.get_value(&value, buffer_ptr, 0);
             }
             return *this;
         }
-        operator value_type() const {
+        operator value_type() const { return get(); }
+        value_type get() const {
             value_type result{};
             for (Idx attribute_idx = 0; attribute_idx < meta_attributes_.size(); ++attribute_idx) {
                 auto const& meta_attribute = get_meta_attribute(attribute_idx);
-                meta_attribute.set_value(&result, attribute_ptr(attribute_idx, meta_attribute.size), 0);
+                char const* buffer_ptr =
+                    reinterpret_cast<char const*>(data_[attribute_idx]) + meta_attribute.size * idx_;
+                meta_attribute.set_value(&result, buffer_ptr, 0);
             }
             return result;
         }
@@ -146,9 +150,6 @@ template <typename T> class mutable_range_object {
       private:
         friend class mutable_range_object<T>::iterator;
 
-        char const* attribute_ptr(Idx attribute_idx, size_t attribute_size) const {
-            return reinterpret_cast<char const*>(data_[attribute_idx]) + attribute_size * idx_;
-        };
         MetaAttribute const& get_meta_attribute(Idx attribute_idx) const {
             return meta_attributes_[attribute_idx].get();
         }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -417,18 +417,16 @@ template <dataset_type_tag dataset_type_> class Dataset {
         // return span based on uniform or non-uniform buffer
         ComponentInfo const& info = dataset_info_.component_info[component_idx];
         Buffer const& buffer = buffers_[component_idx];
-        assert(buffer.data != nullptr);
         auto const ptr = reinterpret_cast<StructType*>(buffer.data);
-        std::span<StructType> const total_range{ptr, ptr + info.total_elements};
+        // std::span<StructType> const total_range{ptr, ptr + info.total_elements};
         if (scenario < 0) {
-            return total_range;
+            return std::span<StructType>{ptr, ptr + info.total_elements};
         }
         if (info.elements_per_scenario < 0) {
-            return std::span<StructType>{total_range.begin() + buffer.indptr[scenario],
-                                         total_range.begin() + buffer.indptr[scenario + 1]};
+            return std::span<StructType>{ptr + buffer.indptr[scenario], ptr + buffer.indptr[scenario + 1]};
         }
-        return std::span<StructType>{total_range.begin() + info.elements_per_scenario * scenario,
-                                     total_range.begin() + info.elements_per_scenario * (scenario + 1)};
+        return std::span<StructType>{ptr + info.elements_per_scenario * scenario,
+                                     ptr + info.elements_per_scenario * (scenario + 1)};
     }
 
     // get non-empty columnar buffer

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -49,7 +49,7 @@ struct DatasetInfo {
     std::vector<ComponentInfo> component_info;
 
     DatasetInfo(bool is_batch, Idx batch_size, MetaDataset const* dataset)
-        : is_batch(is_batch), batch_size(batch_size), dataset(dataset), component_info() {}
+        : is_batch(is_batch), batch_size(batch_size), dataset(dataset) {}
 };
 
 template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRange {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -134,7 +134,7 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
 
     ColumnarAttributeRange() = default;
     ColumnarAttributeRange(Idx size, std::vector<AttributeBuffer<Data>> attribute_buffers)
-        : size_{size}, attribute_buffers_{attribute_buffers} {}
+        : size_{size}, attribute_buffers_{std::move(attribute_buffers)} {}
     ColumnarAttributeRange(ColumnarAttributeRange::iterator begin, ColumnarAttributeRange::iterator end)
         : size_{std::distance(begin, end)},
           attribute_buffers_{begin->attribute_buffers_.begin(), begin->attribute_buffers_.end()} {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -124,13 +124,9 @@ template <typename T, dataset_type_tag dataset_type> class ColumnarAttributeRang
       private:
         friend class boost::iterator_core_access;
 
-        constexpr auto dereference() const -> value_type { return *&current_; }
-        constexpr auto dereference() -> value_type { return *&current_; }
-        constexpr auto equal(iterator const& other) const {
-            return current_.idx_ == other.current_.idx_ &&
-                   current_.meta_attributes_.size() == other.current_.meta_attributes_.size() &&
-                   current_.meta_attributes_.begin() == other.current_.meta_attributes_.begin();
-        }
+        constexpr auto dereference() const -> value_type const& { return *&current_; }
+        constexpr auto dereference() -> value_type& { return *&current_; }
+        constexpr auto equal(iterator const& other) const { return current_.idx_ == other.current_.idx_; }
         constexpr auto distance_to(iterator const& other) const { return other.current_.idx_ - current_.idx_; }
         constexpr void increment() { ++current_.idx_; }
         constexpr void decrement() { --current_.idx_; }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -447,10 +447,11 @@ template <dataset_type_tag dataset_type_> class Dataset {
         if (scenario < 0) {
             return total_range;
         }
-        // if (info.elements_per_scenario < 0) {
-        //     return RangeObject<StructType>{ptr + buffer.indptr[scenario], ptr + buffer.indptr[scenario + 1]};
-        // }
-        return RangeObject<StructType>{total_range.begin() + scenario * info.elements_per_scenario,
+        if (info.elements_per_scenario < 0) {
+            return RangeObject<StructType>{total_range.begin() + buffer.indptr[scenario],
+                                           total_range.begin() + buffer.indptr[scenario + 1]};
+        }
+        return RangeObject<StructType>{total_range.begin() + info.elements_per_scenario * scenario,
                                        total_range.begin() + info.elements_per_scenario * (scenario + 1)};
     }
 };

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -189,6 +189,18 @@ void check_equal(A::InputType const& first, A::InputType const& second) {
 } // namespace
 } // namespace test
 
+namespace {
+template <typename DatasetType, typename BufferSpan, typename Idx>
+auto get_colummnar_element(BufferSpan const& buffer_span, Idx idx) {
+    if constexpr (std::same_as<DatasetType, ConstDataset>) {
+        static_assert(std::same_as<decltype(buffer_span[idx]), const_range_object<A::InputType const>::Proxy>);
+    } else {
+        static_assert(std::same_as<decltype(buffer_span[idx]), mutable_range_object<A::InputType>::Proxy>);
+    }
+    return static_cast<A::InputType>(buffer_span[idx]);
+}
+} // namespace
+
 TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::InputType>,
                    mutable_range_object<A::InputType>) {
     using Data = std::conditional_t<std::same_as<RangeObjectType, const_range_object<A::InputType>>, void const, void>;
@@ -645,16 +657,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                     auto const check_span = [&](auto const& buffer_span) {
                         CHECK(buffer_span.size() == total_elements);
                         for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                            auto const element = [idx, &buffer_span] {
-                                if constexpr (std::same_as<DatasetType, ConstDataset>) {
-                                    static_assert(std::same_as<decltype(buffer_span[idx]),
-                                                               const_range_object<A::InputType const>::Proxy>);
-                                } else {
-                                    static_assert(std::same_as<decltype(buffer_span[idx]),
-                                                               mutable_range_object<A::InputType>::Proxy>);
-                                }
-                                return static_cast<A::InputType>(buffer_span[idx]);
-                            }();
+                            auto const element = get_colummnar_element<DatasetType>(buffer_span, idx);
                             CHECK(element.id == id_buffer[idx]);
                             CHECK(element.a1 == a1_buffer[idx]);
                             CHECK(is_nan(element.a0));
@@ -722,16 +725,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                             }
                             CHECK(buffer_span.size() == element_number);
                             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                                auto const element = [idx, aux_idx, &buffer_span] {
-                                    if constexpr (std::same_as<DatasetType, ConstDataset>) {
-                                        static_assert(std::same_as<decltype(buffer_span[aux_idx + idx]),
-                                                                   const_range_object<A::InputType const>::Proxy>);
-                                    } else {
-                                        static_assert(std::same_as<decltype(buffer_span[aux_idx + idx]),
-                                                                   mutable_range_object<A::InputType>::Proxy>);
-                                    }
-                                    return static_cast<A::InputType>(buffer_span[aux_idx + idx]);
-                                }();
+                                auto const element = get_colummnar_element<DatasetType>(buffer_span, aux_idx + idx);
                                 CHECK(element.id == id_buffer[aux_idx + idx]);
                                 CHECK(element.a1 == a1_buffer[aux_idx + idx]);
                                 CHECK(is_nan(element.a0));
@@ -805,16 +799,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                     auto const check_span = [&](auto const& buffer_span) {
                         CHECK(buffer_span.size() == total_elements);
                         for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                            auto const element = [idx, &buffer_span] {
-                                if constexpr (std::same_as<DatasetType, ConstDataset>) {
-                                    static_assert(std::same_as<decltype(buffer_span[idx]),
-                                                               const_range_object<A::InputType const>::Proxy>);
-                                } else {
-                                    static_assert(std::same_as<decltype(buffer_span[idx]),
-                                                               mutable_range_object<A::InputType>::Proxy>);
-                                }
-                                return static_cast<A::InputType>(buffer_span[idx]);
-                            }();
+                            auto const element = get_colummnar_element<DatasetType>(buffer_span, idx);
                             CHECK(element.id == id_buffer[idx]);
                             CHECK(element.a1 == a1_buffer[idx]);
                             CHECK(is_nan(element.a0));
@@ -890,16 +875,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                         }
                         CHECK(buffer_span.size() == element_number);
                         for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                            auto const element = [idx, aux_idx, &buffer_span] {
-                                if constexpr (std::same_as<DatasetType, ConstDataset>) {
-                                    static_assert(std::same_as<decltype(buffer_span[aux_idx + idx]),
-                                                               const_range_object<A::InputType const>::Proxy>);
-                                } else {
-                                    static_assert(std::same_as<decltype(buffer_span[aux_idx + idx]),
-                                                               mutable_range_object<A::InputType>::Proxy>);
-                                }
-                                return static_cast<A::InputType>(buffer_span[aux_idx + idx]);
-                            }();
+                            auto const element = get_colummnar_element<DatasetType>(buffer_span, aux_idx + idx);
                             CHECK(element.id == id_buffer[aux_idx + idx]);
                             CHECK(element.a1 == a1_buffer[aux_idx + idx]);
                             CHECK(is_nan(element.a0));

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -803,76 +803,74 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
         }
         SUBCASE("Inhomogeneous columnar buffer") {
             SUBCASE("Single dataset") {
-                //     for (auto const elements_per_scenario : {0, 1, 2}) {
-                //         CAPTURE(elements_per_scenario);
-                //         auto const total_elements = elements_per_scenario;
+                for (auto const elements_per_scenario : {0, 1, 2}) {
+                    CAPTURE(elements_per_scenario);
+                    auto const total_elements = elements_per_scenario;
 
-                //         auto dataset = create_dataset(false, 1, dataset_type);
+                    auto dataset = create_dataset(false, 1, dataset_type);
 
-                //         auto id_buffer = std::vector<ID>(total_elements);
-                //         auto a1_buffer = std::vector<double>(total_elements);
+                    auto id_buffer = std::vector<ID>(total_elements);
+                    auto a1_buffer = std::vector<double>(total_elements);
+                    auto a_indptr = std::vector<Idx>{0, total_elements};
 
-                //         add_homogeneous_buffer(dataset, A::name, elements_per_scenario, nullptr);
+                    add_inhomogeneous_buffer(dataset, A::name, total_elements, a_indptr.data(), nullptr);
 
-                //         auto const check_span = [&](auto const& buffer_span) {
-                //             CHECK(buffer_span.size() == total_elements);
-                //             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                //                 auto const element = [idx, &buffer_span] {
-                //                     if constexpr (std::same_as<DatasetType, ConstDataset>) {
-                //                         static_assert(std::same_as<decltype(buffer_span[idx]),
-                //                                                    const_range_object<A::InputType const>::Proxy>);
-                //                     } else {
-                //                         static_assert(std::same_as<decltype(buffer_span[idx]),
-                //                                                    mutable_range_object<A::InputType>::Proxy>);
-                //                     }
-                //                     return static_cast<A::InputType>(buffer_span[idx]);
-                //                 }();
-                //                 CHECK(element.id == id_buffer[idx]);
-                //                 CHECK(element.a1 == a1_buffer[idx]);
-                //                 CHECK(is_nan(element.a0));
-                //             }
-                //         };
-                //         auto const check_all_spans = [&] {
-                //             check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>());
-                //             check_span(
-                //                 dataset.template get_columnar_buffer_span<input_getter_s,
-                //                 A>(DatasetType::invalid_index));
+                    auto const check_span = [&](auto const& buffer_span) {
+                        CHECK(buffer_span.size() == total_elements);
+                        for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
+                            auto const element = [idx, &buffer_span] {
+                                if constexpr (std::same_as<DatasetType, ConstDataset>) {
+                                    static_assert(std::same_as<decltype(buffer_span[idx]),
+                                                               const_range_object<A::InputType const>::Proxy>);
+                                } else {
+                                    static_assert(std::same_as<decltype(buffer_span[idx]),
+                                                               mutable_range_object<A::InputType>::Proxy>);
+                                }
+                                return static_cast<A::InputType>(buffer_span[idx]);
+                            }();
+                            CHECK(element.id == id_buffer[idx]);
+                            CHECK(element.a1 == a1_buffer[idx]);
+                            CHECK(is_nan(element.a0));
+                        }
+                    };
+                    auto const check_all_spans = [&] {
+                        check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>());
+                        check_span(
+                            dataset.template get_columnar_buffer_span<input_getter_s, A>(DatasetType::invalid_index));
 
-                //             check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>(0));
+                        check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>(0));
 
-                //             auto const all_scenario_spans =
-                //                 dataset.template get_columnar_buffer_span_all_scenarios<input_getter_s, A>();
-                //             CHECK(all_scenario_spans.size() == 1);
-                //             check_span(all_scenario_spans[0]);
-                //         };
+                        auto const all_scenario_spans =
+                            dataset.template get_columnar_buffer_span_all_scenarios<input_getter_s, A>();
+                        CHECK(all_scenario_spans.size() == 1);
+                        check_span(all_scenario_spans[0]);
+                    };
 
-                //         add_attribute_buffer(dataset, A::name, A::InputType::a1_name, a1_buffer.data());
-                //         add_attribute_buffer(dataset, A::name, A::InputType::id_name, id_buffer.data());
+                    add_attribute_buffer(dataset, A::name, A::InputType::a1_name, a1_buffer.data());
+                    add_attribute_buffer(dataset, A::name, A::InputType::id_name, id_buffer.data());
+                    check_all_spans();
 
-                //         check_all_spans();
+                    std::ranges::fill(id_buffer, 1);
+                    check_all_spans();
 
-                //         std::ranges::fill(id_buffer, 1);
-                //         check_all_spans();
+                    std::transform(boost::counting_iterator<ID>{0}, boost::counting_iterator<ID>{total_elements},
+                                   id_buffer.begin(), [](ID value) { return value * 2; });
+                    check_all_spans();
 
-                //         std::transform(boost::counting_iterator<ID>{0}, boost::counting_iterator<ID>{total_elements},
-                //                        id_buffer.begin(), [](ID value) { return value * 2; });
+                    std::ranges::transform(id_buffer, a1_buffer.begin(),
+                                           [](ID value) { return static_cast<double>(value); });
+                    check_all_spans();
 
-                //         check_all_spans();
-                //         std::ranges::transform(id_buffer, a1_buffer.begin(),
-                //                                [](ID value) { return static_cast<double>(value); });
-                //         check_all_spans();
-
-                //         if constexpr (!std::same_as<DatasetType, ConstDataset>) {
-                //             auto const buffer_span = dataset.template get_columnar_buffer_span<input_getter_s, A>();
-                //             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                //                 buffer_span[0] = A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
-                //                 CHECK(id_buffer.front() == -10);
-                //                 CHECK(a1_buffer.front() == -2.0);
-                //                 check_all_spans();
-                //             }
-                //         }
-                //     }
-                // }
+                    if constexpr (!std::same_as<DatasetType, ConstDataset>) {
+                        auto const buffer_span = dataset.template get_columnar_buffer_span<input_getter_s, A>();
+                        for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
+                            buffer_span[idx] = A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
+                            CHECK(id_buffer[idx] == -10);
+                            CHECK(a1_buffer[idx] == -2.0);
+                            check_all_spans();
+                        }
+                    }
+                }
             }
             SUBCASE("Batch dataset") {
                 // for (auto const batch_size : {0, 1, 2}) {

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -351,11 +351,6 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                 add_buffer(dataset, name, elements_per_scenario, total_elements, indptr_buffer, data_buffer);
             }
         };
-    auto const add_attribute_info = [&add_attribute_buffer, &fake_data](DatasetType& dataset, std::string_view name,
-                                                                        std::string_view attribute) {
-        fake_data.resize(std::max(narrow_cast<Idx>(fake_data.size()), dataset.get_component_info(name).total_elements));
-        add_attribute_buffer(dataset, name, attribute, static_cast<void*>(fake_data.data()));
-    };
 
     SUBCASE("Constructor") {
         SUBCASE("Single dataset") {

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -24,8 +24,6 @@ struct AInput {
     ID id{na_IntID};
     double a0{nan};
     double a1{nan};
-
-    bool operator==(AInput const& other) const { return this->id == other.id; }
 };
 struct AUpdate {
     static constexpr auto id_name = "id";
@@ -254,7 +252,7 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
         auto const start = total_range.begin() + 2;
         auto const stop = total_range.begin() + 4;
         RangeObjectType sub_range{start, stop};
-        CHECK(sub_range[0].get() == total_range[2].get());
+        CHECK(sub_range[0].get().id == total_range[2].get().id);
     }
 
     SUBCASE("Read access") {
@@ -745,7 +743,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                             }
                             CHECK(buffer_span.size() == element_number);
                             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                                auto const element = get_colummnar_element<DatasetType>(buffer_span, aux_idx + idx);
+                                auto const element = get_colummnar_element<DatasetType>(buffer_span, idx);
                                 CHECK(element.id == id_buffer[aux_idx + idx]);
                                 CHECK(element.a1 == a1_buffer[aux_idx + idx]);
                                 CHECK(is_nan(element.a0));
@@ -790,7 +788,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                                         dataset.template get_columnar_buffer_span<input_getter_s, A>(scenario);
                                     Idx size = buffer_span.size();
                                     for (Idx idx = 0; idx < size; ++idx) {
-                                        buffer_span[idx + (scenario * elements_per_scenario)] =
+                                        buffer_span[idx] =
                                             A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
                                         CHECK(id_buffer[idx + (scenario * elements_per_scenario)] == -10);
                                         CHECK(a1_buffer[idx + (scenario * elements_per_scenario)] == -2.0);
@@ -896,7 +894,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                         }
                         CHECK(buffer_span.size() == element_number);
                         for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
-                            auto const element = get_colummnar_element<DatasetType>(buffer_span, aux_idx + idx);
+                            auto const element = get_colummnar_element<DatasetType>(buffer_span, idx);
                             CHECK(element.id == id_buffer[aux_idx + idx]);
                             CHECK(element.a1 == a1_buffer[aux_idx + idx]);
                             CHECK(is_nan(element.a0));
@@ -941,7 +939,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                                     dataset.template get_columnar_buffer_span<input_getter_s, A>(scenario);
                                 Idx size = buffer_span.size();
                                 for (Idx idx = 0; idx < size; ++idx) {
-                                    buffer_span[idx + (a_indptr[scenario])] =
+                                    buffer_span[idx] =
                                         A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
                                     CHECK(id_buffer[idx + (a_indptr[scenario])] == -10);
                                     CHECK(a1_buffer[idx + (a_indptr[scenario])] == -2.0);

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -212,8 +212,8 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
     using Data = std::conditional_t<std::same_as<RangeObjectType, const_range_object<A::InputType>>, void const, void>;
 
     auto const& all_attributes = test_meta_data.datasets.front().get_component(A::name);
-    auto const sub_attributes = std::vector<std::reference_wrapper<MetaAttribute const>>{
-        all_attributes.get_attribute("a1"), all_attributes.get_attribute("id")};
+    auto const sub_attributes =
+        std::vector<AttributeBuffer<Data>>{all_attributes.get_attribute("a1"), all_attributes.get_attribute("id")};
 
     auto id_buffer = std::vector<ID>{0, 1, 2};
     auto a1_buffer = std::vector<double>{0.0, 1.0, nan};

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -199,18 +199,11 @@ auto get_colummnar_element(BufferSpan const& buffer_span, Idx idx) {
     return static_cast<A::InputType>(buffer_span[idx]);
 }
 
-template <typename BufferSpan> Idx get_size(BufferSpan const& buffer_span) { return buffer_span.size(); }
-
-template <typename BufferSpan> auto get_data(BufferSpan const& buffer_span) -> decltype(buffer_span.data()) {
-
-    return buffer_span.data();
-}
-
 template <typename BufferSpan>
 void check_row_span(BufferSpan const& buffer_span, Idx const& total_elements,
                     std::vector<A::InputType> const& a_buffer) {
-    CHECK(get_size(buffer_span) == total_elements);
-    CHECK(get_data(buffer_span) == a_buffer.data());
+    CHECK(std::size(buffer_span) == total_elements);
+    CHECK(std::data(buffer_span) == a_buffer.data());
 }
 } // namespace
 
@@ -245,17 +238,12 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
     };
 
     SUBCASE("Constructor") {
-        using Data =
-            std::conditional_t<std::same_as<RangeObjectType, const_range_object<A::InputType>>, void const, void>;
-
-        auto const& all_attributes = test_meta_data.datasets.front().get_component(A::name);
-
-        auto id_buffer = std::vector<ID>{0, 1, 2, 3, 4};
-        auto const total_elements = narrow_cast<Idx>(id_buffer.size());
-        AttributeBuffer<Data> const attribute_id{.data = static_cast<Data*>(id_buffer.data()),
+        id_buffer = {0, 1, 2, 3, 4};
+        auto const element_total = narrow_cast<Idx>(id_buffer.size());
+        AttributeBuffer<Data> const id_attribute{.data = static_cast<Data*>(id_buffer.data()),
                                                  .meta_attribute = &all_attributes.get_attribute("id")};
-        std::vector<AttributeBuffer<Data>> const elements{attribute_id};
-        RangeObjectType total_range{total_elements, elements};
+        std::vector<AttributeBuffer<Data>> const element{id_attribute};
+        RangeObjectType total_range{element_total, elements};
         auto const start = total_range.begin() + 2;
         auto const stop = total_range.begin() + 4;
         RangeObjectType sub_range{start, stop};

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -707,41 +707,41 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
             }
         }
         SUBCASE("Batch dataset") {
-            for (auto const batch_size : {0, 1, 2}) {
-                CAPTURE(batch_size);
-                for (auto const elements_per_scenario : {0, 1, 2}) {
-                    CAPTURE(elements_per_scenario);
-                    auto const total_elements = elements_per_scenario * batch_size;
+            // for (auto const batch_size : {0, 1, 2}) {
+            //     CAPTURE(batch_size);
+            //     for (auto const elements_per_scenario : {0, 1, 2}) {
+            //         CAPTURE(elements_per_scenario);
+            //         auto const total_elements = elements_per_scenario * batch_size;
 
-                    auto dataset = create_dataset(true, batch_size, dataset_type);
+            //         auto dataset = create_dataset(true, batch_size, dataset_type);
 
-                    auto a_buffer = std::vector<A::InputType>(total_elements);
-                    add_homogeneous_buffer(dataset, A::name, elements_per_scenario,
-                                           static_cast<void*>(a_buffer.data()));
+            //         auto a_buffer = std::vector<A::InputType>(total_elements);
+            //         add_homogeneous_buffer(dataset, A::name, elements_per_scenario,
+            //                                static_cast<void*>(a_buffer.data()));
 
-                    CHECK(dataset.template get_buffer_span<input_getter_s, A>().data() == a_buffer.data());
-                    CHECK(dataset.template get_buffer_span<input_getter_s, A>().size() == total_elements);
-                    CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).data() ==
-                          a_buffer.data());
-                    CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).size() ==
-                          total_elements);
+            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().data() == a_buffer.data());
+            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().size() == total_elements);
+            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).data() ==
+            //               a_buffer.data());
+            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).size() ==
+            //               total_elements);
 
-                    auto const all_scenario_spans = dataset.template get_buffer_span_all_scenarios<input_getter_s, A>();
-                    CHECK(all_scenario_spans.size() == batch_size);
+            //         auto const all_scenario_spans = dataset.template get_buffer_span_all_scenarios<input_getter_s, A>();
+            //         CHECK(all_scenario_spans.size() == batch_size);
 
-                    for (Idx scenario : {0, 1, 2, 3}) {
-                        CAPTURE(scenario);
-                        if (scenario < batch_size) {
-                            auto const scenario_span = dataset.template get_buffer_span<input_getter_s, A>(scenario);
+            //         for (Idx scenario : {0, 1, 2, 3}) {
+            //             CAPTURE(scenario);
+            //             if (scenario < batch_size) {
+            //                 auto const scenario_span = dataset.template get_buffer_span<input_getter_s, A>(scenario);
 
-                            CHECK(scenario_span.data() == a_buffer.data() + scenario * elements_per_scenario);
-                            CHECK(scenario_span.size() == elements_per_scenario);
-                            CHECK(all_scenario_spans[scenario].data() == scenario_span.data());
-                            CHECK(all_scenario_spans[scenario].size() == scenario_span.size());
-                        }
-                    }
-                }
-            }
+            //                 CHECK(scenario_span.data() == a_buffer.data() + scenario * elements_per_scenario);
+            //                 CHECK(scenario_span.size() == elements_per_scenario);
+            //                 CHECK(all_scenario_spans[scenario].data() == scenario_span.data());
+            //                 CHECK(all_scenario_spans[scenario].size() == scenario_span.size());
+            //             }
+            //         }
+            //     }
+            // }
         }
     }
     SUBCASE("Duplicate buffer entry") {

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -239,11 +239,11 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
 
     SUBCASE("Constructor") {
         id_buffer = {0, 1, 2, 3, 4};
-        auto const element_total = narrow_cast<Idx>(id_buffer.size());
+        auto const elements_total = narrow_cast<Idx>(id_buffer.size());
         AttributeBuffer<Data> const id_attribute{.data = static_cast<Data*>(id_buffer.data()),
                                                  .meta_attribute = &all_attributes.get_attribute("id")};
         std::vector<AttributeBuffer<Data>> const element{id_attribute};
-        RangeObjectType total_range{element_total, elements};
+        RangeObjectType total_range{elements_total, element};
         auto const start = total_range.begin() + 2;
         auto const stop = total_range.begin() + 4;
         RangeObjectType sub_range{start, stop};

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -254,9 +254,6 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
         auto const start = total_range.begin() + 1;
         auto const stop = total_range.begin() + 4;
         RangeObjectType sub_range{start, stop};
-        auto const tr0 = total_range[0].get();
-        auto const tr1 = total_range[1].get();
-        auto const sr0 = sub_range[0].get();
         CHECK(sub_range[0].get() == total_range[1].get());
     }
 

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -251,10 +251,10 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
                                                  .meta_attribute = &all_attributes.get_attribute("id")};
         std::vector<AttributeBuffer<Data>> const elements{attribute_id};
         RangeObjectType total_range{total_elements, elements};
-        auto const start = total_range.begin() + 1;
+        auto const start = total_range.begin() + 2;
         auto const stop = total_range.begin() + 4;
         RangeObjectType sub_range{start, stop};
-        CHECK(sub_range[0].get() == total_range[1].get());
+        CHECK(sub_range[0].get() == total_range[2].get());
     }
 
     SUBCASE("Read access") {

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -222,7 +222,7 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
     SUBCASE("Read access") {
         check_buffer(range_object);
         id_buffer = {2, 3, 4};
-        a1_buffer = {6.0, -2.0, 2.0, nan};
+        a1_buffer = {6.0, -2.0, nan};
         check_buffer(range_object);
     }
 

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -213,17 +213,14 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
 
     auto const& all_attributes = test_meta_data.datasets.front().get_component(A::name);
     
-    auto const sub_attributes =
-        std::vector<AttributeBuffer<Data>>{all_attributes.get_attribute("a1"), all_attributes.get_attribute("id")};
-
     auto id_buffer = std::vector<ID>{0, 1, 2};
     auto a1_buffer = std::vector<double>{0.0, 1.0, nan};
     auto const total_elements = narrow_cast<Idx>(id_buffer.size());
     REQUIRE(narrow_cast<Idx>(a1_buffer.size()) >= total_elements);
-
-    auto buffers = std::vector{static_cast<Data*>(a1_buffer.data()), static_cast<Data*>(id_buffer.data())};
-
-    RangeObjectType range_object{total_elements, buffers, sub_attributes};
+    AttributeBuffer<Data> const attribute_id{.data = static_cast<Data*>(id_buffer.data()), .meta_attribute = &all_attributes.get_attribute("id")};
+    AttributeBuffer<Data> const attribute_a1{.data = static_cast<Data*>(a1_buffer.data()), .meta_attribute = &all_attributes.get_attribute("a1")};
+    std::vector<AttributeBuffer<Data>> const elements{attribute_id, attribute_a1};
+    RangeObjectType range_object{total_elements, elements};
 
     static_assert(std::convertible_to<decltype(*range_object.begin()), A::InputType>);
 

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -726,8 +726,8 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
             //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).size() ==
             //               total_elements);
 
-            //         auto const all_scenario_spans = dataset.template get_buffer_span_all_scenarios<input_getter_s, A>();
-            //         CHECK(all_scenario_spans.size() == batch_size);
+            //         auto const all_scenario_spans = dataset.template get_buffer_span_all_scenarios<input_getter_s,
+            //         A>(); CHECK(all_scenario_spans.size() == batch_size);
 
             //         for (Idx scenario : {0, 1, 2, 3}) {
             //             CAPTURE(scenario);
@@ -743,31 +743,146 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
             //     }
             // }
         }
-    }
-    SUBCASE("Duplicate buffer entry") {
-        auto const& dataset_type = test_meta_data_all.datasets.front();
-        CAPTURE(std::string_view{dataset_type.name});
+        SUBCASE("Inhomogeneous columnar buffer") {
+            SUBCASE("Single dataset") {
+                //     for (auto const elements_per_scenario : {0, 1, 2}) {
+                //         CAPTURE(elements_per_scenario);
+                //         auto const total_elements = elements_per_scenario;
 
-        auto dataset = create_dataset(true, 0, dataset_type);
-        auto a_buffer = std::vector<A::InputType>(1);
-        auto a_indptr = std::vector<Idx>{0};
-        SUBCASE("Homogeneous buffer") {
-            add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
-            CHECK_THROWS_AS(add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data())),
-                            DatasetError);
+                //         auto dataset = create_dataset(false, 1, dataset_type);
+
+                //         auto id_buffer = std::vector<ID>(total_elements);
+                //         auto a1_buffer = std::vector<double>(total_elements);
+
+                //         add_homogeneous_buffer(dataset, A::name, elements_per_scenario, nullptr);
+
+                //         auto const check_span = [&](auto const& buffer_span) {
+                //             CHECK(buffer_span.size() == total_elements);
+                //             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
+                //                 auto const element = [idx, &buffer_span] {
+                //                     if constexpr (std::same_as<DatasetType, ConstDataset>) {
+                //                         static_assert(std::same_as<decltype(buffer_span[idx]),
+                //                                                    const_range_object<A::InputType const>::Proxy>);
+                //                     } else {
+                //                         static_assert(std::same_as<decltype(buffer_span[idx]),
+                //                                                    mutable_range_object<A::InputType>::Proxy>);
+                //                     }
+                //                     return static_cast<A::InputType>(buffer_span[idx]);
+                //                 }();
+                //                 CHECK(element.id == id_buffer[idx]);
+                //                 CHECK(element.a1 == a1_buffer[idx]);
+                //                 CHECK(is_nan(element.a0));
+                //             }
+                //         };
+                //         auto const check_all_spans = [&] {
+                //             check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>());
+                //             check_span(
+                //                 dataset.template get_columnar_buffer_span<input_getter_s,
+                //                 A>(DatasetType::invalid_index));
+
+                //             check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>(0));
+
+                //             auto const all_scenario_spans =
+                //                 dataset.template get_columnar_buffer_span_all_scenarios<input_getter_s, A>();
+                //             CHECK(all_scenario_spans.size() == 1);
+                //             check_span(all_scenario_spans[0]);
+                //         };
+
+                //         add_attribute_buffer(dataset, A::name, A::InputType::a1_name, a1_buffer.data());
+                //         add_attribute_buffer(dataset, A::name, A::InputType::id_name, id_buffer.data());
+
+                //         check_all_spans();
+
+                //         std::ranges::fill(id_buffer, 1);
+                //         check_all_spans();
+
+                //         std::transform(boost::counting_iterator<ID>{0}, boost::counting_iterator<ID>{total_elements},
+                //                        id_buffer.begin(), [](ID value) { return value * 2; });
+
+                //         check_all_spans();
+                //         std::ranges::transform(id_buffer, a1_buffer.begin(),
+                //                                [](ID value) { return static_cast<double>(value); });
+                //         check_all_spans();
+
+                //         if constexpr (!std::same_as<DatasetType, ConstDataset>) {
+                //             auto const buffer_span = dataset.template get_columnar_buffer_span<input_getter_s, A>();
+                //             for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
+                //                 buffer_span[0] = A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
+                //                 CHECK(id_buffer.front() == -10);
+                //                 CHECK(a1_buffer.front() == -2.0);
+                //                 check_all_spans();
+                //             }
+                //         }
+                //     }
+                // }
+            }
+            SUBCASE("Batch dataset") {
+                // for (auto const batch_size : {0, 1, 2}) {
+                //     CAPTURE(batch_size);
+                //     for (auto const elements_per_scenario : {0, 1, 2}) {
+                //         CAPTURE(elements_per_scenario);
+                //         auto const total_elements = elements_per_scenario * batch_size;
+
+                //         auto dataset = create_dataset(true, batch_size, dataset_type);
+
+                //         auto a_buffer = std::vector<A::InputType>(total_elements);
+                //         add_homogeneous_buffer(dataset, A::name, elements_per_scenario,
+                //                                static_cast<void*>(a_buffer.data()));
+
+                //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().data() == a_buffer.data());
+                //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().size() == total_elements);
+                //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).data()
+                //         ==
+                //               a_buffer.data());
+                //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).size()
+                //         ==
+                //               total_elements);
+
+                //         auto const all_scenario_spans = dataset.template
+                //         get_buffer_span_all_scenarios<input_getter_s, A>(); CHECK(all_scenario_spans.size() ==
+                //         batch_size);
+
+                //         for (Idx scenario : {0, 1, 2, 3}) {
+                //             CAPTURE(scenario);
+                //             if (scenario < batch_size) {
+                //                 auto const scenario_span = dataset.template get_buffer_span<input_getter_s,
+                //                 A>(scenario);
+
+                //                 CHECK(scenario_span.data() == a_buffer.data() + scenario * elements_per_scenario);
+                //                 CHECK(scenario_span.size() == elements_per_scenario);
+                //                 CHECK(all_scenario_spans[scenario].data() == scenario_span.data());
+                //                 CHECK(all_scenario_spans[scenario].size() == scenario_span.size());
+                //             }
+                //         }
+                //     }
+                // }
+            }
         }
-        SUBCASE("Inhomogeneous buffer") {
-            add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
-            CHECK_THROWS_AS(
-                add_inhomogeneous_buffer(dataset, A::name, 0, a_indptr.data(), static_cast<void*>(a_buffer.data())),
-                DatasetError);
-        }
-        SUBCASE("Mixed buffer types") {
-            auto a_indptr = std::vector<Idx>{0, 0};
-            add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
-            CHECK_THROWS_AS(
-                add_inhomogeneous_buffer(dataset, A::name, 0, a_indptr.data(), static_cast<void*>(a_buffer.data())),
-                DatasetError);
+        SUBCASE("Duplicate buffer entry") {
+            auto const& dataset_type = test_meta_data_all.datasets.front();
+            CAPTURE(std::string_view{dataset_type.name});
+
+            auto dataset = create_dataset(true, 0, dataset_type);
+            auto a_buffer = std::vector<A::InputType>(1);
+            auto a_indptr = std::vector<Idx>{0};
+            SUBCASE("Homogeneous buffer") {
+                add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
+                CHECK_THROWS_AS(add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data())),
+                                DatasetError);
+            }
+            SUBCASE("Inhomogeneous buffer") {
+                add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
+                CHECK_THROWS_AS(
+                    add_inhomogeneous_buffer(dataset, A::name, 0, a_indptr.data(), static_cast<void*>(a_buffer.data())),
+                    DatasetError);
+            }
+            SUBCASE("Mixed buffer types") {
+                auto a_indptr = std::vector<Idx>{0, 0};
+                add_homogeneous_buffer(dataset, A::name, 0, static_cast<void*>(a_buffer.data()));
+                CHECK_THROWS_AS(
+                    add_inhomogeneous_buffer(dataset, A::name, 0, a_indptr.data(), static_cast<void*>(a_buffer.data())),
+                    DatasetError);
+            }
         }
     }
 

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -212,6 +212,7 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
     using Data = std::conditional_t<std::same_as<RangeObjectType, const_range_object<A::InputType>>, void const, void>;
 
     auto const& all_attributes = test_meta_data.datasets.front().get_component(A::name);
+    
     auto const sub_attributes =
         std::vector<AttributeBuffer<Data>>{all_attributes.get_attribute("a1"), all_attributes.get_attribute("id")};
 

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -705,43 +705,80 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                     }
                 }
             }
-        }
-        SUBCASE("Batch dataset") {
-            // for (auto const batch_size : {0, 1, 2}) {
-            //     CAPTURE(batch_size);
-            //     for (auto const elements_per_scenario : {0, 1, 2}) {
-            //         CAPTURE(elements_per_scenario);
-            //         auto const total_elements = elements_per_scenario * batch_size;
+            SUBCASE("Batch dataset") {
+                for (auto const batch_size : {0, 1, 2}) { // fails for batch_size = 2. problem with duplicate attribute
+                    CAPTURE(batch_size);
+                    for (auto const elements_per_scenario : {0, 1, 2}) {
+                        CAPTURE(elements_per_scenario);
+                        auto const total_elements = elements_per_scenario * batch_size;
 
-            //         auto dataset = create_dataset(true, batch_size, dataset_type);
+                        auto dataset = create_dataset(true, batch_size, dataset_type);
 
-            //         auto a_buffer = std::vector<A::InputType>(total_elements);
-            //         add_homogeneous_buffer(dataset, A::name, elements_per_scenario,
-            //                                static_cast<void*>(a_buffer.data()));
+                        auto id_buffer = std::vector<ID>(total_elements);
+                        auto a1_buffer = std::vector<double>(total_elements);
+                        add_homogeneous_buffer(dataset, A::name, elements_per_scenario, nullptr);
 
-            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().data() == a_buffer.data());
-            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>().size() == total_elements);
-            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).data() ==
-            //               a_buffer.data());
-            //         CHECK(dataset.template get_buffer_span<input_getter_s, A>(DatasetType::invalid_index).size() ==
-            //               total_elements);
+                        auto const check_span = [&](auto const& buffer_span, Idx const& scenario = -1) {
+                            auto element_number = total_elements;
+                            Idx aux_idx = 0;
+                            if (scenario != -1) {
+                                element_number = elements_per_scenario;
+                                aux_idx = static_cast<Idx>(scenario * elements_per_scenario);
+                            }
+                            CHECK(buffer_span.size() == element_number);
+                            for (Idx idx = 0; idx < buffer_span.size(); ++idx) {
+                                auto const element = [idx, &buffer_span] {
+                                    if constexpr(std::same_as<DatasetType, ConstDataset>) {
+                                        static_assert(std::same_as<decltype(buffer_span[idx]),
+                                                                const_range_object<A::InputType const>::Proxy>);
+                                    } else {
+                                        static_assert(std::same_as<decltype(buffer_span[idx]),
+                                                                mutable_range_object<A::InputType>::Proxy>);
+                                    }
+                                    return static_cast<A::InputType>(buffer_span[idx]);
+                                }();
+                                CHECK(element.id == id_buffer[aux_idx + idx]);
+                                CHECK(element.a1 == a1_buffer[aux_idx + idx]);
+                                CHECK(is_nan(element.a0));
+                            }
+                        };
+                        auto const check_all_spans = [&] (auto const& scenario) {
+                            check_span(dataset.template get_columnar_buffer_span<input_getter_s, A>());
+                            check_span(
+                                dataset.template get_columnar_buffer_span<input_getter_s, A>(DatasetType::invalid_index));
 
-            //         auto const all_scenario_spans = dataset.template get_buffer_span_all_scenarios<input_getter_s,
-            //         A>(); CHECK(all_scenario_spans.size() == batch_size);
+                            auto const all_scenario_spans =
+                                dataset.template get_columnar_buffer_span_all_scenarios<input_getter_s, A>();
+                            CHECK(all_scenario_spans.size() == batch_size);
 
-            //         for (Idx scenario : {0, 1, 2, 3}) {
-            //             CAPTURE(scenario);
-            //             if (scenario < batch_size) {
-            //                 auto const scenario_span = dataset.template get_buffer_span<input_getter_s, A>(scenario);
+                            auto const scenario_span =
+                                dataset.template get_columnar_buffer_span<input_getter_s, A>(scenario);
+                            check_span(scenario_span, scenario);
+                            CHECK(all_scenario_spans[scenario].size() == scenario_span.size());
+                            check_span(all_scenario_spans[scenario], scenario);
+                        };
+                        for (Idx scenario : {0, 1, 2, 3}) {
+                            CAPTURE(scenario);
+                            if (scenario < batch_size) {
+                                add_attribute_buffer(dataset, A::name, A::InputType::a1_name, a1_buffer.data());
+                                add_attribute_buffer(dataset, A::name, A::InputType::id_name, id_buffer.data());
+                                check_all_spans(scenario);
 
-            //                 CHECK(scenario_span.data() == a_buffer.data() + scenario * elements_per_scenario);
-            //                 CHECK(scenario_span.size() == elements_per_scenario);
-            //                 CHECK(all_scenario_spans[scenario].data() == scenario_span.data());
-            //                 CHECK(all_scenario_spans[scenario].size() == scenario_span.size());
-            //             }
-            //         }
-            //     }
-            // }
+                                std::ranges::fill(id_buffer, 1);
+                                check_all_spans(scenario);
+
+                                std::transform(boost::counting_iterator<ID>{0}, boost::counting_iterator<ID>{total_elements},
+                                            id_buffer.begin(), [](ID value) { return value * 2; });
+                                check_all_spans(scenario);
+
+                                std::ranges::transform(id_buffer, a1_buffer.begin(),
+                                                    [](ID value) { return static_cast<double>(value); });
+                                check_all_spans(scenario);
+                            }
+                        }//missing last check. Will be added after add attributes is fixed
+                    }
+                }
+            }
         }
         SUBCASE("Inhomogeneous columnar buffer") {
             SUBCASE("Single dataset") {

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -192,11 +192,10 @@ void check_equal(A::InputType const& first, A::InputType const& second) {
 namespace {
 template <typename DatasetType, typename BufferSpan, typename Idx>
 auto get_colummnar_element(BufferSpan const& buffer_span, Idx idx) {
-    if constexpr (std::same_as<DatasetType, ConstDataset>) {
-        static_assert(std::same_as<decltype(buffer_span[idx]), const_range_object<A::InputType const>::Proxy>);
-    } else {
-        static_assert(std::same_as<decltype(buffer_span[idx]), mutable_range_object<A::InputType>::Proxy>);
-    }
+    using ProxyType =
+        std::conditional_t<std::same_as<DatasetType, ConstDataset>, const_range_object<A::InputType const>::Proxy,
+                           mutable_range_object<A::InputType>::Proxy>;
+    static_assert(std::same_as<decltype(buffer_span[idx]), ProxyType>);
     return static_cast<A::InputType>(buffer_span[idx]);
 }
 } // namespace

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -199,11 +199,18 @@ auto get_colummnar_element(BufferSpan const& buffer_span, Idx idx) {
     return static_cast<A::InputType>(buffer_span[idx]);
 }
 
+template <typename BufferSpan> Idx get_size(BufferSpan const& buffer_span) { return buffer_span.size(); }
+
+template <typename BufferSpan> auto get_data(BufferSpan const& buffer_span) -> decltype(buffer_span.data()) {
+
+    return buffer_span.data();
+}
+
 template <typename BufferSpan>
 void check_row_span(BufferSpan const& buffer_span, Idx const& total_elements,
                     std::vector<A::InputType> const& a_buffer) {
-    CHECK(buffer_span.size() == total_elements);
-    CHECK(buffer_span.data() == a_buffer.data());
+    CHECK(get_size(buffer_span) == total_elements);
+    CHECK(get_data(buffer_span) == a_buffer.data());
 }
 } // namespace
 
@@ -360,12 +367,12 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                                                         Idx* indptr, void* data) {
         add_buffer(dataset, name, -1, total_elements, indptr, data);
     };
-    auto get_data_buffer = [&fake_data](bool const& is_columnar, Idx const& total_elements) -> void* {
+    auto get_data_buffer = [&fake_data](bool const& is_columnar, Idx const& total_elements) -> Idx* {
         if (is_columnar) {
             return nullptr;
         }
         fake_data.resize(std::max(narrow_cast<Idx>(fake_data.size()), total_elements));
-        return static_cast<void*>(fake_data.data());
+        return fake_data.data();
     };
     auto get_indptr_buffer = [&fake_indptr](Idx const& elements_per_scenario, Idx const& total_elements,
                                             DatasetType const& dataset) -> Idx* {
@@ -788,8 +795,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                                         dataset.template get_columnar_buffer_span<input_getter_s, A>(scenario);
                                     Idx size = buffer_span.size();
                                     for (Idx idx = 0; idx < size; ++idx) {
-                                        buffer_span[idx] =
-                                            A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
+                                        buffer_span[idx] = A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
                                         CHECK(id_buffer[idx + (scenario * elements_per_scenario)] == -10);
                                         CHECK(a1_buffer[idx + (scenario * elements_per_scenario)] == -2.0);
                                         check_all_spans(scenario);
@@ -939,8 +945,7 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                                     dataset.template get_columnar_buffer_span<input_getter_s, A>(scenario);
                                 Idx size = buffer_span.size();
                                 for (Idx idx = 0; idx < size; ++idx) {
-                                    buffer_span[idx] =
-                                        A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
+                                    buffer_span[idx] = A::InputType{.id = -10, .a0 = -1.0, .a1 = -2.0};
                                     CHECK(id_buffer[idx + (a_indptr[scenario])] == -10);
                                     CHECK(a1_buffer[idx + (a_indptr[scenario])] == -2.0);
                                     check_all_spans(scenario);

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -359,13 +359,13 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
         fake_indptr.back() = total_elements;
         return fake_indptr.data();
     };
-    auto const add_component_info = [&add_buffer, &fake_data, &fake_indptr, &get_data_buffer, &get_indptr_buffer](
+    auto const add_component_info = [&add_buffer, &get_data_buffer, &get_indptr_buffer](
                                         DatasetType& dataset, std::string_view name, Idx elements_per_scenario,
                                         Idx total_elements, bool is_columnar = false) {
         if constexpr (std::same_as<DatasetType, WritableDataset>) {
             (void)add_buffer;
-            (void)fake_data;
-            (void)fake_indptr;
+            (void)get_data_buffer;
+            (void)get_indptr_buffer;
             dataset.add_component_info(name, elements_per_scenario, total_elements);
         } else {
             void* data_buffer = get_data_buffer(is_columnar, total_elements);

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -212,13 +212,15 @@ TEST_CASE_TEMPLATE("Test range object", RangeObjectType, const_range_object<A::I
     using Data = std::conditional_t<std::same_as<RangeObjectType, const_range_object<A::InputType>>, void const, void>;
 
     auto const& all_attributes = test_meta_data.datasets.front().get_component(A::name);
-    
+
     auto id_buffer = std::vector<ID>{0, 1, 2};
     auto a1_buffer = std::vector<double>{0.0, 1.0, nan};
     auto const total_elements = narrow_cast<Idx>(id_buffer.size());
     REQUIRE(narrow_cast<Idx>(a1_buffer.size()) >= total_elements);
-    AttributeBuffer<Data> const attribute_id{.data = static_cast<Data*>(id_buffer.data()), .meta_attribute = &all_attributes.get_attribute("id")};
-    AttributeBuffer<Data> const attribute_a1{.data = static_cast<Data*>(a1_buffer.data()), .meta_attribute = &all_attributes.get_attribute("a1")};
+    AttributeBuffer<Data> const attribute_id{.data = static_cast<Data*>(id_buffer.data()),
+                                             .meta_attribute = &all_attributes.get_attribute("id")};
+    AttributeBuffer<Data> const attribute_a1{.data = static_cast<Data*>(a1_buffer.data()),
+                                             .meta_attribute = &all_attributes.get_attribute("a1")};
     std::vector<AttributeBuffer<Data>> const elements{attribute_id, attribute_a1};
     RangeObjectType range_object{total_elements, elements};
 


### PR DESCRIPTION
Relates to #548 .

This preps the C++ core dataset for columnar data support.

TODO:

* [x] create row-like element view on columnar data using a `Proxy` pattern
  * [x] `ConstDataset` should only have a getter
  * [x] `MutableDataset` and `WritableDataset` should have both a getter and a setter
* [x] add the view of columnar object to the actual `Dataset` structure