### PR TITLE
don't parse_skip() for very many components

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
@@ -703,7 +703,7 @@ class Deserializer {
     void parse_component(Idx component_idx) {
         if (dataset_handler_.is_row_based(component_idx)) {
             parse_component(row_based, component_idx);
-        } else {
+        } else if (!dataset_handler_.get_buffer(component_idx).attributes.empty()) {
             parse_component(columnar, component_idx);
         }
     }


### PR DESCRIPTION
Fixes very slow row-based deserialization cfr. https://github.com/PowerGridModel/power-grid-model/pull/708#discussion_r1746985416

**NOTE:** columnar deserialization is still potentially slow due to very many `parse_skip` calls when a certain column is not present

Issue was introduced in #708 

A couple issues are not yet explained and also need further investigation but are out of scope of the immediate regression mitigation:

* why does the python deserializer end up in this edge case? does it call `parse` multiple times on different components?
* how can we improve the efficiency of the deserializer when the columnar dataset contains few columns?