### PR TITLE
fix quick start

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,7 +34,6 @@ and there are no build errors, segmentation violations, undefined symbols, etc.
 The function should be imported and called by a user by running following commands:
 
 ```python
-from power_grid_model.utils import self_test
 self_test()
 ```
 
@@ -152,18 +151,7 @@ To validate the `input_data` and `update_data` for valid values, use {py:class}`
 
 ## Batch Data
 
-Optionally, we can add batch scenarios using the `update_data` argument. 
-The code below initializes a symmetric load update array with a shape of `(5, 4)`. This is in the form of $\text{number of batches} \times \text{number of components}$.
-The `update_data` is an optional argument to the {py:class}`power_grid_model.PowerGridModel` object or the calculation functions.
-
-```python
-from power_grid_model import initialize_array
-
-sym_load_update = initialize_array('update', 'sym_load', (5, 4))
-# --- Add other sym_load attributes --- 
-update_data = {
-    "sym_load": sym_load_update
-}
-
-model.calculate_power_flow(update_data=update_data)
-```
+You can calculate a (large) number of scenarios using one command and even in parallel threading.
+This is what makes Power Grid Model a powerful calculation engine.
+You need to create a batch update dataset and put it in the `update_data` argument of `calculate_power_flow`.
+Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute batch calculations.


### PR DESCRIPTION
Closes #710 

The quick start of batch calculation is removed. To demo the batch calculation properly, a full explanation on batch dataset is needed. This is too much duplication with regards to the power flow example.