### PR TITLE
Bug/Fix feedstock mac

### DIFF
--- a/tests/unit/test_power_grid_model.py
+++ b/tests/unit/test_power_grid_model.py
@@ -149,10 +149,8 @@ def test_simple_power_flow(model: PowerGridModel, sym_output):
     compare_result(result, sym_output, rtol=0.0, atol=1e-8)
 
 
-def test_simple_permanent_update(
-    model: PowerGridModel, update_batch, sym_output_batch
-):  # error if permanent update is not single scenario
-    model.update(update_data=update_batch)  # single permanent model update
+def test_simple_permanent_update(model: PowerGridModel, update_batch, sym_output_batch):
+    model.update(update_data=get_dataset_scenario(update_batch, 0))  # single permanent model update
     result = model.calculate_power_flow()
     expected_result = get_dataset_scenario(sym_output_batch, 0)
     compare_result(result, expected_result, rtol=0.0, atol=1e-8)


### PR DESCRIPTION
[Feedstock](https://github.com/conda-forge/power-grid-model-feedstock/pull/272) is crashing after 1.9.72 on Mac OS. From the [error log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1054810&view=results) in the Azure pipelines, this can be traced back to https://github.com/PowerGridModel/power-grid-model/pull/778, specifically to the `test_simple_permanent_update` test. 

In the test, a single permanent update was done via `model.update(update_data=update_batch)`, where `update_batch` was a many-scenario batch dataset, rather than a single scenario one, which is expected to work. However, due to the crash in the feedstock's CI, it was found that this functionality is not properly tested in the core.

In this PR, the python test `test_simple_permanent_update` is changed to handle a single scenario permanent update to confirm this was the root of the issue and tests are added in the core to test the intended functionality.

I expect two possible outcomes:

- [ ] CI passes here: We merge and check if it now passes in feedstock. If it passes in the feedstock, the bug is either in the python interface with the C API (unlikely) or a memory alignment problem (most likely),  as it was found in https://github.com/PowerGridModel/power-grid-model/pull/718/commits/b3ca98f3a933306efea2afb752d3433aa43b93e8 and reproduced in https://github.com/PowerGridModel/power-grid-model/pull/769. The core should be good.
- [ ] CI fails here: Since the new tests pass in my local, the core implementation should be fine and I would expect this to fail on the Mac CI, and would have to assess in that case. 
