### PR TITLE
Feature/Update reuse

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.2
+    rev: v4.0.0
     hooks:
       - id: reuse
   - repo: https://github.com/pycqa/isort

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,8 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: power-grid-model
-Upstream-Contact: Power Grid Model project <powergridmodel@lfenergy.org>
-Source: https://github.com/PowerGridModel/power-grid-model
-
-Files: ./*
-Copyright: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
-License: MPL-2.0

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 version = 1
 SPDX-PackageName = "power-grid-model"
 SPDX-PackageSupplier = "Power Grid Model project <powergridmodel@lfenergy.org>"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,10 @@
+version = 1
+SPDX-PackageName = "power-grid-model"
+SPDX-PackageSupplier = "Power Grid Model project <powergridmodel@lfenergy.org>"
+SPDX-PackageDownloadLocation = "https://github.com/PowerGridModel/power-grid-model"
+
+[[annotations]]
+path = "./**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>"
+SPDX-License-Identifier = "MPL-2.0"


### PR DESCRIPTION
There is a new release of the reuse-tool (https://github.com/fsfe/reuse-tool/releases/tag/v4.0.0), which makes `.reuse/dep5` deprecated and it is replaced by `REUSE.toml`.

This PR updates to to reuse 4.0.0 and adds `REUSE.toml` with `reuse convert-dep5` command.
