### PR TITLE
Bugfix/dont crash on invalid homogeneous batch dataset

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -507,7 +507,9 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         std::vector<CalculationInfo> infos(n_scenarios);
 
         // lambda for sub batch calculation
-        auto sub_batch = sub_batch_calculation_(calculation_fn, result_data, update_data, exceptions, infos);
+        SequenceIdx all_scenarios_sequence;
+        auto sub_batch =
+            sub_batch_calculation_(calculation_fn, result_data, update_data, all_scenarios_sequence, exceptions, infos);
 
         batch_dispatch(sub_batch, n_scenarios, threading);
 
@@ -520,33 +522,33 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
     template <typename Calculate>
         requires std::invocable<std::remove_cvref_t<Calculate>, MainModelImpl&, MutableDataset const&, Idx>
     auto sub_batch_calculation_(Calculate&& calculation_fn, MutableDataset const& result_data,
-                                ConstDataset const& update_data, std::vector<std::string>& exceptions,
-                                std::vector<CalculationInfo>& infos) {
+                                ConstDataset const& update_data, SequenceIdx& all_scenarios_sequence,
+                                std::vector<std::string>& exceptions, std::vector<CalculationInfo>& infos) {
         // const ref of current instance
         MainModelImpl const& base_model = *this;
 
         // cache component update order if possible
         bool const is_independent = MainModelImpl::is_update_independent(update_data);
+        if (is_independent) {
+            all_scenarios_sequence = get_sequence_idx_map(update_data);
+        }
 
-        std::shared_ptr<SequenceIdx const> all_scenarios_sequence{
-            is_independent ? std::make_shared<SequenceIdx const>(get_sequence_idx_map(update_data)) : nullptr};
-
-        return [&base_model, &exceptions, &infos, &calculation_fn, &result_data, &update_data, all_scenarios_sequence,
+        return [&base_model, &exceptions, &infos, &calculation_fn, &result_data, &update_data,
+                &all_scenarios_sequence = std::as_const(all_scenarios_sequence),
                 is_independent](Idx start, Idx stride, Idx n_scenarios) {
             assert(n_scenarios <= narrow_cast<Idx>(exceptions.size()));
             assert(n_scenarios <= narrow_cast<Idx>(infos.size()));
-            assert(is_independent == (all_scenarios_sequence != nullptr));
 
             Timer const t_total(infos[start], 0000, "Total in thread");
 
-            auto const copy_model = [&base_model, &infos](Idx scenario_idx) {
-                Timer const t_copy_model(infos[scenario_idx], 1100, "Copy model");
+            auto const copy_model_functor = [&base_model, &infos](Idx scenario_idx) {
+                Timer const t_copy_model_functor(infos[scenario_idx], 1100, "Copy model");
                 return MainModelImpl{base_model};
             };
-            auto model = copy_model(start);
+            auto model = copy_model_functor(start);
 
             SequenceIdx cacheable_scenario_sequence = SequenceIdx{};
-            auto const& scenario_sequence = is_independent ? *all_scenarios_sequence : cacheable_scenario_sequence;
+            auto const& scenario_sequence = is_independent ? all_scenarios_sequence : cacheable_scenario_sequence;
             auto [setup, winddown] = scenario_update_restore(model, update_data, scenario_sequence,
                                                              cacheable_scenario_sequence, is_independent, infos);
 
@@ -556,7 +558,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                     infos[scenario_idx].merge(model.calculation_info_);
                 },
                 std::move(setup), std::move(winddown), scenario_exception_handler(model, exceptions, infos),
-                [&model, &copy_model](Idx scenario_idx) { model = copy_model(scenario_idx); });
+                [&model, &copy_model_functor](Idx scenario_idx) { model = copy_model_functor(scenario_idx); });
 
             for (Idx scenario_idx = start; scenario_idx < n_scenarios; scenario_idx += stride) {
                 Timer const t_total_single(infos[scenario_idx], 0100, "Total single calculation in thread");

--- a/tests/data/power_flow/non-existent-id-update-batch/input.json
+++ b/tests/data/power_flow/non-existent-id-update-batch/input.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.0",
+  "type": "input",
+  "is_batch": false,
+  "attributes": {},
+  "data": {
+    "node": [
+      {
+        "id": 1,
+        "u_rated": 10.0
+      },
+      {
+        "id": 2,
+        "u_rated": 10.0
+      }
+    ],
+    "line": [
+      {
+        "id": 4,
+        "from_node": 1,
+        "to_node": 2,
+        "from_status": 1,
+        "to_status": 1,
+        "r1": 0.0,
+        "x1": 1.0,
+        "c1": 0.0,
+        "tan1": 0.0,
+        "i_n": 1e3
+      }
+    ],
+    "source": [
+      {
+        "id": 6,
+        "node": 1,
+        "status": 1,
+        "u_ref": 1.0,
+        "sk": 100.0,
+        "rx_ratio": 0.0
+      }
+    ],
+    "sym_load": [
+      {
+        "id": 7,
+        "node": 2,
+        "status": 1,
+        "type": 1,
+        "p_specified": 0.0,
+        "q_specified": 0.0
+      },
+      {
+        "id": 8,
+        "node": 2,
+        "status": 1,
+        "type": 1,
+        "p_specified": 0.0,
+        "q_specified": 0.0
+      }
+    ]
+  }
+}

--- a/tests/data/power_flow/non-existent-id-update-batch/input.json.license
+++ b/tests/data/power_flow/non-existent-id-update-batch/input.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/power_flow/non-existent-id-update-batch/params.json
+++ b/tests/data/power_flow/non-existent-id-update-batch/params.json
@@ -1,0 +1,9 @@
+{
+  "calculation_method": "linear",
+  "rtol": 1e-5,
+  "atol": 1e-5,
+  "fail": {
+    "raises": "PowerGridError",
+    "reason": "Same invalid ID in update data set"
+  }
+}

--- a/tests/data/power_flow/non-existent-id-update-batch/params.json.license
+++ b/tests/data/power_flow/non-existent-id-update-batch/params.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/power_flow/non-existent-id-update-batch/sym_output_batch.json
+++ b/tests/data/power_flow/non-existent-id-update-batch/sym_output_batch.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "type": "sym_output",
+  "is_batch": true,
+  "attributes": {},
+  "data": [
+    {},
+    {}
+  ]
+}

--- a/tests/data/power_flow/non-existent-id-update-batch/sym_output_batch.json.license
+++ b/tests/data/power_flow/non-existent-id-update-batch/sym_output_batch.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/power_flow/non-existent-id-update-batch/update_batch.json
+++ b/tests/data/power_flow/non-existent-id-update-batch/update_batch.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "type": "update",
+  "is_batch": true,
+  "attributes": {},
+  "data": [
+    {
+      "sym_load": [
+        {
+          "id": -1,
+          "q_specified": 50.0
+        }
+      ]
+    },
+    {
+      "sym_load": [
+        {
+          "id": -1,
+          "q_specified": 10.0
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/power_flow/non-existent-id-update-batch/update_batch.json.license
+++ b/tests/data/power_flow/non-existent-id-update-batch/update_batch.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
## The issue

Non-caught exceptions caused by real-world update scenarios thrown by a worker thread in parallel batch calculations cause fatal crashes.

## Considerations

After investigation related to exceptions during thread creation/execution, the following findings were made:

* [x] It is possible that the main thread throws an error when creating a thread
  * [x] If this happens, stack unwinding is done
  * [x] then a joinable `std::thread` will be destructed
  * [x] this causes `std::terminate()`
  * [x] This is OK because it is of the highest severity and the PowerGridModel instance cannot continue with its current tasks
    * [x] Decision: intended behavior. the users' program crashes and we do not catch this to throw a `PowerGridError`
* [x] It is possible that a worker thread raises a exception
  * [x] Option 1: in a scenario
    * [x] this should be handled by the scenario runner and instead a `PowerGridBatchError` should be raised
    * [x] This is intended behavior
  * [x] Option 2: during creation of the thread
    * [x] Option 2a: during copy of MainModel, e.g.
      * [x] This points at a severe issue like running out of memory
      * [x] This causes `std::terminate()`
      * [x] This is intended behavior (see above)
    * [x] Option 2b: during other caching mechanisms
      * [x] This may be caused by a real-life scenario (see below)
      * [x] This causes `std::terminate()` (fatal crash).
      * [x] This is a bug: instead, it should cause an actual `PowerGridError`
      * [x] This is solved by this PR

## Preconditions

The above-mentioned bug solved in this PR arises when all of the following conditions are satisfied:
1. There is a batch calculation
2. Running in parallel with at least 2 threads (`threading=0` or `threading=x` where `x >= 2`)
3. With at least 2 scenarios
4. With homogeneous update data (all scenarios touch the same IDs)
5. And at least 1 ID in the update data is not present in the input data

These conditions trigger the following contributing factors:
* The 5th condition triggers the exception
* The 4th condition triggers throwing the exception in the setup part instead of in a scenario
* The 1st, 2nd and 3rd condition triggers throwing the exception in a worker thread

## The solution

The caching in which the exception was moved from the worker-thread setup part to all-scenario combined setup. This prevents non-handled exceptions from being raised in the worker thread
