### PR TITLE
Remove static functions in CPP wrapper

### DIFF
--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
@@ -34,7 +34,7 @@ class Buffer {
         set_value(attribute, src_ptr, buffer_offset, 1, src_stride);
     }
     void set_value(MetaAttribute const* attribute, RawDataConstPtr src_ptr, Idx buffer_offset, Idx size,
-                   Idx src_stride) { // NOSONAR: no const
+                   Idx src_stride) { // NOSONAR: no-const
         handle_.call_with(PGM_buffer_set_value, attribute, buffer_.get(), src_ptr, buffer_offset, size, src_stride);
     }
 

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
@@ -21,43 +21,32 @@ class Buffer {
 
     Idx size() const { return size_; }
 
-    static void set_nan(Buffer& buffer, Idx buffer_offset, Idx size) {
-        buffer.handle_.call_with(PGM_buffer_set_nan, buffer.component_, buffer.buffer_.get(), buffer_offset, size);
+    void set_nan() { set_nan(0, size_); }
+    void set_nan(Idx buffer_offset) { set_nan(buffer_offset, 1); }
+    void set_nan(Idx buffer_offset, Idx size) {
+        handle_.call_with(PGM_buffer_set_nan, component_, buffer_.get(), buffer_offset, size);
     }
-    void set_nan() { set_nan(*this, 0, size_); }
-    void set_nan(Idx buffer_offset) { set_nan(*this, buffer_offset, 1); }
-    void set_nan(Idx buffer_offset, Idx size) { set_nan(*this, buffer_offset, size); }
 
-    static void set_value(MetaAttribute const* attribute, Buffer& buffer, // NOSONAR: no reference-to-const
-                          RawDataConstPtr src_ptr, Idx buffer_offset, Idx size, Idx src_stride) {
-        buffer.handle_.call_with(PGM_buffer_set_value, attribute, buffer.buffer_.get(), src_ptr, buffer_offset, size,
-                                 src_stride);
-    }
     void set_value(MetaAttribute const* attribute, RawDataConstPtr src_ptr, Idx src_stride) {
-        set_value(attribute, *this, src_ptr, 0, size_, src_stride);
+        set_value(attribute, src_ptr, 0, size_, src_stride);
     }
     void set_value(MetaAttribute const* attribute, RawDataConstPtr src_ptr, Idx buffer_offset, Idx src_stride) {
-        set_value(attribute, *this, src_ptr, buffer_offset, 1, src_stride);
+        set_value(attribute, src_ptr, buffer_offset, 1, src_stride);
     }
     void set_value(MetaAttribute const* attribute, RawDataConstPtr src_ptr, Idx buffer_offset, Idx size,
                    Idx src_stride) {
-        set_value(attribute, *this, src_ptr, buffer_offset, size, src_stride);
+        handle_.call_with(PGM_buffer_set_value, attribute, buffer_.get(), src_ptr, buffer_offset, size, src_stride);
     }
 
-    static void get_value(MetaAttribute const* attribute, Buffer const& buffer, RawDataPtr dest_ptr, Idx buffer_offset,
-                          Idx size, Idx dest_stride) {
-        buffer.handle_.call_with(PGM_buffer_get_value, attribute, buffer.buffer_.get(), dest_ptr, buffer_offset, size,
-                                 dest_stride);
-    }
     void get_value(MetaAttribute const* attribute, RawDataPtr dest_ptr, Idx dest_stride) const {
-        get_value(attribute, *this, dest_ptr, 0, size_, dest_stride);
+        get_value(attribute, dest_ptr, 0, size_, dest_stride);
     }
     void get_value(MetaAttribute const* attribute, RawDataPtr dest_ptr, Idx buffer_offset, Idx dest_stride) const {
-        get_value(attribute, *this, dest_ptr, buffer_offset, 1, dest_stride);
+        get_value(attribute, dest_ptr, buffer_offset, 1, dest_stride);
     }
     void get_value(MetaAttribute const* attribute, RawDataPtr dest_ptr, Idx buffer_offset, Idx size,
                    Idx dest_stride) const {
-        get_value(attribute, *this, dest_ptr, buffer_offset, size, dest_stride);
+        handle_.call_with(PGM_buffer_get_value, attribute, buffer_.get(), dest_ptr, buffer_offset, size, dest_stride);
     }
 
   private:

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/buffer.hpp
@@ -34,7 +34,7 @@ class Buffer {
         set_value(attribute, src_ptr, buffer_offset, 1, src_stride);
     }
     void set_value(MetaAttribute const* attribute, RawDataConstPtr src_ptr, Idx buffer_offset, Idx size,
-                   Idx src_stride) {
+                   Idx src_stride) { // NOSONAR: no const
         handle_.call_with(PGM_buffer_set_value, attribute, buffer_.get(), src_ptr, buffer_offset, size, src_stride);
     }
 

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
@@ -23,42 +23,25 @@ class DatasetInfo {
     DatasetInfo& operator=(const DatasetInfo&) = delete; // No copy assignment
     ~DatasetInfo() = default;
 
-    static std::string name(DatasetInfo const& info) {
-        return std::string{info.handle_.call_with(PGM_dataset_info_name, info.info_)};
-    }
-    std::string name() const { return name(*this); }
+    std::string name() const { return std::string{handle_.call_with(PGM_dataset_info_name, info_)}; }
 
-    static Idx is_batch(DatasetInfo const& info) {
-        return info.handle_.call_with(PGM_dataset_info_is_batch, info.info_);
-    }
-    Idx is_batch() const { return is_batch(*this); }
+    Idx is_batch() const { return handle_.call_with(PGM_dataset_info_is_batch, info_); }
 
-    static Idx batch_size(DatasetInfo const& info) {
-        return info.handle_.call_with(PGM_dataset_info_batch_size, info.info_);
-    }
-    Idx batch_size() const { return batch_size(*this); }
+    Idx batch_size() const { return handle_.call_with(PGM_dataset_info_batch_size, info_); }
 
-    static Idx n_components(DatasetInfo const& info) {
-        return info.handle_.call_with(PGM_dataset_info_n_components, info.info_);
-    }
-    Idx n_components() const { return n_components(*this); }
+    Idx n_components() const { return handle_.call_with(PGM_dataset_info_n_components, info_); }
 
-    static std::string component_name(DatasetInfo const& info, Idx component_idx) {
-        return std::string{info.handle_.call_with(PGM_dataset_info_component_name, info.info_, component_idx)};
+    std::string component_name(Idx component_idx) const {
+        return std::string{handle_.call_with(PGM_dataset_info_component_name, info_, component_idx)};
     }
-    std::string component_name(Idx component_idx) const { return component_name(*this, component_idx); }
 
-    static Idx component_elements_per_scenario(DatasetInfo const& info, Idx component_idx) {
-        return info.handle_.call_with(PGM_dataset_info_elements_per_scenario, info.info_, component_idx);
-    }
     Idx component_elements_per_scenario(Idx component_idx) const {
-        return component_elements_per_scenario(*this, component_idx);
+        return handle_.call_with(PGM_dataset_info_elements_per_scenario, info_, component_idx);
     }
 
-    static Idx component_total_elements(DatasetInfo const& info, Idx component_idx) {
-        return info.handle_.call_with(PGM_dataset_info_total_elements, info.info_, component_idx);
+    Idx component_total_elements(Idx component_idx) const {
+        return handle_.call_with(PGM_dataset_info_total_elements, info_, component_idx);
     }
-    Idx component_total_elements(Idx component_idx) const { return component_total_elements(*this, component_idx); }
 
   private:
     Handle handle_{};
@@ -77,42 +60,24 @@ class DatasetWritable {
 
     RawWritableDataset* get() const { return dataset_; }
 
-    static DatasetInfo const& get_info(DatasetWritable const& dataset) { return dataset.info_; }
-    DatasetInfo const& get_info() const { return get_info(*this); }
+    DatasetInfo const& get_info() const { return info_; }
 
-    static void set_buffer(DatasetWritable& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx* indptr, RawDataPtr data) {
-        dataset.handle_.call_with(PGM_dataset_writable_set_buffer, dataset.dataset_, component.c_str(), indptr, data);
-    }
     void set_buffer(std::string const& component, Idx* indptr, RawDataPtr data) {
-        set_buffer(*this, component, indptr, data);
+        handle_.call_with(PGM_dataset_writable_set_buffer, dataset_, component.c_str(), indptr, data);
     }
 
-    static void set_buffer(DatasetWritable& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx* indptr, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_writable_set_buffer, dataset.dataset_, component.c_str(), indptr,
-                                  data.get());
-    }
     void set_buffer(std::string const& component, Idx* indptr, Buffer const& data) {
-        set_buffer(*this, component, indptr, data);
+        handle_.call_with(PGM_dataset_writable_set_buffer, dataset_, component.c_str(), indptr, data.get());
     }
 
-    static void set_attribute_buffer(DatasetWritable& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, RawDataPtr data) {
-        dataset.handle_.call_with(PGM_dataset_writable_set_attribute_buffer, dataset.dataset_, component.c_str(),
-                                  attribute.c_str(), data);
-    }
     void set_attribute_buffer(std::string const& component, std::string const& attribute, RawDataPtr data) {
-        set_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_writable_set_attribute_buffer, dataset_, component.c_str(), attribute.c_str(),
+                          data);
     }
 
-    static void set_attribute_buffer(DatasetWritable& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_writable_set_attribute_buffer, dataset.dataset_, component.c_str(),
-                                  attribute.c_str(), data.get());
-    }
     void set_attribute_buffer(std::string const& component, std::string const& attribute, Buffer const& data) {
-        set_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_writable_set_attribute_buffer, dataset_, component.c_str(), attribute.c_str(),
+                          data.get());
     }
 
   private:
@@ -129,48 +94,29 @@ class DatasetMutable {
 
     RawMutableDataset* get() const { return dataset_.get(); }
 
-    static void add_buffer(DatasetMutable& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx elements_per_scenario, Idx total_elements,
-                           Idx const* indptr, RawDataPtr data) {
-        dataset.handle_.call_with(PGM_dataset_mutable_add_buffer, dataset.dataset_.get(), component.c_str(),
-                                  elements_per_scenario, total_elements, indptr, data);
-    }
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
                     RawDataPtr data) {
-        add_buffer(*this, component, elements_per_scenario, total_elements, indptr, data);
+        handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
+                          total_elements, indptr, data);
     }
 
-    static void add_buffer(DatasetMutable& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx elements_per_scenario, Idx total_elements,
-                           Idx const* indptr, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_mutable_add_buffer, dataset.dataset_.get(), component.c_str(),
-                                  elements_per_scenario, total_elements, indptr, data.get());
-    }
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
                     Buffer const& data) {
-        add_buffer(*this, component, elements_per_scenario, total_elements, indptr, data);
+        handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
+                          total_elements, indptr, data.get());
     }
 
-    static void add_attribute_buffer(DatasetMutable& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, RawDataPtr data) {
-        dataset.handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset.dataset_.get(), component.c_str(),
-                                  attribute.c_str(), data);
-    }
     void add_attribute_buffer(std::string const& component, std::string const& attribute, RawDataPtr data) {
-        add_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
+                          attribute.c_str(), data);
     }
 
-    static void add_attribute_buffer(DatasetMutable& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset.dataset_.get(), component.c_str(),
-                                  attribute.c_str(), data.get());
-    }
     void add_attribute_buffer(std::string const& component, std::string const& attribute, Buffer const& data) {
-        add_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
+                          attribute.c_str(), data.get());
     }
 
-    static DatasetInfo const& get_info(DatasetMutable const& dataset) { return dataset.info_; }
-    DatasetInfo const& get_info() const { return get_info(*this); }
+    DatasetInfo const& get_info() const { return info_; }
 
   private:
     Handle handle_{};
@@ -192,48 +138,29 @@ class DatasetConst {
 
     RawConstDataset* get() const { return dataset_.get(); }
 
-    static void add_buffer(DatasetConst& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx elements_per_scenario, Idx total_elements,
-                           Idx const* indptr, RawDataConstPtr data) {
-        dataset.handle_.call_with(PGM_dataset_const_add_buffer, dataset.dataset_.get(), component.c_str(),
-                                  elements_per_scenario, total_elements, indptr, data);
-    }
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
                     RawDataConstPtr data) {
-        add_buffer(*this, component, elements_per_scenario, total_elements, indptr, data);
+        handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
+                          total_elements, indptr, data);
     }
 
-    static void add_buffer(DatasetConst& dataset, // NOSONAR: no reference-to-const
-                           std::string const& component, Idx elements_per_scenario, Idx total_elements,
-                           Idx const* indptr, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_const_add_buffer, dataset.dataset_.get(), component.c_str(),
-                                  elements_per_scenario, total_elements, indptr, data.get());
-    }
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
                     Buffer const& data) {
-        add_buffer(*this, component, elements_per_scenario, total_elements, indptr, data);
+        handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
+                          total_elements, indptr, data.get());
     }
 
-    static void add_attribute_buffer(DatasetConst& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, RawDataConstPtr data) {
-        dataset.handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset.dataset_.get(), component.c_str(),
-                                  attribute.c_str(), data);
-    }
     void add_attribute_buffer(std::string const& component, std::string const& attribute, RawDataConstPtr data) {
-        add_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
+                          data);
     }
 
-    static void add_attribute_buffer(DatasetConst& dataset, // NOSONAR: no reference-to-const
-                                     std::string const& component, std::string const& attribute, Buffer const& data) {
-        dataset.handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset.dataset_.get(), component.c_str(),
-                                  attribute.c_str(), data.get());
-    }
     void add_attribute_buffer(std::string const& component, std::string const& attribute, Buffer const& data) {
-        add_attribute_buffer(*this, component, attribute, data);
+        handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
+                          data.get());
     }
 
-    static DatasetInfo const& get_info(DatasetConst const& dataset) { return dataset.info_; }
-    DatasetInfo const& get_info() const { return get_info(*this); }
+    DatasetInfo const& get_info() const { return info_; }
 
   private:
     Handle handle_{};

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
@@ -95,23 +95,25 @@ class DatasetMutable {
     RawMutableDataset* get() const { return dataset_.get(); }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    RawDataPtr data) {
+                    RawDataPtr data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data);
     }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    Buffer const& data) {
+                    Buffer const& data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data.get());
     }
 
-    void add_attribute_buffer(std::string const& component, std::string const& attribute, RawDataPtr data) {
+    void add_attribute_buffer(std::string const& component, std::string const& attribute,
+                              RawDataPtr data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
                           attribute.c_str(), data);
     }
 
-    void add_attribute_buffer(std::string const& component, std::string const& attribute, Buffer const& data) {
+    void add_attribute_buffer(std::string const& component, std::string const& attribute,
+                              Buffer const& data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
                           attribute.c_str(), data.get());
     }
@@ -139,23 +141,25 @@ class DatasetConst {
     RawConstDataset* get() const { return dataset_.get(); }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    RawDataConstPtr data) {
+                    RawDataConstPtr data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data);
     }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    Buffer const& data) {
+                    Buffer const& data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data.get());
     }
 
-    void add_attribute_buffer(std::string const& component, std::string const& attribute, RawDataConstPtr data) {
+    void add_attribute_buffer(std::string const& component, std::string const& attribute,
+                              RawDataConstPtr data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
                           data);
     }
 
-    void add_attribute_buffer(std::string const& component, std::string const& attribute, Buffer const& data) {
+    void add_attribute_buffer(std::string const& component, std::string const& attribute,
+                              Buffer const& data) { // NOSONAR: no const
         handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
                           data.get());
     }

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/dataset.hpp
@@ -95,25 +95,25 @@ class DatasetMutable {
     RawMutableDataset* get() const { return dataset_.get(); }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    RawDataPtr data) { // NOSONAR: no const
+                    RawDataPtr data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data);
     }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    Buffer const& data) { // NOSONAR: no const
+                    Buffer const& data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_mutable_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data.get());
     }
 
     void add_attribute_buffer(std::string const& component, std::string const& attribute,
-                              RawDataPtr data) { // NOSONAR: no const
+                              RawDataPtr data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
                           attribute.c_str(), data);
     }
 
     void add_attribute_buffer(std::string const& component, std::string const& attribute,
-                              Buffer const& data) { // NOSONAR: no const
+                              Buffer const& data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_mutable_add_attribute_buffer, dataset_.get(), component.c_str(),
                           attribute.c_str(), data.get());
     }
@@ -141,25 +141,25 @@ class DatasetConst {
     RawConstDataset* get() const { return dataset_.get(); }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    RawDataConstPtr data) { // NOSONAR: no const
+                    RawDataConstPtr data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data);
     }
 
     void add_buffer(std::string const& component, Idx elements_per_scenario, Idx total_elements, Idx const* indptr,
-                    Buffer const& data) { // NOSONAR: no const
+                    Buffer const& data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_const_add_buffer, dataset_.get(), component.c_str(), elements_per_scenario,
                           total_elements, indptr, data.get());
     }
 
     void add_attribute_buffer(std::string const& component, std::string const& attribute,
-                              RawDataConstPtr data) { // NOSONAR: no const
+                              RawDataConstPtr data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
                           data);
     }
 
     void add_attribute_buffer(std::string const& component, std::string const& attribute,
-                              Buffer const& data) { // NOSONAR: no const
+                              Buffer const& data) { // NOSONAR: no-const
         handle_.call_with(PGM_dataset_const_add_attribute_buffer, dataset_.get(), component.c_str(), attribute.c_str(),
                           data.get());
     }

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/model.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/model.hpp
@@ -37,32 +37,20 @@ class Model {
 
     PowerGridModel* get() const { return model_.get(); }
 
-    static void update(Model const& model, DatasetConst const& update_dataset) {
-        model.handle_.call_with(PGM_update_model, model.get(), update_dataset.get());
-    }
-    void update(DatasetConst const& update_dataset) const { update(*this, update_dataset); }
-
-    static void get_indexer(Model const& model, std::string const& component, Idx size, ID const* ids, Idx* indexer) {
-        model.handle_.call_with(PGM_get_indexer, model.get(), component.c_str(), size, ids, indexer);
+    void update(DatasetConst const& update_dataset) const {
+        handle_.call_with(PGM_update_model, model_.get(), update_dataset.get());
     }
 
     void get_indexer(std::string const& component, Idx size, ID const* ids, Idx* indexer) const {
-        get_indexer(*this, component, size, ids, indexer);
+        handle_.call_with(PGM_get_indexer, model_.get(), component.c_str(), size, ids, indexer);
     }
 
-    static void calculate(Model const& model, Options const& opt, DatasetMutable const& output_dataset,
-                          DatasetConst const& batch_dataset) {
-        model.handle_.call_with(PGM_calculate, model.get(), opt.get(), output_dataset.get(), batch_dataset.get());
-    }
     void calculate(Options const& opt, DatasetMutable const& output_dataset, DatasetConst const& batch_dataset) const {
-        calculate(*this, opt, output_dataset, batch_dataset);
+        handle_.call_with(PGM_calculate, model_.get(), opt.get(), output_dataset.get(), batch_dataset.get());
     }
 
-    static void calculate(Model const& model, Options const& opt, DatasetMutable const& output_dataset) {
-        model.handle_.call_with(PGM_calculate, model.get(), opt.get(), output_dataset.get(), nullptr);
-    }
     void calculate(Options const& opt, DatasetMutable const& output_dataset) const {
-        calculate(*this, opt, output_dataset);
+        handle_.call_with(PGM_calculate, model_.get(), opt.get(), output_dataset.get(), nullptr);
     }
 
   private:

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/options.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/options.hpp
@@ -18,55 +18,28 @@ class Options {
 
     RawOptions* get() const { return options_.get(); }
 
-    static void set_calculation_type(Options const& options, Idx type) {
-        options.handle_.call_with(PGM_set_calculation_type, options.get(), type);
-    }
-    void set_calculation_type(Idx type) const { set_calculation_type(*this, type); }
+    void set_calculation_type(Idx type) const { handle_.call_with(PGM_set_calculation_type, get(), type); }
 
-    static void set_calculation_method(Options const& options, Idx method) {
-        options.handle_.call_with(PGM_set_calculation_method, options.get(), method);
-    }
-    void set_calculation_method(Idx method) const { set_calculation_method(*this, method); }
+    void set_calculation_method(Idx method) const { handle_.call_with(PGM_set_calculation_method, get(), method); }
 
-    static void set_symmetric(Options const& options, Idx sym) {
-        options.handle_.call_with(PGM_set_symmetric, options.get(), sym);
-    }
-    void set_symmetric(Idx sym) const { set_symmetric(*this, sym); }
+    void set_symmetric(Idx sym) const { handle_.call_with(PGM_set_symmetric, get(), sym); }
 
-    static void set_err_tol(Options const& options, double err_tol) {
-        options.handle_.call_with(PGM_set_err_tol, options.get(), err_tol);
-    }
-    void set_err_tol(double err_tol) const { set_err_tol(*this, err_tol); }
+    void set_err_tol(double err_tol) const { handle_.call_with(PGM_set_err_tol, get(), err_tol); }
 
-    static void set_max_iter(Options const& options, Idx max_iter) {
-        options.handle_.call_with(PGM_set_max_iter, options.get(), max_iter);
-    }
-    void set_max_iter(Idx max_iter) const { set_max_iter(*this, max_iter); }
+    void set_max_iter(Idx max_iter) const { handle_.call_with(PGM_set_max_iter, get(), max_iter); }
 
-    static void set_threading(Options const& options, Idx threading) {
-        options.handle_.call_with(PGM_set_threading, options.get(), threading);
-    }
-    void set_threading(Idx threading) const { set_threading(*this, threading); }
+    void set_threading(Idx threading) const { handle_.call_with(PGM_set_threading, get(), threading); }
 
-    static void set_short_circuit_voltage_scaling(Options const& options, Idx short_circuit_voltage_scaling) {
-        options.handle_.call_with(PGM_set_short_circuit_voltage_scaling, options.get(), short_circuit_voltage_scaling);
-    }
     void set_short_circuit_voltage_scaling(Idx short_circuit_voltage_scaling) const {
-        set_short_circuit_voltage_scaling(*this, short_circuit_voltage_scaling);
+        handle_.call_with(PGM_set_short_circuit_voltage_scaling, get(), short_circuit_voltage_scaling);
     }
 
-    static void set_tap_changing_strategy(Options const& options, Idx tap_changing_strategy) {
-        options.handle_.call_with(PGM_set_tap_changing_strategy, options.get(), tap_changing_strategy);
-    }
     void set_tap_changing_strategy(Idx tap_changing_strategy) const {
-        set_tap_changing_strategy(*this, tap_changing_strategy);
+        handle_.call_with(PGM_set_tap_changing_strategy, get(), tap_changing_strategy);
     }
 
-    static void set_experimental_features(Options const& options, Idx experimental_features) {
-        options.handle_.call_with(PGM_set_experimental_features, options.get(), experimental_features);
-    }
     void set_experimental_features(Idx experimental_features) const {
-        set_experimental_features(*this, experimental_features);
+        handle_.call_with(PGM_set_experimental_features, get(), experimental_features);
     }
 
   private:


### PR DESCRIPTION
As decided, remove `static` functions in the CPP wrapper.