### PR TITLE
Bump actions ubuntu 24.04

### DIFF
--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -5,7 +5,7 @@
 name: conda-pgm-env
 dependencies:
   # build env
-  - python=3.12
+  - python=3.11
   - pip
   - wheel
   - setuptools

--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -5,7 +5,7 @@
 name: conda-pgm-env
 dependencies:
   # build env
-  - python=3.11
+  - python=3.12
   - pip
   - wheel
   - setuptools

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Install and run clang-format
         run: |
-          sudo apt-get update && sudo apt-get install -y clang-format-15
-          find . -regex '.*\.\(h\|c\|cpp\|hpp\|cc\|cxx\)' -exec clang-format-15 -style=file -i {} \;
+          sudo apt-get update && sudo apt-get install -y clang-format-18
+          find . -regex '.*\.\(h\|c\|cpp\|hpp\|cc\|cxx\)' -exec clang-format-18 -style=file -i {} \;
 
       - name: If needed raise error
         run: |

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Install and run clang-format
         run: |
-          sudo apt-get update && sudo apt-get install -y clang-format-18
-          find . -regex '.*\.\(h\|c\|cpp\|hpp\|cc\|cxx\)' -exec clang-format-18 -style=file -i {} \;
+          sudo apt-get update && sudo apt-get install -y clang-format-15
+          find . -regex '.*\.\(h\|c\|cpp\|hpp\|cc\|cxx\)' -exec clang-format-15 -style=file -i {} \;
 
       - name: If needed raise error
         run: |

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   check-code-quality:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Upgrade pip
         run: pip install --upgrade pip

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
 
       - name: Upgrade pip
         run: pip install --upgrade pip

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -31,5 +31,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+    - name: Install R
+      run: |
+        sudo apt-get update && sudo apt-get install -y r-base
     - name: Validate CITATION.cff
       uses: dieghernan/cff-validator@v3

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   validate-citations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build-option: [ debug, release ]

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 clang-tidy-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo apt-get install -y ninja-build clang-18 clang-tidy-15
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
           sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build-option: [ debug, release ]
@@ -60,10 +60,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-18 clang-tidy-18
-          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
+          sudo apt-get install -y ninja-build clang-15 clang-tidy-15
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-18 clang-tidy-15
+          sudo apt-get install -y ninja-build clang-18 clang-tidy-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
+          sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-18 clang-tidy-18
-          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
+          sudo apt-get install -y ninja-build clang-15 clang-tidy-15
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build clang-18 clang-tidy-15
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
           sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
 
       - name: Enable brew

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 clang-tidy-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/clang-tidy-15 /usr/local/bin/clang-tidy
+          sudo apt-get install -y ninja-build clang-18 clang-tidy-18
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
 
       - name: Enable brew
         run: |

--- a/.github/workflows/dco-merge-group.yml
+++ b/.github/workflows/dco-merge-group.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   dco-merge-group:
     name: DCO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: "Workaround for DCO on merge groups"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Set PyPI Version
         run: |
@@ -287,7 +287,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
           architecture: x64
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Set PyPI Version
         run: |
@@ -287,7 +287,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           architecture: x64
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
   acquire-python-version-build-sdist:
     name: Build sdist and set version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -69,7 +69,7 @@ jobs:
           path: ./wheelhouse/*.tar.gz
 
   build-cpp-test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build-option: [ debug, release ]
@@ -185,10 +185,10 @@ jobs:
         platform: [ linux-x64, linux-aarch64, macos, windows ]
         include:
           - platform: linux-x64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cibw_build: "*_x86_64"
           - platform: linux-aarch64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cibw_build: "*_aarch64"
           - platform: macos
             os: macos-14
@@ -209,7 +209,7 @@ jobs:
           path: .
 
       - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up XCode
@@ -268,7 +268,7 @@ jobs:
     needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]
     # always run publish job but fail at the first step if previous jobs have been failed
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
+          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
-          sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
+          sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
 
       - name: Enable brew
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
+          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
-          sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
+          sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
 
       - name: Enable brew
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
           sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
           sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
+          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
-          sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
+          sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
 
       - name: Enable brew
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-15
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
           sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
           sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-18
-          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
+          sudo apt-get install -y ninja-build gcc-12 g++-12 clang-15
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
           sudo ln -s /usr/bin/gcc-12 /usr/local/bin/gcc
           sudo ln -s /usr/bin/g++-12 /usr/local/bin/g++
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
           sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
           sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
 

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   reuse-compliance-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      LLVM_COV: llvm-cov-15
+      LLVM_COV: llvm-cov-18
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
         

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ jobs:
   sonar-cloud:
     if: (github.event_name == 'push') || (!startsWith(github.head_ref, 'release'))
     name: SonarCloud
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      LLVM_COV: llvm-cov-15
+      LLVM_COV: llvm-cov-18
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 lcov gcovr
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo apt-get install -y ninja-build clang-18 lcov gcovr
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build clang-18 lcov gcovr
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
+          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-15 lcov gcovr
-          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo apt-get install -y ninja-build clang-18 lcov gcovr
+          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
       - name: Enable brew
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew
-      LLVM_COV: llvm-cov-18
+      LLVM_COV: llvm-cov-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
         

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-18 lcov gcovr
-          sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
+          sudo apt-get install -y ninja-build clang-15 lcov gcovr
+          sudo ln -s /usr/bin/clang-15 /usr/local/bin/clang
+          sudo ln -s /usr/bin/clang++-15 /usr/local/bin/clang++
       - name: Enable brew
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
         

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.3
+    rev: v15.0.7
     hooks:
       - id: clang-format
         types_or: [ c++, c ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7
+    rev: v18.1.3
     hooks:
       - id: clang-format
         types_or: [ c++, c ]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ sphinx:
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.12"
+    python: "3.11"
   jobs:
     post_install:
       # Build package with doc requirements from pyproject.optional-dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
   jobs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ sphinx:
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     post_install:
       # Build package with doc requirements from pyproject.optional-dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.11"
   jobs:

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -210,7 +210,7 @@ Append the following lines into the file `${HOME}/.bashrc`.
 export CXX=clang++-18            # or g++-13
 export CC=clang-18               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
-export LLVM_COV=llvm-cov-15
+export LLVM_COV=llvm-cov-18
 export CLANG_TIDY=clang-tidy-18  # only if you want to use one of the clang-tidy presets
 ```
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -210,7 +210,7 @@ Append the following lines into the file `${HOME}/.bashrc`.
 export CXX=clang++-18            # or g++-13
 export CC=clang-18               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
-export LLVM_COV=llvm-cov-15
+export LLVM_COV=llvm-cov-18
 export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets
 ```
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -46,8 +46,8 @@ You need a C++ compiler with C++20 support. Below is a list of tested compilers:
   * Version 12.x tested using the musllinux build with custom compiler
   * Version 13.x tested in CI
 * Clang >= 15.0
-  * Version 15.x tested in CI
-  * Version 15.x tested in CI with code quality checks
+  * Version 18.x tested in CI
+  * Version 18.x tested in CI with code quality checks
 
 You can define the environment variable `CXX` to for example `clang++` to specify the C++ compiler.
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -207,11 +207,11 @@ WSL), or in a physical/virtual machine.
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-18            # or g++-13
-export CC=clang-18               # gcc-13
+export CXX=clang++-15            # or g++-13
+export CC=clang-15               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
 export LLVM_COV=llvm-cov-15
-export CLANG_TIDY=clang-tidy-18  # only if you want to use one of the clang-tidy presets
+export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets
 ```
 
 ### Ubuntu Software Packages
@@ -220,7 +220,7 @@ Install the following packages from Ubuntu.
 
 ```shell
 sudo apt update && sudo apt -y upgrade
-sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-18 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
+sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-15 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
 ```
 
 ### C++ packages

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -207,8 +207,8 @@ WSL), or in a physical/virtual machine.
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-15            # or g++-13
-export CC=clang-15               # gcc-13
+export CXX=clang++-18            # or g++-13
+export CC=clang-18               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
 export LLVM_COV=llvm-cov-15
 export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets
@@ -220,7 +220,7 @@ Install the following packages from Ubuntu.
 
 ```shell
 sudo apt update && sudo apt -y upgrade
-sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-15 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
+sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-18 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
 ```
 
 ### C++ packages

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -210,7 +210,7 @@ Append the following lines into the file `${HOME}/.bashrc`.
 export CXX=clang++-18            # or g++-13
 export CC=clang-18               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
-export LLVM_COV=llvm-cov-18
+export LLVM_COV=llvm-cov-15
 export CLANG_TIDY=clang-tidy-18  # only if you want to use one of the clang-tidy presets
 ```
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -207,11 +207,11 @@ WSL), or in a physical/virtual machine.
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-15            # or g++-13
-export CC=clang-15               # gcc-13
+export CXX=clang++-18            # or g++-13
+export CC=clang-18               # gcc-13
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
 export LLVM_COV=llvm-cov-15
-export CLANG_TIDY=clang-tidy-15  # only if you want to use one of the clang-tidy presets
+export CLANG_TIDY=clang-tidy-18  # only if you want to use one of the clang-tidy presets
 ```
 
 ### Ubuntu Software Packages
@@ -220,7 +220,7 @@ Install the following packages from Ubuntu.
 
 ```shell
 sudo apt update && sudo apt -y upgrade
-sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-15 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
+sudo apt install -y wget curl zip unzip tar git build-essential gcovr lcov gcc g++ clang-18 make gdb ninja-build pkg-config python3.10 python3.10-dev python3.10-venv python3-pip
 ```
 
 ### C++ packages

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
@@ -74,8 +74,8 @@ constexpr void set_nan(Enum& x) {
 }
 template <typename T>
     requires requires(T t) {
-                 { set_nan(t) };
-             }
+        { set_nan(t) };
+    }
 inline T const nan_value = [] {
     T v{};
     set_nan(v);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/common.hpp
@@ -30,8 +30,8 @@ template <row_based_or_columnar_c T> constexpr bool is_columnar_v = std::derived
 // The attribute buffers are copies of the associated attribute buffers, when provided, and otherwise empty.
 template <typename BufferType>
     requires requires(BufferType const& b) {
-                 { b.attributes } -> std::convertible_to<std::vector<AttributeBuffer<typename BufferType::Data>>>;
-             }
+        { b.attributes } -> std::convertible_to<std::vector<AttributeBuffer<typename BufferType::Data>>>;
+    }
 std::vector<AttributeBuffer<typename BufferType::Data>>
 reordered_attribute_buffers(BufferType& buffer, std::span<MetaAttribute const* const> attribute_order) {
     using Data = typename BufferType::Data;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
@@ -61,19 +61,17 @@ inline auto sparse_decode(IdxVector const& indptr) {
 
 template <typename T>
 concept grouped_index_vector_type = std::default_initializable<T> && requires(T const t, Idx const idx) {
-                                                                         typename T::iterator;
+    typename T::iterator;
 
-                                                                         { t.size() } -> std::same_as<Idx>;
+    { t.size() } -> std::same_as<Idx>;
 
-                                                                         { t.begin() } -> index_range_iterator;
-                                                                         { t.end() } -> index_range_iterator;
-                                                                         {
-                                                                             t.get_element_range(idx)
-                                                                             } -> random_access_iterable_like<Idx>;
+    { t.begin() } -> index_range_iterator;
+    { t.end() } -> index_range_iterator;
+    { t.get_element_range(idx) } -> random_access_iterable_like<Idx>;
 
-                                                                         { t.element_size() } -> std::same_as<Idx>;
-                                                                         { t.get_group(idx) } -> std::same_as<Idx>;
-                                                                     };
+    { t.element_size() } -> std::same_as<Idx>;
+    { t.get_group(idx) } -> std::same_as<Idx>;
+};
 } // namespace detail
 
 template <typename T>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/iterator_like_concepts.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/iterator_like_concepts.hpp
@@ -11,41 +11,40 @@ namespace power_grid_model {
 
 template <typename T, typename ElementType>
 concept iterator_like = requires(T const t) {
-                            { *t } -> std::convertible_to<std::remove_cvref_t<ElementType> const&>;
-                        };
+    { *t } -> std::convertible_to<std::remove_cvref_t<ElementType> const&>;
+};
 
 template <typename T, typename ElementType>
 concept forward_iterator_like = std::regular<T> && iterator_like<T, ElementType> && requires(T t) {
-                                                                                        { t++ } -> std::same_as<T>;
-                                                                                        { ++t } -> std::same_as<T&>;
-                                                                                    };
+    { t++ } -> std::same_as<T>;
+    { ++t } -> std::same_as<T&>;
+};
 
 template <typename T, typename ElementType>
 concept bidirectional_iterator_like = forward_iterator_like<T, ElementType> && requires(T t) {
-                                                                                   { t-- } -> std::same_as<T>;
-                                                                                   { --t } -> std::same_as<T&>;
-                                                                               };
+    { t-- } -> std::same_as<T>;
+    { --t } -> std::same_as<T&>;
+};
 
 template <typename T, typename ElementType>
 concept random_access_iterator_like =
     bidirectional_iterator_like<T, ElementType> && std::totally_ordered<T> && requires(T t, Idx n) {
-                                                                                  { t + n } -> std::same_as<T>;
-                                                                                  { t - n } -> std::same_as<T>;
-                                                                                  { t += n } -> std::same_as<T&>;
-                                                                                  { t -= n } -> std::same_as<T&>;
-                                                                              };
+        { t + n } -> std::same_as<T>;
+        { t - n } -> std::same_as<T>;
+        { t += n } -> std::same_as<T&>;
+        { t -= n } -> std::same_as<T&>;
+    };
 
 template <typename T, typename ElementType>
 concept random_access_iterable_like = requires(T const t) {
-                                          { t.begin() } -> random_access_iterator_like<ElementType>;
-                                          { t.end() } -> random_access_iterator_like<ElementType>;
-                                      };
+    { t.begin() } -> random_access_iterator_like<ElementType>;
+    { t.end() } -> random_access_iterator_like<ElementType>;
+};
 
 template <typename T>
-concept index_range_iterator =
-    random_access_iterator_like<T, typename T::iterator> && requires(T const t) {
-                                                                typename T::iterator;
-                                                                { *t } -> random_access_iterable_like<Idx>;
-                                                            };
+concept index_range_iterator = random_access_iterator_like<T, typename T::iterator> && requires(T const t) {
+    typename T::iterator;
+    { *t } -> random_access_iterable_like<Idx>;
+};
 
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/three_phase_tensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/three_phase_tensor.hpp
@@ -125,8 +125,8 @@ static_assert(std::is_trivially_destructible_v<ComplexValue<asymmetric_t>>);
 template <class T>
 concept column_vector = (T::ColsAtCompileTime == 1);
 template <class T>
-concept rk2_tensor = (static_cast<Idx>(T::RowsAtCompileTime) ==
-                      static_cast<Idx>(T::ColsAtCompileTime)); // rank 2 tensor
+concept rk2_tensor =
+    (static_cast<Idx>(T::RowsAtCompileTime) == static_cast<Idx>(T::ColsAtCompileTime)); // rank 2 tensor
 template <class T>
 concept column_vector_or_tensor = column_vector<T> || rk2_tensor<T>;
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/component.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/component.hpp
@@ -24,16 +24,16 @@ struct UpdateChange {
 
 template <typename T>
 concept component_c = requires(T t, T const& ct, typename T::UpdateType u, typename T::UpdateType const& cu) {
-                          typename T::InputType;
-                          typename T::UpdateType;
+    typename T::InputType;
+    typename T::UpdateType;
 
-                          { T::name } -> std::convertible_to<std::string_view>;
-                          { ct.math_model_type() } -> std::convertible_to<ComponentType>;
+    { T::name } -> std::convertible_to<std::string_view>;
+    { ct.math_model_type() } -> std::convertible_to<ComponentType>;
 
-                          { ct.id() } -> std::same_as<ID>;
+    { ct.id() } -> std::same_as<ID>;
 
-                          { t.update(cu) } -> std::same_as<UpdateChange>;
-                          { ct.inverse(u) } -> std::same_as<typename T::UpdateType>;
-                      };
+    { t.update(cu) } -> std::same_as<UpdateChange>;
+    { ct.inverse(u) } -> std::same_as<typename T::UpdateType>;
+};
 
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
@@ -77,8 +77,8 @@ class Shunt : public Appliance {
     DoubleComplex y0_{nan};
 
     template <typename T>
-        requires std::same_as<T, ShuntInput> || std::same_as<T, ShuntUpdate> bool
-    update_params(T shunt_params) {
+        requires std::same_as<T, ShuntInput> || std::same_as<T, ShuntUpdate>
+    bool update_params(T shunt_params) {
         bool changed = update_param(shunt_params.g1, g1_);
         changed = update_param(shunt_params.b1, b1_) || changed;
         changed = update_param(shunt_params.g0, g0_) || changed;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer_utils.hpp
@@ -16,15 +16,15 @@ concept enum_c = std::is_enum_v<T>;
 
 template <typename T>
 concept transformer_c = component_c<T> && requires(T const& t, typename T::UpdateType u, typename T::SideType s) {
-                                              { t.node(s) } -> std::same_as<ID>;
-                                              { t.status(s) } -> std::convertible_to<bool>;
+    { t.node(s) } -> std::same_as<ID>;
+    { t.status(s) } -> std::convertible_to<bool>;
 
-                                              { t.tap_side() } -> std::same_as<typename T::SideType>;
-                                              { t.tap_pos() } -> std::convertible_to<IntS>;
-                                              { t.tap_min() } -> std::convertible_to<IntS>;
-                                              { t.tap_max() } -> std::convertible_to<IntS>;
-                                              { t.tap_nom() } -> std::convertible_to<IntS>;
-                                          };
+    { t.tap_side() } -> std::same_as<typename T::SideType>;
+    { t.tap_pos() } -> std::convertible_to<IntS>;
+    { t.tap_min() } -> std::convertible_to<IntS>;
+    { t.tap_max() } -> std::convertible_to<IntS>;
+    { t.tap_nom() } -> std::convertible_to<IntS>;
+};
 
 constexpr double tap_adjust_impedance(double tap_pos, double tap_min, double tap_max, double tap_nom, double xk,
                                       double xk_min, double xk_max) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
@@ -58,9 +58,7 @@ inline SparseIndexMapping build_sparse_mapping(IdxVector const& idx_B_in_A, Idx 
 
     std::vector<SparseEntry> entries(n_A);
     std::ranges::transform(idx_B_in_A, boost::counting_range(Idx{0}, static_cast<Idx>(idx_B_in_A.size())),
-                           entries.begin(), [](Idx j_B, Idx i_A) {
-                               return SparseEntry{i_A, j_B};
-                           });
+                           entries.begin(), [](Idx j_B, Idx i_A) { return SparseEntry{i_A, j_B}; });
 
     SparseIndexMapping sparse_mapping;
     sparse_mapping.indptr.resize(n_B + 1);
@@ -97,9 +95,8 @@ inline auto build_dense_mapping_comparison_sort(IdxVector const& idx_B_in_A, Idx
     std::vector<DenseEntry> mapping_to_from;
     mapping_to_from.reserve(idx_B_in_A.size());
     std::ranges::transform(idx_B_in_A, boost::counting_range(Idx{0}, static_cast<Idx>(idx_B_in_A.size())),
-                           std::back_inserter(mapping_to_from), [](Idx value, Idx orig_idx) {
-                               return std::pair{value, orig_idx};
-                           });
+                           std::back_inserter(mapping_to_from),
+                           [](Idx value, Idx orig_idx) { return std::pair{value, orig_idx}; });
 
     std::ranges::sort(mapping_to_from);
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/math_state.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/math_state.hpp
@@ -30,8 +30,7 @@ inline void update_y_bus(MathState& math_state, std::vector<MathModelParam<sym>>
         } else {
             return math_state.y_bus_vec_asym;
         }
-    }
-    ();
+    }();
 
     assert(y_bus_vec.size() == math_model_params.size());
 
@@ -49,8 +48,7 @@ inline void update_y_bus(MathState& math_state, std::vector<MathModelParam<sym>>
         } else {
             return math_state.y_bus_vec_asym;
         }
-    }
-    ();
+    }();
 
     assert(y_bus_vec.size() == math_model_params.size());
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
@@ -366,7 +366,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, solver_ou
              requires(Component const& component, std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
                  {
                      output_result<Component>(component, solver_output, math_id)
-                     } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
+                 } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
                               MathOutput<std::vector<SolverOutputType>> const& math_output, ResIt res_it) {
@@ -382,7 +382,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, solver_ou
                       std::vector<SolverOutputType> const& solver_output, Idx2D math_id) {
                  {
                      output_result<Component>(component, state, solver_output, math_id)
-                     } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
+                 } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
                               MathOutput<std::vector<SolverOutputType>> const& math_output, ResIt res_it) {
@@ -398,7 +398,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, solver_ou
                       std::vector<SolverOutputType> const& solver_output, Idx obj_seq) {
                  {
                      output_result<Component>(component, state, solver_output, obj_seq)
-                     } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
+                 } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
                               MathOutput<std::vector<SolverOutputType>> const& math_output, ResIt res_it) {
@@ -414,7 +414,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, solver_ou
                       Idx2DBranch3 const& math_id) {
                  {
                      output_result<Component>(component, solver_output, math_id)
-                     } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
+                 } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
                               MathOutput<std::vector<SolverOutputType>> const& math_output, ResIt res_it) {
@@ -429,7 +429,7 @@ template <std::derived_from<Base> Component, class ComponentContainer, typename 
                       MathOutput<SolverOutputType> const& math_output, Idx const obj_seq) {
                  {
                      output_result<Component>(component, state, math_output, obj_seq)
-                     } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
+                 } -> detail::assignable_to<std::add_lvalue_reference_t<std::iter_value_t<ResIt>>>;
              }
 constexpr ResIt output_result(MainModelState<ComponentContainer> const& state,
                               MathOutput<SolverOutputType> const& math_output, ResIt res_it) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state.hpp
@@ -30,18 +30,12 @@ concept main_model_state_c = std::same_as<StateType, MainModelState<typename Sta
 
 template <typename ContainerType, typename ComponentType>
 concept component_container_c = requires(ContainerType const& c, ID id) {
-                                    { c.template citer<ComponentType>().begin() } -> std::forward_iterator;
-                                    { c.template citer<ComponentType>().end() } -> std::forward_iterator;
-                                    {
-                                        *(c.template citer<ComponentType>().begin())
-                                        } -> std::same_as<ComponentType const&>;
-                                    {
-                                        *(c.template citer<ComponentType>().end())
-                                        } -> std::same_as<ComponentType const&>;
-                                    {
-                                        c.template get_item<ComponentType>(id)
-                                        } -> std::convertible_to<ComponentType const&>;
-                                };
+    { c.template citer<ComponentType>().begin() } -> std::forward_iterator;
+    { c.template citer<ComponentType>().end() } -> std::forward_iterator;
+    { *(c.template citer<ComponentType>().begin()) } -> std::same_as<ComponentType const&>;
+    { *(c.template citer<ComponentType>().end()) } -> std::same_as<ComponentType const&>;
+    { c.template get_item<ComponentType>(id) } -> std::convertible_to<ComponentType const&>;
+};
 
 template <template <typename T> class StateType, typename ContainerType, typename ComponentType>
 concept model_component_state_c =

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -103,11 +103,11 @@ decltype(auto) calculation_type_symmetry_func_selector(CalculationType calculati
     calculation_type_func_selector(
         calculation_type,
         []<calculation_type_tag calculation_type, typename Functor_, typename... Args_>(
-            CalculationSymmetry calculation_symmetry_, Functor_ && f_, Args_ && ... args_) {
+            CalculationSymmetry calculation_symmetry_, Functor_&& f_, Args_&&... args_) {
             calculation_symmetry_func_selector(
                 calculation_symmetry_,
-                []<symmetry_tag sym, typename SubFunctor, typename... SubArgs>(SubFunctor && sub_f,
-                                                                               SubArgs && ... sub_args) {
+                []<symmetry_tag sym, typename SubFunctor, typename... SubArgs>(SubFunctor&& sub_f,
+                                                                               SubArgs&&... sub_args) {
                     std::forward<SubFunctor>(sub_f).template operator()<calculation_type, sym>(
                         std::forward<SubArgs>(sub_args)...);
                 },
@@ -153,7 +153,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         (functor.template operator()<ComponentType>(), ...);
     }
     template <class Functor> static constexpr auto run_functor_with_all_types_return_array(Functor functor) {
-        return std::array{functor.template operator()<ComponentType>()...};
+        return std::array { functor.template operator()<ComponentType>()... };
     }
 
   public:
@@ -1149,8 +1149,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
     template <calculation_input_type CalcInputType>
     static auto calculate_param(auto const& c, auto const&... extra_args)
         requires requires {
-                     { c.calc_param(extra_args...) };
-                 }
+            { c.calc_param(extra_args...) };
+        }
     {
         return c.calc_param(extra_args...);
     }
@@ -1158,8 +1158,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
     template <calculation_input_type CalcInputType>
     static auto calculate_param(auto const& c, auto const&... extra_args)
         requires requires {
-                     { c.template calc_param<typename CalcInputType::sym>(extra_args...) };
-                 }
+            { c.template calc_param<typename CalcInputType::sym>(extra_args...) };
+        }
     {
         return c.template calc_param<typename CalcInputType::sym>(extra_args...);
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -327,8 +327,7 @@ template <symmetry_tag sym> class IterativeLinearSESolver {
                 } else {
                     return voltage(0);
                 }
-            }
-            ();
+            }();
             return cabs(voltage_a) / voltage_a;
         }();
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -24,9 +24,9 @@ template <class ArrayLike>
 concept eigen_array = std::same_as<decltype(check_array_base(ArrayLike{})), int>; // should be an eigen array
 
 template <class LHSArrayLike, class RHSArrayLike>
-concept matrix_multiplicable = eigen_array<LHSArrayLike> && eigen_array<RHSArrayLike> &&
-                               (static_cast<Idx>(LHSArrayLike::ColsAtCompileTime) ==
-                                static_cast<Idx>(RHSArrayLike::RowsAtCompileTime));
+concept matrix_multiplicable =
+    eigen_array<LHSArrayLike> && eigen_array<RHSArrayLike> &&
+    (static_cast<Idx>(LHSArrayLike::ColsAtCompileTime) == static_cast<Idx>(RHSArrayLike::RowsAtCompileTime));
 
 template <class Tensor, class RHSVector, class XVector>
 concept tensor_lu =

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/base_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/base_optimizer.hpp
@@ -64,8 +64,8 @@ concept optimizer_c =
     requires(Optimizer optimizer, typename Optimizer::State const& state, CalculationMethod method) {
         {
             optimizer.optimize(state, method)
-            } -> std::same_as<MathOutput<
-                detail::state_calculator_result_t<typename Optimizer::Calculator, typename Optimizer::State>>>;
+        } -> std::same_as<
+              MathOutput<detail::state_calculator_result_t<typename Optimizer::Calculator, typename Optimizer::State>>>;
     };
 
 template <typename StateCalculator, typename State_>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -1184,9 +1184,9 @@ class TapPositionOptimizerImpl<std::tuple<TransformerTypes...>, StateCalculator,
 
     template <transformer_c T>
         requires requires(UpdateBuffer const& u) {
-                     { get<T>(u).data() } -> std::convertible_to<void const*>;
-                     { get<T>(u).size() } -> std::convertible_to<Idx>;
-                 }
+            { get<T>(u).data() } -> std::convertible_to<void const*>;
+            { get<T>(u).size() } -> std::convertible_to<Idx>;
+        }
     static auto add_buffer_to_update_dataset(UpdateBuffer const& update_buffer, std::string_view component_name,
                                              ConstDataset& update_data) {
         auto const& data = get<T>(update_buffer);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
@@ -535,11 +535,11 @@ class Topology {
     void couple_all_appliance() {
         // shunt
         couple_object_components<&MathModelTopology::n_bus>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.shunts_per_bus; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.shunts_per_bus; },
             {comp_topo_.shunt_node_idx, comp_coup_.node}, comp_coup_.shunt);
         // load_gen
         couple_object_components<&MathModelTopology::n_bus>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.load_gens_per_bus; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.load_gens_per_bus; },
             {comp_topo_.load_gen_node_idx, comp_coup_.node}, comp_coup_.load_gen);
 
         // set load gen type
@@ -557,7 +557,7 @@ class Topology {
 
         // source
         couple_object_components<&MathModelTopology::n_bus>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.sources_per_bus; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.sources_per_bus; },
             {comp_topo_.source_node_idx, comp_coup_.node}, comp_coup_.source,
             [this](Idx i) { return comp_conn_.source_connected[i]; });
     }
@@ -565,24 +565,24 @@ class Topology {
     void couple_sensors() {
         // voltage sensors
         couple_object_components<&MathModelTopology::n_bus>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.voltage_sensors_per_bus; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.voltage_sensors_per_bus; },
             {comp_topo_.voltage_sensor_node_idx, comp_coup_.node}, comp_coup_.voltage_sensor);
 
         // source power sensors
         couple_object_components<&MathModelTopology::n_source>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_source; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_source; },
             {comp_topo_.power_sensor_object_idx, comp_coup_.source}, comp_coup_.power_sensor,
             [this](Idx i) { return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::source; });
 
         // shunt power sensors
         couple_object_components<&MathModelTopology::n_shunt>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_shunt; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_shunt; },
             {comp_topo_.power_sensor_object_idx, comp_coup_.shunt}, comp_coup_.power_sensor,
             [this](Idx i) { return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::shunt; });
 
         // load + generator power sensors
         couple_object_components<&MathModelTopology::n_load_gen>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_load_gen; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_load_gen; },
             {comp_topo_.power_sensor_object_idx, comp_coup_.load_gen}, comp_coup_.power_sensor,
             [this](Idx i) {
                 return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::load ||
@@ -606,18 +606,18 @@ class Topology {
 
         // branch 'from' power sensors
         couple_object_components<&MathModelTopology::n_branch>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_branch_from; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_branch_from; },
             object_finder_from_sensor, comp_coup_.power_sensor, predicate_from_sensor);
 
         // branch 'to' power sensors
         couple_object_components<&MathModelTopology::n_branch>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_branch_to; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_branch_to; },
             {comp_topo_.power_sensor_object_idx, comp_coup_.branch}, comp_coup_.power_sensor,
             [this](Idx i) { return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::branch_to; });
 
         // node injection power sensors
         couple_object_components<&MathModelTopology::n_bus>(
-            [](MathModelTopology & math_topo) -> auto& { return math_topo.power_sensors_per_bus; },
+            [](MathModelTopology& math_topo) -> auto& { return math_topo.power_sensors_per_bus; },
             {comp_topo_.power_sensor_object_idx, comp_coup_.node}, comp_coup_.power_sensor,
             [this](Idx i) { return comp_topo_.power_sensor_terminal_type[i] == MeasuredTerminalType::node; });
     }

--- a/power_grid_model_c/power_grid_model_c/src/handle.hpp
+++ b/power_grid_model_c/power_grid_model_c/src/handle.hpp
@@ -28,8 +28,8 @@ struct PGM_Handle {
 };
 
 template <class Exception = std::exception, class Functor>
-auto call_with_catch(PGM_Handle* handle, Functor func, PGM_Idx error_code, std::string_view extra_msg = {})
-    -> std::invoke_result_t<Functor> {
+auto call_with_catch(PGM_Handle* handle, Functor func, PGM_Idx error_code,
+                     std::string_view extra_msg = {}) -> std::invoke_result_t<Functor> {
     if (handle) {
         PGM_clear_error(handle);
     }

--- a/power_grid_model_c/power_grid_model_c/src/model.cpp
+++ b/power_grid_model_c/power_grid_model_c/src/model.cpp
@@ -28,9 +28,7 @@ PGM_PowerGridModel* PGM_create_model(PGM_Handle* handle, double system_frequency
                                      PGM_ConstDataset const* input_dataset) {
     return call_with_catch(
         handle,
-        [system_frequency, input_dataset] {
-            return new PGM_PowerGridModel{system_frequency, *input_dataset, 0};
-        },
+        [system_frequency, input_dataset] { return new PGM_PowerGridModel{system_frequency, *input_dataset, 0}; },
         PGM_regular_error);
 }
 
@@ -43,8 +41,7 @@ void PGM_update_model(PGM_Handle* handle, PGM_PowerGridModel* model, PGM_ConstDa
 
 // copy model
 PGM_PowerGridModel* PGM_copy_model(PGM_Handle* handle, PGM_PowerGridModel const* model) {
-    return call_with_catch(
-        handle, [model] { return new PGM_PowerGridModel{*model}; }, PGM_regular_error);
+    return call_with_catch(handle, [model] { return new PGM_PowerGridModel{*model}; }, PGM_regular_error);
 }
 
 // get indexer

--- a/power_grid_model_c/power_grid_model_c/src/serialization.cpp
+++ b/power_grid_model_c/power_grid_model_c/src/serialization.cpp
@@ -46,8 +46,7 @@ PGM_WritableDataset* PGM_deserializer_get_dataset(PGM_Handle* /*unused*/, PGM_De
 }
 
 void PGM_deserializer_parse_to_buffer(PGM_Handle* handle, PGM_Deserializer* deserializer) {
-    call_with_catch(
-        handle, [deserializer] { deserializer->parse(); }, PGM_serialization_error);
+    call_with_catch(handle, [deserializer] { deserializer->parse(); }, PGM_serialization_error);
 }
 
 // false warning from clang-tidy

--- a/tests/cpp_unit_tests/test_all_components.cpp
+++ b/tests/cpp_unit_tests/test_all_components.cpp
@@ -45,9 +45,9 @@ static_assert(component_c<TransformerTapRegulator>);
 // (This would mean that we lose private member variables or overloads)
 template <typename T, typename U>
 concept is_copyable_to = std::derived_from<T, U> && requires(T const t, U u) {
-                                                        { U{t} } -> std::same_as<U>;   // copy
-                                                        { u = t } -> std::same_as<U&>; // copy assignment
-                                                    };
+    { U{t} } -> std::same_as<U>;   // copy
+    { u = t } -> std::same_as<U&>; // copy assignment
+};
 
 static_assert(is_copyable_to<Fault, Fault>);
 static_assert(!is_copyable_to<Fault, Base>);

--- a/tests/cpp_unit_tests/test_optimizer.hpp
+++ b/tests/cpp_unit_tests/test_optimizer.hpp
@@ -132,12 +132,12 @@ static_assert(
 static_assert(
     std::convertible_to<decltype(stub_steady_state_state_calculator<asymmetric_t>), AsymStubSteadyStateCalculator>);
 
-constexpr void stub_update(StubUpdateType const& /* update_data */){
+constexpr void stub_update(StubUpdateType const& /* update_data */) {
     // stub
 };
 static_assert(std::convertible_to<decltype(stub_update), StubUpdate>);
 
-constexpr void stub_const_dataset_update(ConstDataset const& /* update_data */){
+constexpr void stub_const_dataset_update(ConstDataset const& /* update_data */) {
     // stub
 };
 static_assert(std::convertible_to<decltype(stub_const_dataset_update), ConstDatasetUpdate>);


### PR DESCRIPTION
Partially solves #773. Only upgrading the clang-tidy workflow to `ubuntu-24.04` and clang-tidy itself to version 18.1.3 are left; however, discussion on how to resolve each resulting issue of this upgrade is out of scope of this PR.

-----
This in an experiment PR to try to bump to Ubuntu 24.04 in github actions.

In https://github.com/actions/runner-images/issues/10636, it is stated that `ubuntu-latest` won't fully migrate to 24.04 until October 30th, hence the explicit versioning in https://github.com/PowerGridModel/power-grid-model/pull/770/commits/6032f7295ce1bb9898e04f8676620071c4fc9133.

Relevant tools, packages, etc. are updated to the latest supported by this Ubuntu image as stated in https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md