### PR TITLE
find boost using CONFIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 include(GNUInstallDirs)
 
 find_package(Eigen3 CONFIG REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(msgpack-cxx REQUIRED)
 


### PR DESCRIPTION
Conforms to https://cmake.org/cmake/help/latest/policy/CMP0167.html

Boost 1.70 (the first version that supports `CONFIG` mode for `find_package`) was released in 2019. It is reasonable to assume all people who want to build themselves have bumped beyond that
