### PR TITLE
Allow python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,7 @@ test-command = "pytest {package}/tests"
 # we do not support 
 #    PyPy
 #    musllinux in aarch64
-#    Python 3.13 (because NumPy is not yet compatible)
-skip = ["pp*", "*-musllinux_aarch64", "cp313-*"]
+skip = ["pp*", "*-musllinux_aarch64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
`numpy` supports now python 3.13