### PR TITLE
Feature / Add enum options to deserialize relevant attributes 

### DIFF
--- a/src/power_grid_model/__init__.py
+++ b/src/power_grid_model/__init__.py
@@ -20,3 +20,4 @@ from power_grid_model.enum import (
     TapChangingStrategy,
     WindingType,
 )
+from power_grid_model.typing import ComponentAttributeMapping

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -319,7 +319,7 @@ def compatibility_convert_row_columnar_dataset(
     Args:
         data (Dataset): dataset to convert
         data_filter (ComponentAttributeMapping): desired component and attribute mapping
-        dataset_type (DatasetType): type of dataset, input, update or (sym | asym | sc)_output
+        dataset_type (DatasetType): type of dataset (e.g., input, update or [sym | asym | sc]_output)
         available_components (list[ComponentType] | None): available components in model
 
     Returns:

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -11,7 +11,6 @@ We do not officially support this functionality and may remove features in this 
 """
 
 from copy import deepcopy
-from types import EllipsisType
 from typing import Optional, cast
 
 import numpy as np
@@ -32,7 +31,7 @@ from power_grid_model.data_types import (
     SinglePythonDataset,
     SparseBatchData,
 )
-from power_grid_model.typing import ComponentAttributeMapping, _ComponentAttributeMappingDict
+from power_grid_model.typing import ComponentAttributeMapping, _ComponentAttributeMappingDict, ComponentAttributeFilterOptions
 
 
 def is_nan(data) -> bool:
@@ -348,7 +347,7 @@ def _convert_data_to_row_or_columnar(
     data: SingleComponentData,
     comp_name: ComponentType,
     dataset_type: DatasetType,
-    attrs: set[str] | list[str] | None | EllipsisType,
+    attrs: set[str] | list[str] | None | ComponentAttributeFilterOptions,
 ) -> SingleComponentData:
     """Converts row or columnar component data to row or columnar component data as requested in `attrs`."""
     if attrs is None:
@@ -383,8 +382,8 @@ def process_data_filter(
     """
     if data_filter is None:
         processed_data_filter: _ComponentAttributeMappingDict = {ComponentType[k]: None for k in available_components}
-    elif data_filter is Ellipsis:
-        processed_data_filter = {ComponentType[k]: ... for k in available_components}
+    elif isinstance(data_filter, ComponentAttributeFilterOptions):
+        processed_data_filter = {ComponentType[k]: data_filter for k in available_components}
     elif isinstance(data_filter, (list, set)):
         processed_data_filter = {ComponentType[k]: None for k in data_filter}
     elif isinstance(data_filter, dict) and all(

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -31,7 +31,11 @@ from power_grid_model.data_types import (
     SinglePythonDataset,
     SparseBatchData,
 )
-from power_grid_model.typing import ComponentAttributeMapping, _ComponentAttributeMappingDict, ComponentAttributeFilterOptions
+from power_grid_model.typing import (
+    ComponentAttributeFilterOptions,
+    ComponentAttributeMapping,
+    _ComponentAttributeMappingDict,
+)
 
 
 def is_nan(data) -> bool:
@@ -359,7 +363,7 @@ def _convert_data_to_row_or_columnar(
         return output_array
     if isinstance(attrs, (list, set)) and len(attrs) == 0:
         return {}
-    if isinstance(attrs, EllipsisType):
+    if isinstance(attrs, ComponentAttributeFilterOptions):
         names = data.dtype.names if not is_columnar(data) else data.keys()
         return {attr: deepcopy(data[attr]) for attr in names}
     return {attr: deepcopy(data[attr]) for attr in attrs}
@@ -387,7 +391,8 @@ def process_data_filter(
     elif isinstance(data_filter, (list, set)):
         processed_data_filter = {ComponentType[k]: None for k in data_filter}
     elif isinstance(data_filter, dict) and all(
-        attrs is None or attrs is Ellipsis or isinstance(attrs, (set, list)) for attrs in data_filter.values()
+        attrs is None or isinstance(attrs, (set, list, ComponentAttributeFilterOptions))
+        for attrs in data_filter.values()
     ):
         processed_data_filter = data_filter
     else:
@@ -421,7 +426,7 @@ def validate_data_filter(
 
     unknown_attributes = {}
     for comp_name, attrs in data_filter.items():
-        if attrs is None or attrs is Ellipsis:
+        if attrs is None or isinstance(attrs, ComponentAttributeFilterOptions):
             continue
         attr_names = dataset_meta[comp_name].dtype.names
         diff = set(attrs).difference(attr_names) if attr_names is not None else set(attrs)

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -319,7 +319,7 @@ def compatibility_convert_row_columnar_dataset(
     Args:
         data (Dataset): dataset to convert
         data_filter (ComponentAttributeMapping): desired component and attribute mapping
-        dataset_type (DatasetType): type of dataset
+        dataset_type (DatasetType): type of dataset, input, update or (sym | asym | sc)_output
         available_components (list[ComponentType] | None): available components in model
 
     Returns:

--- a/src/power_grid_model/core/serialization.py
+++ b/src/power_grid_model/core/serialization.py
@@ -217,6 +217,7 @@ def json_deserialize(
 
     Args:
         data: the data to deserialize.
+        data_filter: the data filter to apply to the dataset.
 
     Raises:
         ValueError: if the data is inconsistent with the rest of the dataset or a component is unknown.

--- a/src/power_grid_model/typing.py
+++ b/src/power_grid_model/typing.py
@@ -17,7 +17,7 @@ class ComponentAttributeFilterOptions(IntEnum):
     ALL = 0
     """Filter all components/attributes"""
     RELEVANT = 1
-    """Filter only components/attributes that contain non-NaN values"""
+    """Filter only non-empty components/attributes that contain non-NaN values"""
 
 
 _ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]

--- a/src/power_grid_model/typing.py
+++ b/src/power_grid_model/typing.py
@@ -23,5 +23,9 @@ class ComponentAttributeFilterOptions(IntEnum):
 _ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]
 
 ComponentAttributeMapping = (
-    set[ComponentTypeVar] | list[ComponentTypeVar] | ComponentAttributeFilterOptions | None | _ComponentAttributeMappingDict
+    set[ComponentTypeVar]
+    | list[ComponentTypeVar]
+    | ComponentAttributeFilterOptions
+    | None
+    | _ComponentAttributeMappingDict
 )

--- a/src/power_grid_model/typing.py
+++ b/src/power_grid_model/typing.py
@@ -6,12 +6,22 @@
 Type hints for PGM. This includes all miscellaneous type hints not under dataset or dataset_definitions categories
 """
 
-from types import EllipsisType
+from enum import IntEnum
 
 from power_grid_model.core.dataset_definitions import ComponentType, ComponentTypeVar
 
-_ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | EllipsisType]
+
+class ComponentAttributeFilterOptions(IntEnum):
+    """Filter option component or attribute"""
+
+    ALL = 0
+    """Filter all components/attributes"""
+    RELEVANT = 1
+    """Filter only components/attributes that contain non-NaN values"""
+
+
+_ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]
 
 ComponentAttributeMapping = (
-    set[ComponentTypeVar] | list[ComponentTypeVar] | EllipsisType | None | _ComponentAttributeMappingDict
+    set[ComponentTypeVar] | list[ComponentTypeVar] | ComponentAttributeFilterOptions | None | _ComponentAttributeMappingDict
 )

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -431,33 +431,33 @@ def test_convert_batch_dataset_to_batch_list_invalid_type_sparse(_mock: MagicMoc
         convert_batch_dataset_to_batch_list(update_data)
 
 
-data_filter_all = ComponentAttributeFilterOptions.ALL
-data_filter_relevant = ComponentAttributeFilterOptions.RELEVANT
+DATA_FILTER_ALL = ComponentAttributeFilterOptions.ALL
+DATA_FILTER_RELEVANT = ComponentAttributeFilterOptions.RELEVANT
 
 
 @pytest.mark.parametrize(
     ("data_filter", "expected"),
     [
         (None, {CT.node: None, CT.sym_load: None, CT.source: None}),
-        (data_filter_all, {CT.node: data_filter_all, CT.sym_load: data_filter_all, CT.source: data_filter_all}),
+        (DATA_FILTER_ALL, {CT.node: DATA_FILTER_ALL, CT.sym_load: DATA_FILTER_ALL, CT.source: DATA_FILTER_ALL}),
         (
-            data_filter_relevant,
-            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant, CT.source: data_filter_relevant},
+            DATA_FILTER_RELEVANT,
+            {CT.node: DATA_FILTER_RELEVANT, CT.sym_load: DATA_FILTER_RELEVANT, CT.source: DATA_FILTER_RELEVANT},
         ),
         ([CT.node, CT.sym_load], {CT.node: None, CT.sym_load: None}),
         ({CT.node, CT.sym_load}, {CT.node: None, CT.sym_load: None}),
         ({CT.node: [], CT.sym_load: []}, {CT.node: [], CT.sym_load: []}),
         ({CT.node: [], CT.sym_load: ["p"]}, {CT.node: [], CT.sym_load: ["p"]}),
         ({CT.node: None, CT.sym_load: ["p"]}, {CT.node: None, CT.sym_load: ["p"]}),
-        ({CT.node: data_filter_all, CT.sym_load: ["p"]}, {CT.node: data_filter_all, CT.sym_load: ["p"]}),
-        ({CT.node: data_filter_relevant, CT.sym_load: ["p"]}, {CT.node: data_filter_relevant, CT.sym_load: ["p"]}),
+        ({CT.node: DATA_FILTER_ALL, CT.sym_load: ["p"]}, {CT.node: DATA_FILTER_ALL, CT.sym_load: ["p"]}),
+        ({CT.node: DATA_FILTER_RELEVANT, CT.sym_load: ["p"]}, {CT.node: DATA_FILTER_RELEVANT, CT.sym_load: ["p"]}),
         (
-            {CT.node: data_filter_all, CT.sym_load: data_filter_all},
-            {CT.node: data_filter_all, CT.sym_load: data_filter_all},
+            {CT.node: DATA_FILTER_ALL, CT.sym_load: DATA_FILTER_ALL},
+            {CT.node: DATA_FILTER_ALL, CT.sym_load: DATA_FILTER_ALL},
         ),
         (
-            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant},
-            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant},
+            {CT.node: DATA_FILTER_RELEVANT, CT.sym_load: DATA_FILTER_RELEVANT},
+            {CT.node: DATA_FILTER_RELEVANT, CT.sym_load: DATA_FILTER_RELEVANT},
         ),
         ({CT.node: ["u"], CT.sym_load: ["p"]}, {CT.node: ["u"], CT.sym_load: ["p"]}),
     ],

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -20,6 +20,7 @@ from power_grid_model._utils import (
 )
 from power_grid_model.core.dataset_definitions import ComponentType as CT, DatasetType as DT
 from power_grid_model.data_types import BatchDataset, BatchList
+from power_grid_model.typing import ComponentAttributeFilterOptions
 
 from .utils import convert_python_to_numpy
 
@@ -430,18 +431,34 @@ def test_convert_batch_dataset_to_batch_list_invalid_type_sparse(_mock: MagicMoc
         convert_batch_dataset_to_batch_list(update_data)
 
 
+data_filter_all = ComponentAttributeFilterOptions.ALL
+data_filter_relevant = ComponentAttributeFilterOptions.RELEVANT
+
+
 @pytest.mark.parametrize(
     ("data_filter", "expected"),
     [
         (None, {CT.node: None, CT.sym_load: None, CT.source: None}),
-        (..., {CT.node: ..., CT.sym_load: ..., CT.source: ...}),
+        (data_filter_all, {CT.node: data_filter_all, CT.sym_load: data_filter_all, CT.source: data_filter_all}),
+        (
+            data_filter_relevant,
+            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant, CT.source: data_filter_relevant},
+        ),
         ([CT.node, CT.sym_load], {CT.node: None, CT.sym_load: None}),
         ({CT.node, CT.sym_load}, {CT.node: None, CT.sym_load: None}),
         ({CT.node: [], CT.sym_load: []}, {CT.node: [], CT.sym_load: []}),
         ({CT.node: [], CT.sym_load: ["p"]}, {CT.node: [], CT.sym_load: ["p"]}),
         ({CT.node: None, CT.sym_load: ["p"]}, {CT.node: None, CT.sym_load: ["p"]}),
-        ({CT.node: ..., CT.sym_load: ["p"]}, {CT.node: ..., CT.sym_load: ["p"]}),
-        ({CT.node: ..., CT.sym_load: ...}, {CT.node: ..., CT.sym_load: ...}),
+        ({CT.node: data_filter_all, CT.sym_load: ["p"]}, {CT.node: data_filter_all, CT.sym_load: ["p"]}),
+        ({CT.node: data_filter_relevant, CT.sym_load: ["p"]}, {CT.node: data_filter_relevant, CT.sym_load: ["p"]}),
+        (
+            {CT.node: data_filter_all, CT.sym_load: data_filter_all},
+            {CT.node: data_filter_all, CT.sym_load: data_filter_all},
+        ),
+        (
+            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant},
+            {CT.node: data_filter_relevant, CT.sym_load: data_filter_relevant},
+        ),
         ({CT.node: ["u"], CT.sym_load: ["p"]}, {CT.node: ["u"], CT.sym_load: ["p"]}),
     ],
 )

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -353,7 +353,7 @@ def split_deserialized_dataset_into_individual_scenario(scenario_idx, deserializ
 def assert_not_a_value(value: np.ndarray):
     """Assert value contains only NaN-like values.
 
-    Depending on type, maps to np.nan, -127, na_IntID, ComponentAttributeFilterOptions
+    Depending on type, maps to np.nan, -127, na_IntID, etc.
     """
     if value.dtype.names:
         for key in value.dtype.names:

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -14,6 +14,7 @@ from power_grid_model._utils import is_columnar, is_sparse
 from power_grid_model.core.dataset_definitions import ComponentType
 from power_grid_model.core.power_grid_dataset import get_dataset_type
 from power_grid_model.data_types import BatchDataset, Dataset, SingleDataset
+from power_grid_model.typing import ComponentAttributeFilterOptions
 from power_grid_model.utils import json_deserialize, json_serialize, msgpack_deserialize, msgpack_serialize
 
 
@@ -43,7 +44,7 @@ def is_non_compact_list(data_entry):
 def is_serialized_data_type_deducible(serialized_input, data_filter) -> bool:
     """Find out if deserialization of serialized_input would contain atleast one component with row based data"""
     serialized_input_data = serialized_input["data"]
-    if not serialized_input_data or data_filter is Ellipsis:
+    if not serialized_input_data or isinstance(data_filter, ComponentAttributeFilterOptions):
         return False
     if data_filter is None:
         return True
@@ -62,27 +63,29 @@ def is_columnar_filter(data_filter, component) -> bool:
     """A function to find if a data_filter will give out row or columnar format for a component"""
     if data_filter is None:
         return False
-    if data_filter is Ellipsis:
+    if isinstance(data_filter, ComponentAttributeFilterOptions):
         return True
     return data_filter[component] is not None
 
 
 def is_attribute_filtered_out(data_filter, component, attribute) -> bool:
     """Checks if attribute is being filtered out / excluded"""
-    if data_filter is None or data_filter is Ellipsis:
+    if data_filter is None or isinstance(data_filter, ComponentAttributeFilterOptions):
         return False
 
     if component not in data_filter:
         return True
 
     return not (
-        data_filter[component] is None or data_filter[component] is Ellipsis or attribute in data_filter[component]
+        data_filter[component] is None
+        or isinstance(data_filter[component], ComponentAttributeFilterOptions)
+        or attribute in data_filter[component]
     )
 
 
 def is_component_filtered_out(data_filter, component) -> bool:
     """Checks if component is being filtered out / excluded"""
-    if data_filter is None or data_filter is Ellipsis:
+    if data_filter is None or isinstance(data_filter, ComponentAttributeFilterOptions):
         return False
     return component not in data_filter
 
@@ -307,7 +310,8 @@ def serialized_data(request):
 @pytest.fixture(
     params=[
         pytest.param(None, id="All row filter"),
-        pytest.param(..., id="All columnar filter"),
+        pytest.param(ComponentAttributeFilterOptions.ALL, id="All columnar filter"),
+        pytest.param(ComponentAttributeFilterOptions.RELEVANT, id="All relevant columnar filter"),
         pytest.param({"node": ["id"], "sym_load": ["id"]}, id="columnar filter"),
         pytest.param({"node": ["id"], "sym_load": None}, id="mixed columnar/row filter"),
         pytest.param({"node": ["id"], "shunt": None}, id="unused component filter"),
@@ -349,7 +353,7 @@ def split_deserialized_dataset_into_individual_scenario(scenario_idx, deserializ
 def assert_not_a_value(value: np.ndarray):
     """Assert value contains only NaN-like values.
 
-    Depending on type, maps to np.nan, -127, na_IntID, ...
+    Depending on type, maps to np.nan, -127, na_IntID, ComponentAttributeFilterOptions
     """
     if value.dtype.names:
         for key in value.dtype.names:

--- a/tests/unit/validation/test_batch_validation.py
+++ b/tests/unit/validation/test_batch_validation.py
@@ -8,6 +8,7 @@ import pytest
 
 from power_grid_model import DatasetType, LoadGenType, initialize_array
 from power_grid_model._utils import compatibility_convert_row_columnar_dataset
+from power_grid_model.typing import ComponentAttributeFilterOptions
 from power_grid_model.validation import validate_batch_data
 from power_grid_model.validation.errors import MultiComponentNotUniqueError, NotBooleanError
 
@@ -56,7 +57,8 @@ def original_batch_data() -> dict[str, np.ndarray]:
 
 @pytest.fixture
 def original_batch_data_columnar(original_batch_data):
-    return compatibility_convert_row_columnar_dataset(original_batch_data, Ellipsis, DatasetType.update)
+    data_filter = ComponentAttributeFilterOptions.ALL
+    return compatibility_convert_row_columnar_dataset(original_batch_data, data_filter, DatasetType.update)
 
 
 @pytest.fixture(params=["original_batch_data", "original_batch_data_columnar"])

--- a/tests/unit/validation/test_batch_validation.py
+++ b/tests/unit/validation/test_batch_validation.py
@@ -56,12 +56,22 @@ def original_batch_data() -> dict[str, np.ndarray]:
 
 
 @pytest.fixture
-def original_batch_data_columnar(original_batch_data):
-    data_filter = ComponentAttributeFilterOptions.ALL
-    return compatibility_convert_row_columnar_dataset(original_batch_data, data_filter, DatasetType.update)
+def original_batch_data_columnar_all(original_batch_data):
+    return compatibility_convert_row_columnar_dataset(
+        original_batch_data, ComponentAttributeFilterOptions.ALL, DatasetType.update
+    )
 
 
-@pytest.fixture(params=["original_batch_data", "original_batch_data_columnar"])
+@pytest.fixture
+def original_batch_data_columnar_relevant(original_batch_data):
+    return compatibility_convert_row_columnar_dataset(
+        original_batch_data, ComponentAttributeFilterOptions.RELEVANT, DatasetType.update
+    )
+
+
+@pytest.fixture(
+    params=["original_batch_data", "original_batch_data_columnar_all", "original_batch_data_columnar_relevant"]
+)
 def batch_data(request):
     return request.getfixturevalue(request.param)
 

--- a/tests/unit/validation/test_input_validation.py
+++ b/tests/unit/validation/test_input_validation.py
@@ -18,6 +18,7 @@ from power_grid_model import (
 )
 from power_grid_model._utils import compatibility_convert_row_columnar_dataset
 from power_grid_model.enum import CalculationType, FaultPhase, FaultType
+from power_grid_model.typing import ComponentAttributeFilterOptions
 from power_grid_model.validation import validate_input_data
 from power_grid_model.validation.errors import (
     FaultPhaseError,
@@ -277,7 +278,8 @@ def original_data() -> dict[ComponentType, np.ndarray]:
 
 @pytest.fixture
 def original_data_columnar(original_data):
-    return compatibility_convert_row_columnar_dataset(original_data, Ellipsis, DatasetType.input)
+    data_filter = ComponentAttributeFilterOptions.ALL
+    return compatibility_convert_row_columnar_dataset(original_data, data_filter, DatasetType.input)
 
 
 @pytest.fixture(params=["original_data", "original_data_columnar"])

--- a/tests/unit/validation/test_input_validation.py
+++ b/tests/unit/validation/test_input_validation.py
@@ -277,12 +277,20 @@ def original_data() -> dict[ComponentType, np.ndarray]:
 
 
 @pytest.fixture
-def original_data_columnar(original_data):
-    data_filter = ComponentAttributeFilterOptions.ALL
-    return compatibility_convert_row_columnar_dataset(original_data, data_filter, DatasetType.input)
+def original_data_columnar_all(original_data):
+    return compatibility_convert_row_columnar_dataset(
+        original_data, ComponentAttributeFilterOptions.ALL, DatasetType.input
+    )
 
 
-@pytest.fixture(params=["original_data", "original_data_columnar"])
+@pytest.fixture
+def original_data_columnar_relevant(original_data):
+    return compatibility_convert_row_columnar_dataset(
+        original_data, ComponentAttributeFilterOptions.RELEVANT, DatasetType.input
+    )
+
+
+@pytest.fixture(params=["original_data", "original_data_columnar_all", "original_data_columnar_relevant"])
 def input_data(request):
     return request.getfixturevalue(request.param)
 


### PR DESCRIPTION
This PR adds to the deserialization step the possibility of deserializing only relevant data (components or attributes that are not NaN or not empty). This option will be part of `IntEnum` that is defined as: 
 - `ALL`, `0`, all data
 - `RELEVANT`, `1`, all relevant data

What's included in this PR:
- [x] Remove Ellipsis and replace with the new enum
~~- [ ] Add the logic for `RELEVANT`~~
- [x] Update tests to migrate from Ellipse to new enum
~~- [ ] Update tests for `RELEVANT` logic~~

This PR is based on main but should be further tested with https://github.com/PowerGridModel/power-grid-model/pull/699