### PR TITLE
Improve C and CPP API target structure

### DIFF
--- a/power_grid_model_c/power_grid_model_c/CMakeLists.txt
+++ b/power_grid_model_c/power_grid_model_c/CMakeLists.txt
@@ -19,17 +19,10 @@ target_include_directories(power_grid_model_c PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-set(PGM_PUBLIC_HEADERS
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/basics.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/buffer.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/handle.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/meta_data.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/model.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/options.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/dataset_definitions.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/serialization.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c/dataset.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/power_grid_model_c.h"
+file(
+  GLOB_RECURSE
+  pgm_c_public_headers
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
 )
 
 target_link_libraries(power_grid_model_c
@@ -37,10 +30,10 @@ target_link_libraries(power_grid_model_c
 )
 
 target_sources(power_grid_model_c PUBLIC 
-  FILE_SET pgm_public_headers 
+  FILE_SET pgm_c_public_headers 
   TYPE HEADERS 
   BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/" 
-  FILES "${PGM_PUBLIC_HEADERS}"
+  FILES "${pgm_c_public_headers}"
   )
 
 set_target_properties(power_grid_model_c PROPERTIES
@@ -53,5 +46,5 @@ set_target_properties(power_grid_model_c PROPERTIES
 install(TARGETS power_grid_model_c
   EXPORT power_grid_modelTargets
   COMPONENT power_grid_model
-  FILE_SET pgm_public_headers
+  FILE_SET pgm_c_public_headers
 )

--- a/power_grid_model_c/power_grid_model_cpp/CMakeLists.txt
+++ b/power_grid_model_c/power_grid_model_cpp/CMakeLists.txt
@@ -10,12 +10,31 @@ target_include_directories(power_grid_model_cpp INTERFACE
   $<INSTALL_INTERFACE:include>
 )
 
+file(
+  GLOB_RECURSE
+  pgm_cpp_public_headers
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+)
+
+target_link_libraries(power_grid_model_cpp
+	INTERFACE power_grid_model_c
+)
+
+target_sources(power_grid_model_cpp PUBLIC 
+  FILE_SET pgm_cpp_public_headers 
+  TYPE HEADERS 
+  BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/" 
+  FILES "${pgm_cpp_public_headers}"
+)
+
+set_target_properties(power_grid_model_cpp PROPERTIES
+  VERSION ${PGM_VERSION}
+  SOVERSION ${PGM_VERSION}
+)
+
+
 install(TARGETS power_grid_model_cpp
   EXPORT power_grid_modelTargets
   COMPONENT power_grid_model
-)
-
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-  DESTINATION include
-  FILES_MATCHING PATTERN "*.hpp"
+  FILE_SET pgm_cpp_public_headers
 )

--- a/tests/native_api_tests/CMakeLists.txt
+++ b/tests/native_api_tests/CMakeLists.txt
@@ -18,4 +18,10 @@ target_link_libraries(power_grid_model_api_tests
         doctest::doctest
 )
 
+# TODO: remove this when the API becomes stable
+target_compile_definitions(power_grid_model_api_tests
+    PRIVATE
+    PGM_ENABLE_EXPERIMENTAL
+)
+
 doctest_discover_tests(power_grid_model_api_tests)

--- a/tests/native_api_tests/test_api_meta_data.cpp
+++ b/tests/native_api_tests/test_api_meta_data.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#define PGM_ENABLE_EXPERIMENTAL
-
 #include "power_grid_model_cpp.hpp"
 
 #include <doctest/doctest.h>

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#define PGM_ENABLE_EXPERIMENTAL
-
 #include "power_grid_model_cpp.hpp"
 
 #include <power_grid_model_c/dataset_definitions.h>

--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#define PGM_ENABLE_EXPERIMENTAL
-
 #include "power_grid_model_cpp.hpp"
 
 #include <power_grid_model_c/dataset_definitions.h>

--- a/tests/package_tests/CMakeLists.txt
+++ b/tests/package_tests/CMakeLists.txt
@@ -20,7 +20,9 @@ set(PROJECT_SOURCES
 # Link against shared power_grid_model object installed by main project
 add_executable(power_grid_model_package_test ${PROJECT_SOURCES})
 target_link_libraries(power_grid_model_package_test PRIVATE power_grid_model::power_grid_model_c)
+target_link_libraries(power_grid_model_package_test PRIVATE power_grid_model::power_grid_model_cpp)
 set_target_properties(power_grid_model_package_test PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+target_compile_definitions(power_grid_model_package_test PRIVATE PGM_ENABLE_EXPERIMENTAL)
 
 install(TARGETS power_grid_model_package_test)
 install(IMPORTED_RUNTIME_ARTIFACTS power_grid_model::power_grid_model_c)

--- a/tests/package_tests/CMakeLists.txt
+++ b/tests/package_tests/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(power_grid_model_package_test ${PROJECT_SOURCES})
 target_link_libraries(power_grid_model_package_test PRIVATE power_grid_model::power_grid_model_c)
 target_link_libraries(power_grid_model_package_test PRIVATE power_grid_model::power_grid_model_cpp)
 set_target_properties(power_grid_model_package_test PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# TODO: remove this when the API becomes stable
 target_compile_definitions(power_grid_model_package_test PRIVATE PGM_ENABLE_EXPERIMENTAL)
 
 install(TARGETS power_grid_model_package_test)

--- a/tests/package_tests/test_c_api_package.cpp
+++ b/tests/package_tests/test_c_api_package.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "power_grid_model_c.h"
+#include "power_grid_model_cpp.hpp"
 
 #include <iostream>
 #include <memory>
@@ -17,8 +18,12 @@ using HandlePtr = std::unique_ptr<PGM_Handle, DeleterFunctor<&PGM_destroy_handle
 } // namespace
 
 auto main() -> int {
-    // get handle
-    HandlePtr const unique_handle{PGM_create_handle()};
-    std::cout << (unique_handle ? "Handle created: API is available.\n" : "No handle could be created.\n");
-    return unique_handle ? 0 : 1;
+    // get handle from C-API
+    HandlePtr const c_handle{PGM_create_handle()};
+    std::cout << (c_handle ? "Handle created: C-API is available.\n" : "No handle could be created.\n");
+    // get handle from C++ API
+    power_grid_model_cpp::Handle const cpp_handle{};
+    std::cout << (cpp_handle.get() ? "Handle created: C++ API is available.\n" : "No handle could be created.\n");
+    int return_code = (c_handle != nullptr) && (cpp_handle.get() != nullptr) ? 0 : 1;
+    return return_code;
 }


### PR DESCRIPTION
Several improvements:

* Headers are retrieved using `glob`.
* C and CPP API both use `FILE_SET`.
* Experimental macro define now in the `CMakeLists.txt`, with a TODO to remove them.
* `power_grid_model_cpp` now depends on `power_grid_model_c`.
* Package test also include a simple cpp header test on handle.