### PR TITLE
Remove sphinx workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,13 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["msgpack", "pre-commit", "pylint", "pytest", "pytest-cov"]
 doc = [
-    "sphinx<8.1",                # Upper bound pin on sphinx can be removed once https://github.com/mgaitan/sphinxcontrib-mermaid/issues/160 is resolved
+    "sphinx",
     "breathe",
     "myst_nb",
     "sphinx_rtd_theme",
     "readthedocs-sphinx-search",
     "sphinx-hoverxref",
-    "sphinxcontrib-mermaid",
+    "sphinxcontrib-mermaid>=1.0.0",
     "numpydoc",
     "pandas",
     "gitpython",


### PR DESCRIPTION
Removes sphinx workaround due to sphinx-mermaid using old API version (upgraded in https://github.com/mgaitan/sphinxcontrib-mermaid/pull/153)