### PR TITLE
more efficient columnar deserialization

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -233,15 +233,19 @@ template <dataset_type_tag dataset_type_> class Dataset {
     }
     constexpr bool is_row_based(Idx const i) const { return is_row_based(buffers_[i]); }
     constexpr bool is_row_based(Buffer const& buffer) const { return buffer.data != nullptr; }
-    constexpr bool is_columnar(std::string_view component) const {
+    constexpr bool is_columnar(std::string_view component, bool with_attribute_buffers = false) const {
         Idx const idx = find_component(component, false);
         if (idx == invalid_index) {
             return false;
         }
-        return is_columnar(idx);
+        return is_columnar(idx, with_attribute_buffers);
     }
-    constexpr bool is_columnar(Idx const i) const { return !is_row_based(i); }
-    constexpr bool is_columnar(Buffer const& buffer) const { return !is_row_based(buffer); }
+    constexpr bool is_columnar(Idx const i, bool with_attribute_buffers = false) const {
+        return is_columnar(buffers_[i], with_attribute_buffers);
+    }
+    constexpr bool is_columnar(Buffer const& buffer, bool with_attribute_buffers = false) const {
+        return !is_row_based(buffer) && !(with_attribute_buffers && buffer.attributes.empty());
+    }
 
     Idx find_component(std::string_view component, bool required = false) const {
         auto const found = std::ranges::find_if(dataset_info_.component_info, [component](ComponentInfo const& x) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/common.hpp
@@ -46,6 +46,11 @@ reordered_attribute_buffers(BufferType& buffer, std::span<MetaAttribute const* c
             }
             return AttributeBuffer<void>{};
         });
+
+    if (std::ranges::all_of(result, [](auto const& attribute_buffer) { return attribute_buffer.data == nullptr; })) {
+        result = {};
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Makes deserialization more efficient compared to #708 as follows:

* for each component type in the data set
  * if there are no row-based buffers or attribute buffers set to a `WritableDataset` component buffer:
    * we skip the component entirely
    * because it is neither `row_based(*)` nor `columnar(*, with_attribute_buffers=true)` and therefore there's nothing to do
  * otherwise, for each scenario
    * for each element of the current component type in that scenario
      * if a row-based buffer is set
        * parse the element as before
      * otherwise, peek whether the current element in the serialized data
        * if it is map-like
          * enter the element and parse as before
        * otherwise, it is array-like.
          * if none of the provided attribute buffers are present in the header,
            * skip this element
          * otherwise, enter the element and parse as before
            * there is no more efficient way to do this, because it's no more efficient way to skip, e.g., 3 attributes in the msgpack data

This provides a sustainable solution compared to the one proposed in #714 

NOTE: the check `if none of the provided attribute buffers are present in the header` is done when reordering the attribute buffers and is reduced to a simple check whether it is empty. this is the best we can do because there's no more efficient way to read only a subset of the msgpack array while skipping all the rest