### PR TITLE
Feature/enable mypy for users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,11 @@ Discussion = "https://github.com/orgs/PowerGridModel/discussions"
 where = ["src"]
 namespaces = false
 
-[tool.setuptools.package-data]
-"power-grid-model" = ["py.typed"]
-
 [tool.setuptools.dynamic]
 version = {file = "PYPI_VERSION"}
+
+[tool.setuptools.package-data]
+"power_grid_model" = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ Discussion = "https://github.com/orgs/PowerGridModel/discussions"
 where = ["src"]
 namespaces = false
 
+[tool.setuptools.package-data]
+"power-grid-model" = ["py.typed"]
+
 [tool.setuptools.dynamic]
 version = {file = "PYPI_VERSION"}
 


### PR DESCRIPTION
Closes #696 

According to https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages and https://peps.python.org/pep-0561/ , this should do the trick

## To test

* [x] Setup
  * [x] Create a new `venv` and activate
  * [x] Download correct wheelhouse from latest CI build (e.g. `wheelhouse-windows` if you are on Windows)
  * [x] Unzip artifact to a location of your choice to obtain the wheelhouse
  * [x] Install `mypy` in the `venv` using `python -m pip install mypy`
  * [x] Create a simple python test file, e.g.
    ```py
    from power_grid_model import initialize_array, DatasetType, ComponentType
    initialize_array(data_type=DatasetType.input, component_type=ComponentType.node, shape=1)
    ```
* [x] Check current latest PGM version is insufficient
  * [x] Install the power-grid-model using `python -m pip install power-grid-model`
  * [x] Run `mypy` using `mypy <test_script.py>`
  * [x] See the following error:
    ```txt
    pgm-sprint-review-demo\demo_notebooks\sprint_review_2024_08_20\use_pgm.py:1: error: Skipping analyzing "power_grid_model": module is installed, but missing library stubs or py.typed marker  [import-untyped]
    pgm-sprint-review-demo\demo_notebooks\sprint_review_2024_08_20\use_pgm.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
    Found 1 error in 1 file (checked 1 source file)
    ```
* [x] Check current PR solves the issue
  * [x] Uninstall power-grid-model using `python -m pip uninstall power-grid-model`
  * [x] Install the power-grid model from this PR using `python -m pip install --no-index --find-links="<wheelhouse_location>" power-grid-model`
  * [x] Run mypy again using `mypy <test_script.py>`
  * [x] See that it runs successfully with the log
    ```
    Success: no issues found in 1 source file
    ```