### PR TITLE
Fix Nightly Clang-Tidy run

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -74,12 +74,12 @@ jobs:
           brew install boost eigen nlohmann-json msgpack-cxx doctest
 
       - name: Set build target in case of push
-        if: github.event_name != 'workflow_dispatch' && github.event.event_name != 'workflow_call'
+        if: inputs.target == null
         run: |
           echo "TARGET=power_grid_model_api_tests" >> $GITHUB_ENV
 
       - name: Set build target in case of workflow dispatch
-        if: github.event_name == 'workflow_dispatch' || github.event.event_name == 'workflow_call'
+        if: inputs.target != null
         run: |
           echo "TARGET=${{ inputs.target }}" >> $GITHUB_ENV
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,11 +26,11 @@ on:
       target:
         type: choice
         description: The CMake target to run
-        default: power_grid_model_c
+        default: all power_grid_model_benchmark_cpp
         options:
           - all
-          - power_grid_model_c
           - all power_grid_model_benchmark_cpp
+          - power_grid_model_c
           - power_grid_model_unit_tests
           - power_grid_model_api_tests
           - power_grid_model_validation_tests

--- a/tests/cpp_unit_tests/test_generic_branch.cpp
+++ b/tests/cpp_unit_tests/test_generic_branch.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Test generic_branch") {
                                    .theta = 0.0,
                                    .sn = 30e6};
 
-    GenericBranch branch{input, u1, u2};
+    GenericBranch const branch{input, u1, u2};
     double const base_y = base_i_to * base_i_to / base_power_1p;
 
     DoubleComplex const y1_series = 1.0 / (input.r1 + 1.0i * input.x1) / base_y;
@@ -96,7 +96,7 @@ TEST_CASE("Test compare_generic_branch") {
                                         .theta = 0.0,
                                         .sn = 1e5};
 
-    GenericBranch gen_branch{genb_input, u1_rated, u2_rated};
+    GenericBranch const gen_branch{genb_input, u1_rated, u2_rated};
 
     double const theta{gen_branch.phase_shift()};
 
@@ -120,7 +120,7 @@ TEST_CASE("Test compare_generic_branch") {
         CHECK(cabs(param1.yft() - yft1) < numerical_tolerance);
     }
 
-    TransformerInput trans_input{
+    TransformerInput const trans_input{
         .id = 1,
         .from_node = 2,
         .to_node = 3,
@@ -159,10 +159,10 @@ TEST_CASE("Test compare_generic_branch") {
     double const k{(trans_input.u1 / trans_input.u2) / nominal_ratio};
     double const i0{trans_input.i0};
 
-    Transformer transformer(trans_input, u1_rated, u2_rated);
+    Transformer const transformer(trans_input, u1_rated, u2_rated);
 
     DoubleComplex const trafo_ratio = k * std::exp(1.0i * (transformer.phase_shift()));
-    double ratio_abs = std::abs(trafo_ratio);
+    double const ratio_abs = std::abs(trafo_ratio);
 
     // y_series:
     double const z_series_abs = uk * u2 * u2 / sn;


### PR DESCRIPTION
Fix the issue where the Nightly clang-tidy run doesn't actually run the full clang-tidy (as found in https://github.com/PowerGridModel/power-grid-model/pull/770 / https://github.com/PowerGridModel/power-grid-model/pull/770#issuecomment-2404978937 / https://github.com/PowerGridModel/power-grid-model/actions/runs/11266502113/job/31330087503#step:6:2

* [x] new workflow code works for PRs / calls that do not have `inputs`
* [x] new workflow code works for workflow dispatch / calls that do have `inputs`
* [x] https://github.com/PowerGridModel/power-grid-model/actions/runs/11275168764/job/31355968241#step:7:1
* [x] full clang-tidy build runs successfully (https://github.com/PowerGridModel/power-grid-model/actions/runs/11275275616/job/31356339338)