### PR TITLE
BUG / Memory access violation in buffer span of update data

### DIFF
--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -475,7 +475,6 @@ TEST_CASE("API Model") {
 
         // update dataset - col
         DatasetConst update_dataset_col{"update", 1, 2};
-        DatasetConst update_dataset_col_no_id{"update", 1, 2};
 
         update_dataset_col.add_buffer("source", -1, 1, source_indptr.data(), nullptr);
         update_dataset_col.add_attribute_buffer("source", "id", update_source_id.data());
@@ -484,12 +483,6 @@ TEST_CASE("API Model") {
         update_dataset_col.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
         update_dataset_col.add_attribute_buffer("sym_load", "id", update_sym_load_id.data());
         update_dataset_col.add_attribute_buffer("sym_load", "q_specified", update_sym_load_q_specified.data());
-
-        update_dataset_col_no_id.add_buffer("source", -1, 1, source_indptr.data(), nullptr);
-        update_dataset_col_no_id.add_attribute_buffer("source", "u_ref", update_source_u_ref.data());
-
-        update_dataset_col_no_id.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
-        update_dataset_col_no_id.add_attribute_buffer("sym_load", "q_specified", update_sym_load_q_specified.data());
 
         // output data
         Buffer node_batch_output{PGM_def_sym_output_node, 2};

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -385,7 +385,7 @@ TEST_CASE("API Model") {
         }
     }
 
-    SUBCASE("Model update error AddressSanitizer Repro Case") {
+    SUBCASE("Model update error") {
         std::vector<ID> const node_id{0};
         std::vector<double> const node_u_rated{100.0};
         Buffer node_buffer{PGM_def_input_node, 1};
@@ -463,7 +463,7 @@ TEST_CASE("API Model") {
         std::vector<Idx> sym_load_indptr{0, 1, 2};
         std::vector<ID> const update_sym_load_id{2, 5};
         std::vector<double> const update_sym_load_q_specified{100.0, 300.0};
-        Buffer update_sym_load_buffer{PGM_def_update_sym_load, 1};
+        Buffer update_sym_load_buffer{PGM_def_update_sym_load, 2};
         update_sym_load_buffer.set_nan();
         update_sym_load_buffer.set_value(PGM_def_update_sym_load_id, update_sym_load_id.data(), -1);
         update_sym_load_buffer.set_value(PGM_def_update_sym_load_q_specified, update_sym_load_q_specified.data(), -1);
@@ -500,10 +500,6 @@ TEST_CASE("API Model") {
                 CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
                                 PowerGridBatchError);
             }
-            SUBCASE("Columnar update dataset") {
-                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_col),
-                                PowerGridBatchError);
-            }
         }
 
         SUBCASE("Columnar input dataset") {
@@ -511,10 +507,6 @@ TEST_CASE("API Model") {
 
             SUBCASE("Row-based update dataset") {
                 CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
-                                PowerGridBatchError);
-            }
-            SUBCASE("Columnar update dataset") {
-                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_col),
                                 PowerGridBatchError);
             }
         }

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -384,6 +384,148 @@ TEST_CASE("API Model") {
             CHECK(batch_node_result_u_angle[1] == doctest::Approx(0.0));
         }
     }
+
+    SUBCASE("Model update error AddressSanitizer Repro Case") {
+        std::vector<ID> const node_id{0};
+        std::vector<double> const node_u_rated{100.0};
+        Buffer node_buffer{PGM_def_input_node, 1};
+        node_buffer.set_nan();
+        node_buffer.set_value(PGM_def_input_node_id, node_id.data(), -1);
+        node_buffer.set_value(PGM_def_input_node_u_rated, node_u_rated.data(), -1);
+
+        std::vector<ID> const source_id{1};
+        std::vector<ID> const source_node{0};
+        std::vector<int8_t> const source_status{1};
+        std::vector<double> const source_u_ref{1.0};
+        std::vector<double> const source_sk{1000.0};
+        std::vector<double> const source_rx_ratio{0.0};
+        Buffer source_buffer{PGM_def_input_source, 1};
+        source_buffer.set_nan();
+        source_buffer.set_value(PGM_def_input_source_id, source_id.data(), -1);
+        source_buffer.set_value(PGM_def_input_source_node, source_node.data(), -1);
+        source_buffer.set_value(PGM_def_input_source_status, source_status.data(), -1);
+        source_buffer.set_value(PGM_def_input_source_u_ref, source_u_ref.data(), -1);
+        source_buffer.set_value(PGM_def_input_source_sk, source_sk.data(), -1);
+        source_buffer.set_value(PGM_def_input_source_rx_ratio, source_rx_ratio.data(), -1);
+
+        std::vector<ID> const sym_load_id{2};
+        std::vector<ID> const sym_load_node{0};
+        std::vector<int8_t> const sym_load_status{1};
+        std::vector<int8_t> const sym_load_type{2};
+        std::vector<double> const sym_load_p_specified{0.0};
+        std::vector<double> const sym_load_q_specified{500.0};
+        Buffer sym_load_buffer{PGM_def_input_sym_load, 1};
+        sym_load_buffer.set_nan();
+        sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_type, sym_load_type.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, sym_load_p_specified.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, sym_load_q_specified.data(), -1);
+
+        // input dataset - row
+        DatasetConst input_dataset_row{"input", 0, 1};
+        input_dataset_row.add_buffer("node", 1, 1, nullptr, node_buffer);
+        input_dataset_row.add_buffer("source", 1, 1, nullptr, source_buffer);
+        input_dataset_row.add_buffer("sym_load", 1, 1, nullptr, sym_load_buffer);
+
+        // input dataset - col
+        DatasetConst input_dataset_col{"input", 0, 1};
+        input_dataset_col.add_buffer("node", 1, 1, nullptr, nullptr);
+        input_dataset_col.add_attribute_buffer("node", "id", node_id.data());
+        input_dataset_col.add_attribute_buffer("node", "u_rated", node_u_rated.data());
+
+        input_dataset_col.add_buffer("source", 1, 1, nullptr, nullptr);
+        input_dataset_col.add_attribute_buffer("source", "id", source_id.data());
+        input_dataset_col.add_attribute_buffer("source", "node", source_node.data());
+        input_dataset_col.add_attribute_buffer("source", "status", source_status.data());
+        input_dataset_col.add_attribute_buffer("source", "u_ref", source_u_ref.data());
+        input_dataset_col.add_attribute_buffer("source", "sk", source_sk.data());
+        input_dataset_col.add_attribute_buffer("source", "rx_ratio", source_rx_ratio.data());
+
+        input_dataset_col.add_buffer("sym_load", 1, 1, nullptr, nullptr);
+        input_dataset_col.add_attribute_buffer("sym_load", "id", sym_load_id.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "node", sym_load_node.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "status", sym_load_status.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "type", sym_load_type.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "p_specified", sym_load_p_specified.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "q_specified", sym_load_q_specified.data());
+
+        // update dataset
+        std::vector<Idx> source_indptr{0, 1, 1};
+        std::vector<ID> const update_source_id{1};
+        std::vector<double> const update_source_u_ref{0.5};
+        Buffer update_source_buffer{PGM_def_update_source, 1};
+        update_source_buffer.set_nan();
+        update_source_buffer.set_value(PGM_def_update_source_id, update_source_id.data(), -1);
+        update_source_buffer.set_value(PGM_def_update_source_u_ref, update_source_u_ref.data(), -1);
+
+        std::vector<Idx> sym_load_indptr{0, 1, 2};
+        std::vector<ID> const update_sym_load_id{2, 5};
+        std::vector<double> const update_sym_load_q_specified{100.0, 300.0};
+        Buffer update_sym_load_buffer{PGM_def_update_sym_load, 1};
+        update_sym_load_buffer.set_nan();
+        update_sym_load_buffer.set_value(PGM_def_update_sym_load_id, update_sym_load_id.data(), -1);
+        update_sym_load_buffer.set_value(PGM_def_update_sym_load_q_specified, update_sym_load_q_specified.data(), -1);
+
+        // update dataset - row
+        DatasetConst update_dataset_row{"update", 1, 2};
+        update_dataset_row.add_buffer("source", -1, 1, source_indptr.data(), update_source_buffer);
+        update_dataset_row.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), update_sym_load_buffer);
+
+        // update dataset - col
+        DatasetConst update_dataset_col{"update", 1, 2};
+        DatasetConst update_dataset_col_no_id{"update", 1, 2};
+
+        update_dataset_col.add_buffer("source", -1, 1, source_indptr.data(), nullptr);
+        update_dataset_col.add_attribute_buffer("source", "id", update_source_id.data());
+        update_dataset_col.add_attribute_buffer("source", "u_ref", update_source_u_ref.data());
+
+        update_dataset_col.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
+        update_dataset_col.add_attribute_buffer("sym_load", "id", update_sym_load_id.data());
+        update_dataset_col.add_attribute_buffer("sym_load", "q_specified", update_sym_load_q_specified.data());
+
+        update_dataset_col_no_id.add_buffer("source", -1, 1, source_indptr.data(), nullptr);
+        update_dataset_col_no_id.add_attribute_buffer("source", "u_ref", update_source_u_ref.data());
+
+        update_dataset_col_no_id.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
+        update_dataset_col_no_id.add_attribute_buffer("sym_load", "q_specified", update_sym_load_q_specified.data());
+
+        // output data
+        Buffer node_batch_output{PGM_def_sym_output_node, 2};
+        node_batch_output.set_nan();
+        DatasetMutable batch_output_dataset{"sym_output", 1, 2};
+        batch_output_dataset.add_buffer("node", 1, 2, nullptr, node_batch_output);
+
+        // options
+        Options const options{};
+
+        SUBCASE("Row-based input dataset") {
+            Model model{50.0, input_dataset_row};
+
+            SUBCASE("Row-based update dataset") {
+                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
+                                PowerGridBatchError);
+            }
+            SUBCASE("Columnar update dataset") {
+                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_col),
+                                PowerGridBatchError);
+            }
+        }
+
+        SUBCASE("Columnar input dataset") {
+            Model model{50.0, input_dataset_col};
+
+            SUBCASE("Row-based update dataset") {
+                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
+                                PowerGridBatchError);
+            }
+            SUBCASE("Columnar update dataset") {
+                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_col),
+                                PowerGridBatchError);
+            }
+        }
+    }
 }
 
 } // namespace power_grid_model_cpp

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -385,71 +385,71 @@ TEST_CASE("API Model") {
         }
     }
 
-    SUBCASE("Model update error") {
-        std::vector<ID> const node_id{0};
-        std::vector<double> const node_u_rated{100.0};
-        Buffer node_buffer{PGM_def_input_node, 1};
-        node_buffer.set_nan();
-        node_buffer.set_value(PGM_def_input_node_id, node_id.data(), -1);
-        node_buffer.set_value(PGM_def_input_node_u_rated, node_u_rated.data(), -1);
+    SUBCASE("Self contained model update error") {
+        std::vector<ID> const input_node_id{0};
+        std::vector<double> const input_node_u_rated{100.0};
+        Buffer input_node_buffer{PGM_def_input_node, 1};
+        input_node_buffer.set_nan();
+        input_node_buffer.set_value(PGM_def_input_node_id, input_node_id.data(), -1);
+        input_node_buffer.set_value(PGM_def_input_node_u_rated, input_node_u_rated.data(), -1);
 
-        std::vector<ID> const source_id{1};
-        std::vector<ID> const source_node{0};
-        std::vector<int8_t> const source_status{1};
-        std::vector<double> const source_u_ref{1.0};
-        std::vector<double> const source_sk{1000.0};
-        std::vector<double> const source_rx_ratio{0.0};
-        Buffer source_buffer{PGM_def_input_source, 1};
-        source_buffer.set_nan();
-        source_buffer.set_value(PGM_def_input_source_id, source_id.data(), -1);
-        source_buffer.set_value(PGM_def_input_source_node, source_node.data(), -1);
-        source_buffer.set_value(PGM_def_input_source_status, source_status.data(), -1);
-        source_buffer.set_value(PGM_def_input_source_u_ref, source_u_ref.data(), -1);
-        source_buffer.set_value(PGM_def_input_source_sk, source_sk.data(), -1);
-        source_buffer.set_value(PGM_def_input_source_rx_ratio, source_rx_ratio.data(), -1);
+        std::vector<ID> const input_source_id{1};
+        std::vector<ID> const input_source_node{0};
+        std::vector<int8_t> const input_source_status{1};
+        std::vector<double> const input_source_u_ref{1.0};
+        std::vector<double> const input_source_sk{1000.0};
+        std::vector<double> const input_source_rx_ratio{0.0};
+        Buffer input_source_buffer{PGM_def_input_source, 1};
+        input_source_buffer.set_nan();
+        input_source_buffer.set_value(PGM_def_input_source_id, input_source_id.data(), -1);
+        input_source_buffer.set_value(PGM_def_input_source_node, input_source_node.data(), -1);
+        input_source_buffer.set_value(PGM_def_input_source_status, input_source_status.data(), -1);
+        input_source_buffer.set_value(PGM_def_input_source_u_ref, input_source_u_ref.data(), -1);
+        input_source_buffer.set_value(PGM_def_input_source_sk, input_source_sk.data(), -1);
+        input_source_buffer.set_value(PGM_def_input_source_rx_ratio, input_source_rx_ratio.data(), -1);
 
-        std::vector<ID> const sym_load_id{2};
-        std::vector<ID> const sym_load_node{0};
-        std::vector<int8_t> const sym_load_status{1};
-        std::vector<int8_t> const sym_load_type{2};
-        std::vector<double> const sym_load_p_specified{0.0};
-        std::vector<double> const sym_load_q_specified{500.0};
-        Buffer sym_load_buffer{PGM_def_input_sym_load, 1};
-        sym_load_buffer.set_nan();
-        sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
-        sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
-        sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
-        sym_load_buffer.set_value(PGM_def_input_sym_load_type, sym_load_type.data(), -1);
-        sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, sym_load_p_specified.data(), -1);
-        sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, sym_load_q_specified.data(), -1);
+        std::vector<ID> const input_sym_load_id{2};
+        std::vector<ID> const input_sym_load_node{0};
+        std::vector<int8_t> const input_sym_load_status{1};
+        std::vector<int8_t> const input_sym_load_type{2};
+        std::vector<double> const input_sym_load_p_specified{0.0};
+        std::vector<double> const input_sym_load_q_specified{500.0};
+        Buffer input_sym_load_buffer{PGM_def_input_sym_load, 1};
+        input_sym_load_buffer.set_nan();
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_id, input_sym_load_id.data(), -1);
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_node, input_sym_load_node.data(), -1);
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_status, input_sym_load_status.data(), -1);
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_type, input_sym_load_type.data(), -1);
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, input_sym_load_p_specified.data(), -1);
+        input_sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, input_sym_load_q_specified.data(), -1);
 
         // input dataset - row
         DatasetConst input_dataset_row{"input", 0, 1};
-        input_dataset_row.add_buffer("node", 1, 1, nullptr, node_buffer);
-        input_dataset_row.add_buffer("source", 1, 1, nullptr, source_buffer);
-        input_dataset_row.add_buffer("sym_load", 1, 1, nullptr, sym_load_buffer);
+        input_dataset_row.add_buffer("node", 1, 1, nullptr, input_node_buffer);
+        input_dataset_row.add_buffer("source", 1, 1, nullptr, input_source_buffer);
+        input_dataset_row.add_buffer("sym_load", 1, 1, nullptr, input_sym_load_buffer);
 
         // input dataset - col
         DatasetConst input_dataset_col{"input", 0, 1};
         input_dataset_col.add_buffer("node", 1, 1, nullptr, nullptr);
-        input_dataset_col.add_attribute_buffer("node", "id", node_id.data());
-        input_dataset_col.add_attribute_buffer("node", "u_rated", node_u_rated.data());
+        input_dataset_col.add_attribute_buffer("node", "id", input_node_id.data());
+        input_dataset_col.add_attribute_buffer("node", "u_rated", input_node_u_rated.data());
 
         input_dataset_col.add_buffer("source", 1, 1, nullptr, nullptr);
-        input_dataset_col.add_attribute_buffer("source", "id", source_id.data());
-        input_dataset_col.add_attribute_buffer("source", "node", source_node.data());
-        input_dataset_col.add_attribute_buffer("source", "status", source_status.data());
-        input_dataset_col.add_attribute_buffer("source", "u_ref", source_u_ref.data());
-        input_dataset_col.add_attribute_buffer("source", "sk", source_sk.data());
-        input_dataset_col.add_attribute_buffer("source", "rx_ratio", source_rx_ratio.data());
+        input_dataset_col.add_attribute_buffer("source", "id", input_source_id.data());
+        input_dataset_col.add_attribute_buffer("source", "node", input_source_node.data());
+        input_dataset_col.add_attribute_buffer("source", "status", input_source_status.data());
+        input_dataset_col.add_attribute_buffer("source", "u_ref", input_source_u_ref.data());
+        input_dataset_col.add_attribute_buffer("source", "sk", input_source_sk.data());
+        input_dataset_col.add_attribute_buffer("source", "rx_ratio", input_source_rx_ratio.data());
 
         input_dataset_col.add_buffer("sym_load", 1, 1, nullptr, nullptr);
-        input_dataset_col.add_attribute_buffer("sym_load", "id", sym_load_id.data());
-        input_dataset_col.add_attribute_buffer("sym_load", "node", sym_load_node.data());
-        input_dataset_col.add_attribute_buffer("sym_load", "status", sym_load_status.data());
-        input_dataset_col.add_attribute_buffer("sym_load", "type", sym_load_type.data());
-        input_dataset_col.add_attribute_buffer("sym_load", "p_specified", sym_load_p_specified.data());
-        input_dataset_col.add_attribute_buffer("sym_load", "q_specified", sym_load_q_specified.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "id", input_sym_load_id.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "node", input_sym_load_node.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "status", input_sym_load_status.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "type", input_sym_load_type.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "p_specified", input_sym_load_p_specified.data());
+        input_dataset_col.add_attribute_buffer("sym_load", "q_specified", input_sym_load_q_specified.data());
 
         // update dataset
         std::vector<Idx> source_indptr{0, 1, 1};
@@ -485,28 +485,28 @@ TEST_CASE("API Model") {
         update_dataset_col.add_attribute_buffer("sym_load", "q_specified", update_sym_load_q_specified.data());
 
         // output data
-        Buffer node_batch_output{PGM_def_sym_output_node, 2};
-        node_batch_output.set_nan();
-        DatasetMutable batch_output_dataset{"sym_output", 1, 2};
-        batch_output_dataset.add_buffer("node", 1, 2, nullptr, node_batch_output);
+        Buffer output_node_batch{PGM_def_sym_output_node, 2};
+        output_node_batch.set_nan();
+        DatasetMutable output_batch_dataset{"sym_output", 1, 2};
+        output_batch_dataset.add_buffer("node", 1, 2, nullptr, output_node_batch);
 
         // options
-        Options const options{};
+        Options const opt{};
 
         SUBCASE("Row-based input dataset") {
-            Model model{50.0, input_dataset_row};
+            Model row_model{50.0, input_dataset_row};
 
             SUBCASE("Row-based update dataset") {
-                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
+                CHECK_THROWS_AS(row_model.calculate(opt, output_batch_dataset, update_dataset_row),
                                 PowerGridBatchError);
             }
         }
 
         SUBCASE("Columnar input dataset") {
-            Model model{50.0, input_dataset_col};
+            Model col_model{50.0, input_dataset_col};
 
             SUBCASE("Row-based update dataset") {
-                CHECK_THROWS_AS(model.calculate(options, batch_output_dataset, update_dataset_row),
+                CHECK_THROWS_AS(col_model.calculate(opt, output_batch_dataset, update_dataset_row),
                                 PowerGridBatchError);
             }
         }


### PR DESCRIPTION
This is the repro case for the `AddressSanitizer` issue on Linux/WSL/gcc13. Source of bug is in main_model_impl.hpp, where the update data is querried as a buffer span.

The root cause of the bug is the fact that the API model is not correctly and thoroughly tested. This is exemplified by https://github.com/PowerGridModel/power-grid-model/pull/795. 

Further, this bug is believed to be closely related to https://github.com/PowerGridModel/power-grid-model/pull/802