### PR TITLE
Feature / Update Python validation to support optional `id` in update data

### DIFF
--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -539,9 +539,28 @@ def is_columnar(component_data: ComponentData) -> bool:
     return not isinstance(component_data, np.ndarray)
 
 
-def is_nan_or_equivalent(array):
+def is_nan_or_default(x: np.ndarray) -> np.ndarray:
+    """
+    Check if elements in the array are NaN or equal to the min of its dtype.
+
+    Args:
+        x: A NumPy array to check.
+
+    Returns:
+        A boolean NumPy array where each element is True if the corresponding element in x is NaN
+        or min of its dtype, and False otherwise.
+    """
+    if x.dtype == np.float64:
+        return np.isnan(x)
+    if x.dtype in (np.int32, np.int8):
+        return x == np.iinfo(x.dtype).min
+    raise TypeError(f"Unsupported data type: {x.dtype}")
+
+
+def is_nan_or_equivalent(array) -> bool:
     """
     Check if the array contains only nan values or equivalent nan values for specific data types.
+    This is the aggregrated version of `is_nan_or_default` for the whole array.
 
     Args:
         array: The array to check.
@@ -749,25 +768,6 @@ def get_dataset_type(data: Dataset) -> DatasetType:
         raise ValueError("The dataset type could not be deduced because multiple dataset types match the data.")
 
     return next(iter(candidates))
-
-
-def is_nan_or_default(x: np.ndarray) -> np.ndarray:
-    """
-    Check if elements in the array are NaN or equal to the min of its dtype.
-
-    Args:
-        x: A NumPy array to check.
-
-    Returns:
-        A boolean NumPy array where each element is True if the corresponding element in x is NaN
-        or min of its dtype, and False otherwise.
-    """
-    if x.dtype == np.float64:
-        return np.isnan(x)
-    elif x.dtype in (np.int32, np.int8):
-        return x == np.iinfo(x.dtype).min
-    else:
-        raise TypeError(f"Unsupported data type: {x.dtype}")
 
 
 def get_comp_batch_size(comp_data: dict) -> int:

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -568,7 +568,7 @@ def is_nan_or_equivalent(array) -> bool:
     Returns:
         bool: True if the array contains only nan or equivalent nan values, False otherwise.
     """
-    return isinstance(array, np.ndarray) and (
+    return isinstance(array, np.ndarray) and bool(
         (array.dtype == np.float64 and np.isnan(array).all())
         or (array.dtype in (np.int32, np.int8) and np.all(array == np.iinfo(array.dtype).min))
     )

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -782,4 +782,4 @@ def get_comp_batch_size(comp_data: dict) -> int:
         The length of the first value in the dictionary if the data is columnar, otherwise the length
         of the dictionary itself.
     """
-    return len(next(iter(comp_data.items()))[1]) if is_columnar(comp_data) else len(comp_data)
+    return len(next(iter(comp_data.values()))) if is_columnar(comp_data) else len(comp_data)

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -749,3 +749,29 @@ def get_dataset_type(data: Dataset) -> DatasetType:
         raise ValueError("The dataset type could not be deduced because multiple dataset types match the data.")
 
     return next(iter(candidates))
+
+
+def is_nan_or_default(x: np.ndarray) -> np.ndarray:
+    """
+    Check if elements in the array are NaN or equal to the default value -2147483648.
+
+    Args:
+        x: A NumPy array to check.
+
+    Returns:
+        A boolean NumPy array where each element is True if the corresponding element in x is NaN or -2147483648, and False otherwise.
+    """
+    return np.isnan(x) | (x == -2147483648)
+
+
+def get_comp_batch_size(_data: dict) -> int:
+    """
+    Get the batch size of the component data.
+
+    Args:
+        _data: A dictionary representing the component data. The dictionary can be either columnar or non-columnar.
+
+    Returns:
+        The length of the first value in the dictionary if the data is columnar, otherwise the length of the dictionary itself.
+    """
+    return len(next(iter(_data.items()))[1]) if is_columnar(_data) else len(_data)

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -753,25 +753,33 @@ def get_dataset_type(data: Dataset) -> DatasetType:
 
 def is_nan_or_default(x: np.ndarray) -> np.ndarray:
     """
-    Check if elements in the array are NaN or equal to the default value -2147483648.
+    Check if elements in the array are NaN or equal to the min of its dtype.
 
     Args:
         x: A NumPy array to check.
 
     Returns:
-        A boolean NumPy array where each element is True if the corresponding element in x is NaN or -2147483648, and False otherwise.
+        A boolean NumPy array where each element is True if the corresponding element in x is NaN
+        or min of its dtype, and False otherwise.
     """
-    return np.isnan(x) | (x == -2147483648)
+    if x.dtype == np.float64:
+        return np.isnan(x)
+    elif x.dtype in (np.int32, np.int8):
+        return x == np.iinfo(x.dtype).min
+    else:
+        raise TypeError(f"Unsupported data type: {x.dtype}")
 
 
-def get_comp_batch_size(_data: dict) -> int:
+def get_comp_batch_size(comp_data: dict) -> int:
     """
-    Get the batch size of the component data.
+    Get the batch size of the component update data.
 
     Args:
-        _data: A dictionary representing the component data. The dictionary can be either columnar or non-columnar.
+        comp_data: A dictionary representing the component data. The dictionary can be either columnar
+        or row-based.
 
     Returns:
-        The length of the first value in the dictionary if the data is columnar, otherwise the length of the dictionary itself.
+        The length of the first value in the dictionary if the data is columnar, otherwise the length
+        of the dictionary itself.
     """
-    return len(next(iter(_data.items()))[1]) if is_columnar(_data) else len(_data)
+    return len(next(iter(comp_data.items()))[1]) if is_columnar(comp_data) else len(comp_data)

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -770,16 +770,17 @@ def get_dataset_type(data: Dataset) -> DatasetType:
     return next(iter(candidates))
 
 
-def get_comp_batch_size(comp_data: dict) -> int:
+def get_comp_size(comp_data: SingleColumnarData | SingleArray) -> int:
     """
-    Get the batch size of the component update data.
+    Get the number of elements in the comp_data of a single dataset.
 
     Args:
-        comp_data: A dictionary representing the component data. The dictionary can be either columnar
-        or row-based.
+        comp_data: Columnar or row based data of a single batch
 
     Returns:
-        The length of the first value in the dictionary if the data is columnar, otherwise the length
-        of the dictionary itself.
+        Number of elements in the component
     """
-    return len(next(iter(comp_data.values()))) if is_columnar(comp_data) else len(comp_data)
+    if not is_columnar(comp_data):
+        return len(comp_data)
+    comp_data = cast(SingleColumnarData, comp_data)
+    return len(next(iter(comp_data.values())))

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -770,7 +770,7 @@ def get_dataset_type(data: Dataset) -> DatasetType:
     return next(iter(candidates))
 
 
-def get_comp_batch_size(comp_data: dict) -> int:
+def get_comp_batch_size(comp_data: ComponentData | dict) -> int:
     """
     Get the batch size of the component update data.
 

--- a/src/power_grid_model/_utils.py
+++ b/src/power_grid_model/_utils.py
@@ -770,7 +770,7 @@ def get_dataset_type(data: Dataset) -> DatasetType:
     return next(iter(candidates))
 
 
-def get_comp_batch_size(comp_data: ComponentData | dict) -> int:
+def get_comp_batch_size(comp_data: dict) -> int:
     """
     Get the batch size of the component update data.
 

--- a/src/power_grid_model/validation/errors.py
+++ b/src/power_grid_model/validation/errors.py
@@ -326,12 +326,13 @@ class InvalidIdError(SingleFieldValidationError):
         self,
         component: ComponentType,
         field: str,
-        ids: list[int],
-        ref_components: ComponentType | list[ComponentType],
+        ids: list[int] = None,
+        ref_components: ComponentType | list[ComponentType] = None,
         filters: Optional[dict[str, Any]] = None,
     ):
         # pylint: disable=too-many-positional-arguments
-        super().__init__(component=component, field=field, ids=ids)
+        self.ids = ids if ids is not None else []
+        super().__init__(component=component, field=field, ids=self.ids)
         self.ref_components = [ref_components] if isinstance(ref_components, (str, ComponentType)) else ref_components
         self.filters = filters if filters else None
 

--- a/src/power_grid_model/validation/errors.py
+++ b/src/power_grid_model/validation/errors.py
@@ -326,12 +326,13 @@ class InvalidIdError(SingleFieldValidationError):
         self,
         component: ComponentType,
         field: str,
-        ids: list[int] = None,
-        ref_components: ComponentType | list[ComponentType] = None,
+        ids: Optional[list[int]] = None,
+        ref_components: Optional[ComponentType | list[ComponentType]] = None,
         filters: Optional[dict[str, Any]] = None,
     ):
         # pylint: disable=too-many-positional-arguments
         self.ids = ids if ids is not None else []
+        ref_components = ref_components if ref_components is not None else []
         super().__init__(component=component, field=field, ids=self.ids)
         self.ref_components = [ref_components] if isinstance(ref_components, (str, ComponentType)) else ref_components
         self.filters = filters if filters else None

--- a/src/power_grid_model/validation/rules.py
+++ b/src/power_grid_model/validation/rules.py
@@ -40,6 +40,7 @@ from typing import Any, Callable, Optional, Type, TypeVar
 import numpy as np
 
 from power_grid_model import ComponentType
+from power_grid_model._utils import is_columnar
 from power_grid_model.data_types import SingleDataset
 from power_grid_model.enum import FaultPhase, FaultType, WindingType
 from power_grid_model.validation.errors import (
@@ -699,13 +700,17 @@ def ids_valid_in_update_data_set(
     component_ref_data = ref_data[component]
     if component_ref_data["id"].size == 0:
         return [InvalidIdError(component=component, field="id", ids=None)]
+    is_nan_or_default = lambda x: np.isnan(x) | (x == -2147483648)
+    get_comp_batch_size = lambda _data: (len(next(iter(_data.items()))[1]) if is_columnar(_data) else len(_data),)
+    id_field_is_nan = np.array(is_nan_or_default(component_data["id"]))
     # check whether id qualify for optional
-    if component_data["id"].size == 0 or np.isnan(component_data["id"]).all():
+    if component_data["id"].size == 0 or np.all(id_field_is_nan):
         # check if the dimension of the component_data is the same as the component_ref_data
-        if len(component_data) != len(component_ref_data):
+        if get_comp_batch_size(component_data) != get_comp_batch_size(component_ref_data):
             return [InvalidIdError(component=component, field="id", ids=None)]
+        return []  # supported optional id
 
-    if np.isnan(component_data["id"]).any() and not np.isnan(component_data["id"]).all():
+    if np.all(id_field_is_nan) and not np.all(~id_field_is_nan):
         return [InvalidIdError(component=component, field="id", ids=None)]
 
     # normal check: exist and match with input

--- a/src/power_grid_model/validation/rules.py
+++ b/src/power_grid_model/validation/rules.py
@@ -40,7 +40,7 @@ from typing import Any, Callable, Optional, Type, TypeVar
 import numpy as np
 
 from power_grid_model import ComponentType
-from power_grid_model._utils import get_comp_batch_size, is_nan_or_default
+from power_grid_model._utils import get_comp_size, is_nan_or_default
 from power_grid_model.data_types import SingleDataset
 from power_grid_model.enum import FaultPhase, FaultType, WindingType
 from power_grid_model.validation.errors import (
@@ -704,7 +704,7 @@ def ids_valid_in_update_data_set(
     # check whether id qualify for optional
     if component_data["id"].size == 0 or np.all(id_field_is_nan):
         # check if the dimension of the component_data is the same as the component_ref_data
-        if get_comp_batch_size(component_data) != get_comp_batch_size(component_ref_data):
+        if get_comp_size(component_data) != get_comp_size(component_ref_data):
             return [InvalidIdError(component=component, field="id", ids=None)]
         return []  # supported optional id
 

--- a/src/power_grid_model/validation/rules.py
+++ b/src/power_grid_model/validation/rules.py
@@ -685,7 +685,7 @@ def all_ids_exist_in_data_set(
     Check that for all records of a particular type of component, the ids exist in the reference data set.
 
     Args:
-        data: The (update) data set for all components
+        data: The input data set for all components
         ref_data: The reference (input) data set for all components
         component: The component of interest
         ref_name: The name of the reference data set, e.g. 'input_data'

--- a/src/power_grid_model/validation/rules.py
+++ b/src/power_grid_model/validation/rules.py
@@ -40,7 +40,7 @@ from typing import Any, Callable, Optional, Type, TypeVar
 import numpy as np
 
 from power_grid_model import ComponentType
-from power_grid_model._utils import is_columnar
+from power_grid_model._utils import get_comp_batch_size, is_nan_or_default
 from power_grid_model.data_types import SingleDataset
 from power_grid_model.enum import FaultPhase, FaultType, WindingType
 from power_grid_model.validation.errors import (
@@ -700,8 +700,6 @@ def ids_valid_in_update_data_set(
     component_ref_data = ref_data[component]
     if component_ref_data["id"].size == 0:
         return [InvalidIdError(component=component, field="id", ids=None)]
-    is_nan_or_default = lambda x: np.isnan(x) | (x == -2147483648)
-    get_comp_batch_size = lambda _data: (len(next(iter(_data.items()))[1]) if is_columnar(_data) else len(_data),)
     id_field_is_nan = np.array(is_nan_or_default(component_data["id"]))
     # check whether id qualify for optional
     if component_data["id"].size == 0 or np.all(id_field_is_nan):

--- a/src/power_grid_model/validation/rules.py
+++ b/src/power_grid_model/validation/rules.py
@@ -678,26 +678,37 @@ def all_not_two_values_equal(
     return []
 
 
-def all_ids_exist_in_data_set(
-    data: SingleDataset, ref_data: SingleDataset, component: ComponentType, ref_name: str
-) -> list[IdNotInDatasetError]:
+def ids_valid_in_update_data_set(
+    update_data: SingleDataset, ref_data: SingleDataset, component: ComponentType, ref_name: str
+) -> list[IdNotInDatasetError | InvalidIdError]:
     """
-    Check that for all records of a particular type of component, the ids exist in the reference data set.
+    Check that for all records of a particular type of component, whether the ids:
+    - exist and match those in the reference data set
+    - are not present but qualifies for optional id
 
     Args:
-        data: The input data set for all components
+        update_data: The update data set for all components
         ref_data: The reference (input) data set for all components
         component: The component of interest
-        ref_name: The name of the reference data set, e.g. 'input_data'
+        ref_name: The name of the reference data set, e.g. 'update_data'
     Returns:
         A list containing zero or one IdNotInDatasetError, listing all ids of the objects in the data set which do not
         exist in the reference data set.
     """
-    component_data = data[component]
+    component_data = update_data[component]
     component_ref_data = ref_data[component]
-    if not isinstance(component_data, np.ndarray) or not isinstance(component_ref_data, np.ndarray):
-        raise NotImplementedError()  # TODO(mgovers): add support for columnar data
+    if component_ref_data["id"].size == 0:
+        return [InvalidIdError(component=component, field="id", ids=None)]
+    # check whether id qualify for optional
+    if component_data["id"].size == 0 or np.isnan(component_data["id"]).all():
+        # check if the dimension of the component_data is the same as the component_ref_data
+        if len(component_data) != len(component_ref_data):
+            return [InvalidIdError(component=component, field="id", ids=None)]
 
+    if np.isnan(component_data["id"]).any() and not np.isnan(component_data["id"]).all():
+        return [InvalidIdError(component=component, field="id", ids=None)]
+
+    # normal check: exist and match with input
     invalid = np.isin(component_data["id"], component_ref_data["id"], invert=True)
     if invalid.any():
         ids = component_data["id"][invalid].flatten().tolist()

--- a/src/power_grid_model/validation/validation.py
+++ b/src/power_grid_model/validation/validation.py
@@ -31,11 +31,7 @@ from power_grid_model.enum import (
     MeasuredTerminalType,
     WindingType,
 )
-from power_grid_model.validation.errors import (
-    MissingValueError,
-    MultiComponentNotUniqueError,
-    ValidationError,
-)
+from power_grid_model.validation.errors import MissingValueError, MultiComponentNotUniqueError, ValidationError
 from power_grid_model.validation.rules import (
     all_between,
     all_between_or_at,

--- a/src/power_grid_model/validation/validation.py
+++ b/src/power_grid_model/validation/validation.py
@@ -32,7 +32,6 @@ from power_grid_model.enum import (
     WindingType,
 )
 from power_grid_model.validation.errors import (
-    IdNotInDatasetError,
     MissingValueError,
     MultiComponentNotUniqueError,
     ValidationError,

--- a/tests/unit/validation/test_batch_validation.py
+++ b/tests/unit/validation/test_batch_validation.py
@@ -119,6 +119,7 @@ def test_validate_batch_data_input_error(input_data, batch_data):
 def test_validate_batch_data_update_error(input_data, batch_data):
     batch_data["line"]["from_status"] = np.array([[12, 34], [0, -128], [56, 78]])
     errors = validate_batch_data(input_data, batch_data)
-    assert len(errors) == 2
-    assert [NotBooleanError("line", "from_status", [5, 6])] == errors[0]
-    assert [NotBooleanError("line", "from_status", [5, 7])] == errors[2]
+    assert len(errors) == 3
+    assert NotBooleanError("line", "from_status", [5, 6]) == errors[0][0]
+    assert NotBooleanError("line", "from_status", [5, 7]) == errors[1][1]
+    assert NotBooleanError("line", "from_status", [5, 6]) == errors[2][0]

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -27,6 +27,7 @@ from power_grid_model.validation.errors import (
 from power_grid_model.validation.validation import (
     assert_valid_data_structure,
     validate_generic_power_sensor,
+    validate_ids,
     validate_required_values,
     validate_unique_ids_across_components,
     validate_values,
@@ -110,6 +111,34 @@ def test_validate_unique_ids_across_components():
         in unique_id_errors
     )
     assert len(unique_id_errors[0].ids) == 4
+
+
+def test_validate_ids():
+    source = initialize_array("input", "source", 3)
+    source["id"] = [1, 2, 3]
+
+    sym_load = initialize_array("input", "sym_load", 3)
+    sym_load["id"] = [4, 5, 6]
+
+    input_data = {
+        "source": source,
+        "sym_load": sym_load,
+    }
+
+    source_update = initialize_array("update", "source", 3)
+    source_update["id"] = [1, 2, 4]
+    source_update["u_ref"] = [1.0, 2.0, 3.0]
+
+    sym_load_update = initialize_array("update", "sym_load", 3)
+    sym_load_update["id"] = [4, 5, 7]
+    sym_load_update["p_specified"] = [4.0, 5.0, 6.0]
+
+    update_data = {"source": source_update, "sym_load": sym_load_update}
+
+    invalid_ids = validate_ids(update_data, input_data)
+
+    assert IdNotInDatasetError("source", [4], "update_data") in invalid_ids
+    assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -173,15 +173,15 @@ def test_validate_ids():
     assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
 
     source_update_part_nan_id = initialize_array("update", "source", 3)
-    source_update_part_nan_id["id"] = [1, -2147483648, 4]
+    source_update_part_nan_id["id"] = [1, np.iinfo(np.int32).min, 4]
     source_update_part_nan_id["u_ref"] = [1.0, 2.0, 3.0]
 
-    update_data_col_less_no_id = compatibility_convert_row_columnar_dataset(
-        data={"source": source_update_less_no_id, "sym_load": sym_load_update},
+    update_data_col_part_nan_id = compatibility_convert_row_columnar_dataset(
+        data={"source": source_update_part_nan_id, "sym_load": sym_load_update},
         data_filter=ComponentAttributeFilterOptions.relevant,
         dataset_type=DatasetType.update,
     )
-    invalid_ids = validate_ids(update_data_col_less_no_id, input_data)
+    invalid_ids = validate_ids(update_data_col_part_nan_id, input_data)
     assert len(invalid_ids) == 2
     assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
 

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -27,7 +27,6 @@ from power_grid_model.validation.errors import (
 from power_grid_model.validation.validation import (
     assert_valid_data_structure,
     validate_generic_power_sensor,
-    validate_ids_exist,
     validate_required_values,
     validate_unique_ids_across_components,
     validate_values,
@@ -111,34 +110,6 @@ def test_validate_unique_ids_across_components():
         in unique_id_errors
     )
     assert len(unique_id_errors[0].ids) == 4
-
-
-def test_validate_ids_exist():
-    source = initialize_array("input", "source", 3)
-    source["id"] = [1, 2, 3]
-
-    sym_load = initialize_array("input", "sym_load", 3)
-    sym_load["id"] = [4, 5, 6]
-
-    input_data = {
-        "source": source,
-        "sym_load": sym_load,
-    }
-
-    source_update = initialize_array("update", "source", 3)
-    source_update["id"] = [1, 2, 4]
-    source_update["u_ref"] = [1.0, 2.0, 3.0]
-
-    sym_load_update = initialize_array("update", "sym_load", 3)
-    sym_load_update["id"] = [4, 5, 7]
-    sym_load_update["p_specified"] = [4.0, 5.0, 6.0]
-
-    update_data = {"source": source_update, "sym_load": sym_load_update}
-
-    invalid_ids = validate_ids_exist(update_data, input_data)
-
-    assert IdNotInDatasetError("source", [4], "input_data") in invalid_ids
-    assert IdNotInDatasetError("sym_load", [7], "input_data") in invalid_ids
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -9,8 +9,16 @@ import numpy as np
 import pytest
 
 from power_grid_model import CalculationType, LoadGenType, MeasuredTerminalType, initialize_array, power_grid_meta_data
+from power_grid_model._utils import compatibility_convert_row_columnar_dataset
 from power_grid_model.core.dataset_definitions import ComponentType, DatasetType
-from power_grid_model.enum import Branch3Side, BranchSide, CalculationType, FaultType, TapChangingStrategy
+from power_grid_model.enum import (
+    Branch3Side,
+    BranchSide,
+    CalculationType,
+    ComponentAttributeFilterOptions,
+    FaultType,
+    TapChangingStrategy,
+)
 from power_grid_model.validation import assert_valid_input_data
 from power_grid_model.validation.errors import (
     IdNotInDatasetError,
@@ -138,6 +146,43 @@ def test_validate_ids():
     invalid_ids = validate_ids(update_data, input_data)
 
     assert IdNotInDatasetError("source", [4], "update_data") in invalid_ids
+    assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
+
+    source_update_no_id = initialize_array("update", "source", 3)
+    source_update_no_id["u_ref"] = [1.0, 2.0, 3.0]
+
+    update_data_col = compatibility_convert_row_columnar_dataset(
+        data={"source": source_update_no_id, "sym_load": sym_load_update},
+        data_filter=ComponentAttributeFilterOptions.relevant,
+        dataset_type=DatasetType.update,
+    )
+    invalid_ids = validate_ids(update_data_col, input_data)
+    assert len(invalid_ids) == 1
+    assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
+
+    source_update_less_no_id = initialize_array("update", "source", 2)
+    source_update_less_no_id["u_ref"] = [1.0, 2.0]
+
+    update_data_col_less_no_id = compatibility_convert_row_columnar_dataset(
+        data={"source": source_update_less_no_id, "sym_load": sym_load_update},
+        data_filter=ComponentAttributeFilterOptions.relevant,
+        dataset_type=DatasetType.update,
+    )
+    invalid_ids = validate_ids(update_data_col_less_no_id, input_data)
+    assert len(invalid_ids) == 2
+    assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
+
+    source_update_part_nan_id = initialize_array("update", "source", 3)
+    source_update_part_nan_id["id"] = [1, -2147483648, 4]
+    source_update_part_nan_id["u_ref"] = [1.0, 2.0, 3.0]
+
+    update_data_col_less_no_id = compatibility_convert_row_columnar_dataset(
+        data={"source": source_update_less_no_id, "sym_load": sym_load_update},
+        data_filter=ComponentAttributeFilterOptions.relevant,
+        dataset_type=DatasetType.update,
+    )
+    invalid_ids = validate_ids(update_data_col_less_no_id, input_data)
+    assert len(invalid_ids) == 2
     assert IdNotInDatasetError("sym_load", [7], "update_data") in invalid_ids
 
 


### PR DESCRIPTION
This PR updates the validation logic required for https://github.com/PowerGridModel/power-grid-model/pull/771, which is the implementation of step 7 in issue https://github.com/PowerGridModel/power-grid-model/issues/548

- [x] Revert the mark as fail
- [x] Update logic for checking
* [x] New unit test for `valid_ids`
  * [x] uniform update 
  * [x] ~~non-uniform update~~