### PR TITLE
Optional IDs tests

### DIFF
--- a/src/power_grid_model/core/buffer_handling.py
+++ b/src/power_grid_model/core/buffer_handling.py
@@ -245,7 +245,7 @@ def _get_sparse_buffer_properties(
             if attribute_data.ndim != ndim + schema.dtype[attribute].ndim or attribute_data.shape[:ndim] != shape:
                 raise ValueError(f"Data buffers must be consistent. {VALIDATOR_MSG}")
 
-    contents_size = shape[0] if len(shape) == 1 else shape[0] * shape[1]
+    contents_size = shape[0]
     check_indptr_consistency(indptr, batch_size, contents_size)
 
     is_batch = True

--- a/src/power_grid_model/core/buffer_handling.py
+++ b/src/power_grid_model/core/buffer_handling.py
@@ -136,7 +136,7 @@ def _get_indptr_view(indptr: np.ndarray) -> IdxPtr:  # type: ignore[valid-type]
     return np.ascontiguousarray(indptr, dtype=IdxNp).ctypes.data_as(IdxPtr)
 
 
-def _get_uniform_buffer_properties(
+def _get_dense_buffer_properties(
     data: ComponentData,
     schema: ComponentMetaData,
     is_batch: bool | None,
@@ -284,7 +284,7 @@ def get_buffer_properties(
         the properties of the dataset component.
     """
     if not is_sparse(data):
-        return _get_uniform_buffer_properties(data=data, schema=schema, is_batch=is_batch, batch_size=batch_size)
+        return _get_dense_buffer_properties(data=data, schema=schema, is_batch=is_batch, batch_size=batch_size)
 
     if is_batch is not None and not is_batch:
         raise ValueError("Sparse data must be batch data")
@@ -334,7 +334,7 @@ def _get_uniform_buffer_view(
     Returns:
         the C API buffer view.
     """
-    properties = _get_uniform_buffer_properties(data, schema=schema, is_batch=is_batch, batch_size=batch_size)
+    properties = _get_dense_buffer_properties(data, schema=schema, is_batch=is_batch, batch_size=batch_size)
 
     return CBuffer(
         data=_get_raw_component_data_view(data=data, schema=schema),

--- a/src/power_grid_model/core/buffer_handling.py
+++ b/src/power_grid_model/core/buffer_handling.py
@@ -245,7 +245,7 @@ def _get_sparse_buffer_properties(
             if attribute_data.ndim != ndim + schema.dtype[attribute].ndim or attribute_data.shape[:ndim] != shape:
                 raise ValueError(f"Data buffers must be consistent. {VALIDATOR_MSG}")
 
-    contents_size = sum(shape)
+    contents_size = shape[0] if len(shape) == 1 else shape[0] * shape[1]
     check_indptr_consistency(indptr, batch_size, contents_size)
 
     is_batch = True

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -538,4 +538,142 @@ TEST_CASE("API Model") {
     }
 }
 
+/*
+
+source_1 -- node_0 --load_2
+
+source and node inputs are row based.
+load input is either row based or columnar.
+load update is row based / columnar and densse / sparse.
+
+invalid_id_t tests are for testing the error handling of the model when the id is not found in the update dataset.
+optional_id_t tests are for testing the model when the id is not added to the update dataset.
+
+*/
+TEST_CASE_TEMPLATE(
+    "API update id tests", T, TypeCombo<row_t, row_t, dense_t, with_id_t>, TypeCombo<row_t, row_t, sparse_t, with_id_t>,
+    TypeCombo<columnar_t, columnar_t, dense_t, with_id_t>, TypeCombo<columnar_t, columnar_t, sparse_t, with_id_t>,
+    TypeCombo<columnar_t, row_t, dense_t, with_id_t>, TypeCombo<columnar_t, row_t, sparse_t, with_id_t>,
+    TypeCombo<row_t, columnar_t, dense_t, with_id_t>, TypeCombo<row_t, columnar_t, sparse_t, with_id_t>,
+    TypeCombo<row_t, row_t, dense_t, optional_id_t>, TypeCombo<row_t, row_t, sparse_t, optional_id_t>,
+    TypeCombo<columnar_t, columnar_t, dense_t, optional_id_t>,
+    TypeCombo<columnar_t, columnar_t, sparse_t, optional_id_t>, TypeCombo<columnar_t, row_t, dense_t, optional_id_t>,
+    TypeCombo<columnar_t, row_t, sparse_t, optional_id_t>, TypeCombo<row_t, columnar_t, dense_t, optional_id_t>,
+    TypeCombo<row_t, columnar_t, sparse_t, optional_id_t>, TypeCombo<row_t, row_t, dense_t, invalid_id_t>,
+    TypeCombo<row_t, row_t, sparse_t, invalid_id_t>, TypeCombo<columnar_t, columnar_t, dense_t, invalid_id_t>,
+    TypeCombo<columnar_t, columnar_t, sparse_t, invalid_id_t>, TypeCombo<columnar_t, row_t, dense_t, invalid_id_t>,
+    TypeCombo<columnar_t, row_t, sparse_t, invalid_id_t>, TypeCombo<row_t, columnar_t, dense_t, invalid_id_t>,
+    TypeCombo<row_t, columnar_t, sparse_t, invalid_id_t>) {
+
+    using namespace std::string_literals;
+    using input_type = typename T::input_type;
+    using update_type = typename T::update_type;
+    using sparsity_type = typename T::sparsity_type;
+    using id_check_type = typename T::id_check_type;
+
+    DatasetConst input_dataset{"input", 0, 1};
+    DatasetConst update_dataset{"update", 1, 2};
+
+    std::vector<ID> const node_id{0};
+    std::vector<double> const node_u_rated{100.0};
+    Buffer node_buffer{PGM_def_input_node, 1};
+    node_buffer.set_nan();
+    node_buffer.set_value(PGM_def_input_node_id, node_id.data(), -1);
+    node_buffer.set_value(PGM_def_input_node_u_rated, node_u_rated.data(), -1);
+    input_dataset.add_buffer("node", 1, 1, nullptr, node_buffer);
+
+    std::vector<ID> const source_id{1};
+    std::vector<ID> const source_node{0};
+    std::vector<int8_t> const source_status{1};
+    std::vector<double> const source_u_ref{1.0};
+    std::vector<double> const source_sk{1000.0};
+    std::vector<double> const source_rx_ratio{0.0};
+    Buffer source_buffer{PGM_def_input_source, 1};
+    source_buffer.set_nan();
+    source_buffer.set_value(PGM_def_input_source_id, source_id.data(), -1);
+    source_buffer.set_value(PGM_def_input_source_node, source_node.data(), -1);
+    source_buffer.set_value(PGM_def_input_source_status, source_status.data(), -1);
+    source_buffer.set_value(PGM_def_input_source_u_ref, source_u_ref.data(), -1);
+    source_buffer.set_value(PGM_def_input_source_sk, source_sk.data(), -1);
+    source_buffer.set_value(PGM_def_input_source_rx_ratio, source_rx_ratio.data(), -1);
+    input_dataset.add_buffer("source", 1, 1, nullptr, source_buffer);
+
+    std::vector<ID> const sym_load_id{2};
+    std::vector<ID> const sym_load_node{0};
+    std::vector<int8_t> const sym_load_status{1};
+    std::vector<int8_t> const sym_load_type{2};
+    std::vector<double> const sym_load_p_specified{0.0};
+    std::vector<double> const sym_load_q_specified{500.0};
+    Buffer sym_load_buffer{PGM_def_input_sym_load, 1};
+    sym_load_buffer.set_nan();
+    sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
+    sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
+    sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
+    sym_load_buffer.set_value(PGM_def_input_sym_load_type, sym_load_type.data(), -1);
+    sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, sym_load_p_specified.data(), -1);
+    sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, sym_load_q_specified.data(), -1);
+
+    if constexpr (std::is_same_v<input_type, row_t>) {
+        input_dataset.add_buffer("sym_load", 1, 1, nullptr, sym_load_buffer);
+    } else {
+        input_dataset.add_buffer("sym_load", 1, 1, nullptr, nullptr);
+        input_dataset.add_attribute_buffer("sym_load", "id", sym_load_id.data());
+        input_dataset.add_attribute_buffer("sym_load", "node", sym_load_node.data());
+        input_dataset.add_attribute_buffer("sym_load", "status", sym_load_status.data());
+        input_dataset.add_attribute_buffer("sym_load", "type", sym_load_type.data());
+        input_dataset.add_attribute_buffer("sym_load", "p_specified", sym_load_p_specified.data());
+        input_dataset.add_attribute_buffer("sym_load", "q_specified", sym_load_q_specified.data());
+    }
+
+    std::vector<Idx> sym_load_indptr{0, 1, 2};
+    std::vector<double> load_updates_q_specified = {100.0, 300.0};
+
+    auto load_updates_id = []() {
+        if constexpr (std::is_same_v<id_check_type, invalid_id_t>) {
+            return std::vector<ID>{2, 5};
+        }
+        return std::vector<ID>{2, 2};
+    }();
+
+    Buffer sym_load_update_buffer{PGM_def_update_sym_load, 2};
+    sym_load_update_buffer.set_nan();
+    if constexpr (!std::is_same_v<id_check_type, optional_id_t>) {
+        sym_load_update_buffer.set_value(PGM_def_update_sym_load_id, load_updates_id.data(), -1);
+    }
+    sym_load_update_buffer.set_value(PGM_def_update_sym_load_q_specified, load_updates_q_specified.data(), -1);
+
+    if constexpr (std::is_same_v<update_type, row_t>) {
+        if constexpr (std::is_same_v<sparsity_type, dense_t>) {
+            update_dataset.add_buffer("sym_load", 1, 2, nullptr, sym_load_update_buffer);
+        } else {
+            update_dataset.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), sym_load_update_buffer);
+        }
+    } else {
+        if constexpr (std::is_same_v<sparsity_type, dense_t>) {
+            update_dataset.add_buffer("sym_load", 1, 2, nullptr, nullptr);
+        } else {
+            update_dataset.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
+        }
+
+        if constexpr (!std::is_same_v<id_check_type, optional_id_t>) {
+            update_dataset.add_attribute_buffer("sym_load", "id", load_updates_id.data());
+        }
+        update_dataset.add_attribute_buffer("sym_load", "q_specified", load_updates_q_specified.data());
+    }
+
+    // output dataset
+    Buffer batch_node_output{PGM_def_sym_output_node, 2};
+    batch_node_output.set_nan();
+    DatasetMutable batch_output_dataset{"sym_output", 1, 2};
+    batch_output_dataset.add_buffer("node", 1, 2, nullptr, batch_node_output);
+    
+    Options const batch_options{};
+    Model model{50.0, input_dataset};
+    if constexpr (std::is_same_v<id_check_type, invalid_id_t>) {
+        CHECK_THROWS_AS(model.calculate(batch_options, batch_output_dataset, update_dataset), PowerGridBatchError);
+    } else {
+        model.calculate(batch_options, batch_output_dataset, update_dataset);
+    }
+}
+
 } // namespace power_grid_model_cpp

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -594,15 +594,15 @@ TEST_CASE_TEMPLATE(
     std::vector<double> const sym_load_p_specified{0.0};
     std::vector<double> const sym_load_q_specified{500.0};
     Buffer sym_load_buffer{PGM_def_input_sym_load, 1};
-    sym_load_buffer.set_nan();
-    sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
-    sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
-    sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
-    sym_load_buffer.set_value(PGM_def_input_sym_load_type, sym_load_type.data(), -1);
-    sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, sym_load_p_specified.data(), -1);
-    sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, sym_load_q_specified.data(), -1);
 
     if constexpr (std::is_same_v<input_type, row_t>) {
+        sym_load_buffer.set_nan();
+        sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_type, sym_load_type.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_p_specified, sym_load_p_specified.data(), -1);
+        sym_load_buffer.set_value(PGM_def_input_sym_load_q_specified, sym_load_q_specified.data(), -1);
         input_dataset.add_buffer("sym_load", 1, 1, nullptr, sym_load_buffer);
     } else {
         input_dataset.add_buffer("sym_load", 1, 1, nullptr, nullptr);

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -600,9 +600,9 @@ TEST_CASE_TEMPLATE(
     std::vector<double> const sym_load_p_specified{0.0};
     std::vector<double> const sym_load_q_specified{500.0};
     Buffer sym_load_buffer{PGM_def_input_sym_load, 1};
+    sym_load_buffer.set_nan();
 
     if constexpr (std::is_same_v<input_type, row_t>) {
-        sym_load_buffer.set_nan();
         sym_load_buffer.set_value(PGM_def_input_sym_load_id, sym_load_id.data(), -1);
         sym_load_buffer.set_value(PGM_def_input_sym_load_node, sym_load_node.data(), -1);
         sym_load_buffer.set_value(PGM_def_input_sym_load_status, sym_load_status.data(), -1);
@@ -620,8 +620,8 @@ TEST_CASE_TEMPLATE(
         input_dataset.add_attribute_buffer("sym_load", "q_specified", sym_load_q_specified.data());
     }
 
-    std::vector<Idx> sym_load_indptr{0, 1, 2};
-    std::vector<double> load_updates_q_specified = {100.0, 300.0};
+    std::vector<Idx> const sym_load_indptr{0, 1, 2};
+    std::vector<double> const load_updates_q_specified = {100.0, 300.0};
 
     auto load_updates_id = []() {
         if constexpr (std::is_same_v<id_check_type, invalid_id_t>) {

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -231,11 +231,8 @@ TEST_CASE("API Model") {
     SUBCASE("Single power flow") {
         SUBCASE("Simple power flow") {
             model.calculate(options, single_output_dataset);
-            node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
             node_output.get_value(PGM_def_sym_output_node_u, node_result_u.data(), 0, 1, -1);
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(50.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.5));
         }
@@ -243,11 +240,8 @@ TEST_CASE("API Model") {
         SUBCASE("Simple update") {
             model.update(single_update_dataset);
             model.calculate(options, single_output_dataset);
-            node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
             node_output.get_value(PGM_def_sym_output_node_u, node_result_u.data(), 0, 1, -1);
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(40.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.4));
         }
@@ -255,16 +249,17 @@ TEST_CASE("API Model") {
         SUBCASE("Copy model") {
             auto model_copy = Model{model};
             model_copy.calculate(options, single_output_dataset);
-            node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
             node_output.get_value(PGM_def_sym_output_node_u, node_result_u.data(), 0, 1, -1);
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
-            node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(50.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.5));
         }
 
-        // Common checks for single power flow tests
+        // Common checks applicable for single power flow tests
+        node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
+        node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
+        node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
+
         CHECK(node_result_id[0] == 0);
         CHECK(node_result_energized[0] == 1);
         CHECK(node_result_u_angle[0] == doctest::Approx(0.0));

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -81,7 +81,6 @@ struct columnar_t {};
 struct sparse_t {};
 struct dense_t {};
 struct with_id_t {};
-struct optional_id_t {};
 struct invalid_id_t {};
 
 template <typename first, typename second, typename third, typename fourth> struct TypeCombo {
@@ -555,15 +554,10 @@ TEST_CASE_TEMPLATE(
     TypeCombo<columnar_t, columnar_t, dense_t, with_id_t>, TypeCombo<columnar_t, columnar_t, sparse_t, with_id_t>,
     TypeCombo<columnar_t, row_t, dense_t, with_id_t>, TypeCombo<columnar_t, row_t, sparse_t, with_id_t>,
     TypeCombo<row_t, columnar_t, dense_t, with_id_t>, TypeCombo<row_t, columnar_t, sparse_t, with_id_t>,
-    TypeCombo<row_t, row_t, dense_t, optional_id_t>, TypeCombo<row_t, row_t, sparse_t, optional_id_t>,
-    TypeCombo<columnar_t, columnar_t, dense_t, optional_id_t>,
-    TypeCombo<columnar_t, columnar_t, sparse_t, optional_id_t>, TypeCombo<columnar_t, row_t, dense_t, optional_id_t>,
-    TypeCombo<columnar_t, row_t, sparse_t, optional_id_t>, TypeCombo<row_t, columnar_t, dense_t, optional_id_t>,
-    TypeCombo<row_t, columnar_t, sparse_t, optional_id_t>, TypeCombo<row_t, row_t, dense_t, invalid_id_t>,
-    TypeCombo<row_t, row_t, sparse_t, invalid_id_t>, TypeCombo<columnar_t, columnar_t, dense_t, invalid_id_t>,
-    TypeCombo<columnar_t, columnar_t, sparse_t, invalid_id_t>, TypeCombo<columnar_t, row_t, dense_t, invalid_id_t>,
-    TypeCombo<columnar_t, row_t, sparse_t, invalid_id_t>, TypeCombo<row_t, columnar_t, dense_t, invalid_id_t>,
-    TypeCombo<row_t, columnar_t, sparse_t, invalid_id_t>) {
+    TypeCombo<row_t, row_t, dense_t, invalid_id_t>, TypeCombo<row_t, row_t, sparse_t, invalid_id_t>,
+    TypeCombo<columnar_t, columnar_t, dense_t, invalid_id_t>, TypeCombo<columnar_t, columnar_t, sparse_t, invalid_id_t>,
+    TypeCombo<columnar_t, row_t, dense_t, invalid_id_t>, TypeCombo<columnar_t, row_t, sparse_t, invalid_id_t>,
+    TypeCombo<row_t, columnar_t, dense_t, invalid_id_t>, TypeCombo<row_t, columnar_t, sparse_t, invalid_id_t>) {
 
     using namespace std::string_literals;
     using input_type = typename T::input_type;
@@ -637,9 +631,7 @@ TEST_CASE_TEMPLATE(
 
     Buffer sym_load_update_buffer{PGM_def_update_sym_load, 2};
     sym_load_update_buffer.set_nan();
-    if constexpr (!std::is_same_v<id_check_type, optional_id_t>) {
-        sym_load_update_buffer.set_value(PGM_def_update_sym_load_id, load_updates_id.data(), -1);
-    }
+    sym_load_update_buffer.set_value(PGM_def_update_sym_load_id, load_updates_id.data(), -1);
     sym_load_update_buffer.set_value(PGM_def_update_sym_load_q_specified, load_updates_q_specified.data(), -1);
 
     if constexpr (std::is_same_v<update_type, row_t>) {
@@ -655,9 +647,7 @@ TEST_CASE_TEMPLATE(
             update_dataset.add_buffer("sym_load", -1, 2, sym_load_indptr.data(), nullptr);
         }
 
-        if constexpr (!std::is_same_v<id_check_type, optional_id_t>) {
-            update_dataset.add_attribute_buffer("sym_load", "id", load_updates_id.data());
-        }
+        update_dataset.add_attribute_buffer("sym_load", "id", load_updates_id.data());
         update_dataset.add_attribute_buffer("sym_load", "q_specified", load_updates_q_specified.data());
     }
 
@@ -666,7 +656,7 @@ TEST_CASE_TEMPLATE(
     batch_node_output.set_nan();
     DatasetMutable batch_output_dataset{"sym_output", 1, 2};
     batch_output_dataset.add_buffer("node", 1, 2, nullptr, batch_node_output);
-    
+
     Options const batch_options{};
     Model model{50.0, input_dataset};
     if constexpr (std::is_same_v<id_check_type, invalid_id_t>) {

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -229,12 +229,30 @@ TEST_CASE("API Model") {
     model = std::move(model_dummy);
 
     SUBCASE("Single power flow") {
+
+        // Common checker used for all single power flow test subcases
+        auto check_common_node_results = [&]() {
+            node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
+            node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
+            node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
+
+            CHECK(node_result_id[0] == 0);
+            CHECK(node_result_energized[0] == 1);
+            CHECK(node_result_u_angle[0] == doctest::Approx(0.0));
+            CHECK(node_result_id[1] == 4);
+            CHECK(node_result_energized[1] == 0);
+            CHECK(node_result_u[1] == doctest::Approx(0.0));
+            CHECK(node_result_u_pu[1] == doctest::Approx(0.0));
+            CHECK(node_result_u_angle[1] == doctest::Approx(0.0));
+        };
+
         SUBCASE("Simple power flow") {
             model.calculate(options, single_output_dataset);
             node_output.get_value(PGM_def_sym_output_node_u, node_result_u.data(), 0, 1, -1);
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(50.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.5));
+            check_common_node_results();
         }
 
         SUBCASE("Simple update") {
@@ -244,6 +262,7 @@ TEST_CASE("API Model") {
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(40.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.4));
+            check_common_node_results();
         }
 
         SUBCASE("Copy model") {
@@ -253,21 +272,8 @@ TEST_CASE("API Model") {
             node_output.get_value(PGM_def_sym_output_node_u_pu, node_result_u_pu.data(), -1);
             CHECK(node_result_u[0] == doctest::Approx(50.0));
             CHECK(node_result_u_pu[0] == doctest::Approx(0.5));
+            check_common_node_results();
         }
-
-        // Common checks applicable for single power flow tests
-        node_output.get_value(PGM_def_sym_output_node_id, node_result_id.data(), -1);
-        node_output.get_value(PGM_def_sym_output_node_energized, node_result_energized.data(), 0, -1);
-        node_output.get_value(PGM_def_sym_output_node_u_angle, node_result_u_angle.data(), -1);
-
-        CHECK(node_result_id[0] == 0);
-        CHECK(node_result_energized[0] == 1);
-        CHECK(node_result_u_angle[0] == doctest::Approx(0.0));
-        CHECK(node_result_id[1] == 4);
-        CHECK(node_result_energized[1] == 0);
-        CHECK(node_result_u[1] == doctest::Approx(0.0));
-        CHECK(node_result_u_pu[1] == doctest::Approx(0.0));
-        CHECK(node_result_u_angle[1] == doctest::Approx(0.0));
     }
 
     SUBCASE("Get indexer") {

--- a/tests/unit/test_buffer_handling.py
+++ b/tests/unit/test_buffer_handling.py
@@ -15,13 +15,15 @@ from power_grid_model.core.power_grid_meta import initialize_array, power_grid_m
 
 
 def load_data(component_type, is_batch, is_sparse, is_columnar):
+    """Creates load data of different formats for testing"""
     shape = (2, 4) if is_batch else (4,)
     load = initialize_array(DatasetType.update, component_type, shape)
+    columnar_names = ["p_specified", "q_specified"]
 
     if is_columnar:
         if is_sparse:
-            return {"indptr": np.array([0, 5, 8]), "data": {k: load.reshape(-1)[k] for k in load.dtype.names}}
-        return {k: load[k] for k in load.dtype.names}
+            return {"indptr": np.array([0, 5, 8]), "data": {k: load.reshape(-1)[k] for k in columnar_names}}
+        return {k: load[k] for k in columnar_names}
     if is_sparse:
         return {"indptr": np.array([0, 5, 8]), "data": load.reshape(-1)}
     return load

--- a/tests/unit/test_buffer_handling.py
+++ b/tests/unit/test_buffer_handling.py
@@ -9,7 +9,7 @@ Power grid model buffer handler tests
 import numpy as np
 import pytest
 
-from power_grid_model.core.buffer_handling import _get_sparse_buffer_properties, _get_uniform_buffer_properties
+from power_grid_model.core.buffer_handling import _get_sparse_buffer_properties, _get_dense_buffer_properties
 from power_grid_model.core.dataset_definitions import ComponentType, DatasetType
 from power_grid_model.core.power_grid_meta import initialize_array, power_grid_meta_data
 
@@ -42,11 +42,11 @@ def load_data(component_type, is_batch, is_sparse, is_columnar):
         pytest.param(ComponentType.asym_load, False, False, id="asym_load-single-row_based"),
     ],
 )
-def test__get_uniform_buffer_properties(component_type, is_batch, is_columnar):
+def test__get_dense_buffer_properties(component_type, is_batch, is_columnar):
     data = load_data(component_type, is_batch=is_batch, is_columnar=is_columnar, is_sparse=False)
     schema = power_grid_meta_data[DatasetType.update][component_type]
     batch_size = 2 if is_batch else None
-    properties = _get_uniform_buffer_properties(data, schema=schema, is_batch=is_batch, batch_size=batch_size)
+    properties = _get_dense_buffer_properties(data, schema=schema, is_batch=is_batch, batch_size=batch_size)
 
     assert not properties.is_sparse
     assert properties.is_batch == is_batch

--- a/tests/unit/test_buffer_handling.py
+++ b/tests/unit/test_buffer_handling.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Power grid model buffer handler tests
+"""
+
+import numpy as np
+import pytest
+
+from power_grid_model.core.buffer_handling import _get_sparse_buffer_properties, _get_uniform_buffer_properties
+from power_grid_model.core.dataset_definitions import ComponentType, DatasetType
+from power_grid_model.core.power_grid_meta import initialize_array, power_grid_meta_data
+
+
+def load_data(component_type, is_batch, is_sparse, is_columnar):
+    shape = (2, 4) if is_batch else (4,)
+    load = initialize_array(DatasetType.update, component_type, shape)
+
+    if is_columnar:
+        if is_sparse:
+            return {"indptr": np.array([0, 5, 8]), "data": {k: load.reshape(-1)[k] for k in load.dtype.names}}
+        return {k: load[k] for k in load.dtype.names}
+    if is_sparse:
+        return {"indptr": np.array([0, 5, 8]), "data": load.reshape(-1)}
+    return load
+
+
+@pytest.mark.parametrize(
+    "component_type, is_batch, is_columnar",
+    [
+        pytest.param(ComponentType.sym_load, True, True, id="sym_load-batch-columnar"),
+        pytest.param(ComponentType.sym_load, True, False, id="sym_load-batch-row_based"),
+        pytest.param(ComponentType.sym_load, False, True, id="sym_load-single-columnar"),
+        pytest.param(ComponentType.sym_load, False, False, id="sym_load-single-row_based"),
+        pytest.param(ComponentType.asym_load, True, True, id="asym_load-batch-columnar"),
+        pytest.param(ComponentType.asym_load, True, False, id="asym_load-batch-row_based"),
+        pytest.param(ComponentType.asym_load, False, True, id="asym_load-single-columnar"),
+        pytest.param(ComponentType.asym_load, False, False, id="asym_load-single-row_based"),
+    ],
+)
+def test__get_uniform_buffer_properties(component_type, is_batch, is_columnar):
+    data = load_data(component_type, is_batch=is_batch, is_columnar=is_columnar, is_sparse=False)
+    schema = power_grid_meta_data[DatasetType.update][component_type]
+    batch_size = 2 if is_batch else None
+    properties = _get_uniform_buffer_properties(data, schema=schema, is_batch=is_batch, batch_size=batch_size)
+
+    assert not properties.is_sparse
+    assert properties.is_batch == is_batch
+    assert properties.batch_size == (2 if is_batch else 1)
+    assert properties.n_elements_per_scenario == 4
+    assert properties.n_total_elements == 8 if is_batch else 4
+    if is_columnar:
+        assert properties.columns == list(data.keys())
+    else:
+        assert properties.columns is None
+
+
+@pytest.mark.parametrize(
+    "component_type, is_columnar",
+    [
+        pytest.param(ComponentType.sym_load, True, id="sym_load-columnar"),
+        pytest.param(ComponentType.sym_load, False, id="sym_load-row_based"),
+        pytest.param(ComponentType.asym_load, True, id="asym_load-columnar"),
+        pytest.param(ComponentType.asym_load, False, id="asym_load-row_based"),
+    ],
+)
+def test__get_sparse_buffer_properties(component_type, is_columnar):
+    data = load_data(component_type, is_batch=True, is_columnar=is_columnar, is_sparse=True)
+
+    schema = power_grid_meta_data[DatasetType.update][component_type]
+    properties = _get_sparse_buffer_properties(data, schema=schema, batch_size=2)
+
+    assert properties.is_sparse
+    assert properties.is_batch
+    assert properties.batch_size == 2
+    assert properties.n_elements_per_scenario == -1
+    assert properties.n_total_elements == 8
+    if is_columnar:
+        assert properties.columns == list(data["data"].keys())
+    else:
+        assert properties.columns is None

--- a/tests/unit/test_buffer_handling.py
+++ b/tests/unit/test_buffer_handling.py
@@ -9,7 +9,7 @@ Power grid model buffer handler tests
 import numpy as np
 import pytest
 
-from power_grid_model.core.buffer_handling import _get_sparse_buffer_properties, _get_dense_buffer_properties
+from power_grid_model.core.buffer_handling import _get_dense_buffer_properties, _get_sparse_buffer_properties
 from power_grid_model.core.dataset_definitions import ComponentType, DatasetType
 from power_grid_model.core.power_grid_meta import initialize_array, power_grid_meta_data
 

--- a/tests/unit/test_power_grid_model.py
+++ b/tests/unit/test_power_grid_model.py
@@ -281,10 +281,7 @@ def input_sym_load_col(input_row):
     )
 
 
-@pytest.fixture(params=[
-    pytest.param("input_row", id="input_row"),
-    pytest.param("input_sym_load_col", id="input_col")
-])
+@pytest.fixture(params=[pytest.param("input_row", id="input_row"), pytest.param("input_sym_load_col", id="input_col")])
 def minimal_input(request):
     return request.getfixturevalue(request.param)
 
@@ -345,7 +342,9 @@ def test_update_ids_batch(minimal_update, minimal_input):
         pytest.param(update_sym_load_row_optional_id(), id="update_dense_row"),
         pytest.param(update_sym_load_col(update_sym_load_row_optional_id()), id="update_dense_col"),
         pytest.param(update_sym_load_sparse(update_sym_load_row_optional_id()), id="update_sparse_row"),
-        pytest.param(update_sym_load_col(update_sym_load_sparse(update_sym_load_row_optional_id())), id="update_sparse_col"),
+        pytest.param(
+            update_sym_load_col(update_sym_load_sparse(update_sym_load_row_optional_id())), id="update_sparse_col"
+        ),
     ],
 )
 def test_update_id_optional(minimal_update, minimal_input):

--- a/tests/unit/test_power_grid_model.py
+++ b/tests/unit/test_power_grid_model.py
@@ -281,7 +281,10 @@ def input_sym_load_col(input_row):
     )
 
 
-@pytest.fixture(params=["input_row", "input_sym_load_col"])
+@pytest.fixture(params=[
+    pytest.param("input_row", id="input_row"),
+    pytest.param("input_sym_load_col", id="input_col")
+])
 def minimal_input(request):
     return request.getfixturevalue(request.param)
 
@@ -324,10 +327,10 @@ def update_sym_load_sparse(update_data):
 @pytest.mark.parametrize(
     "minimal_update",
     [
-        update_sym_load_row(),
-        update_sym_load_col(update_sym_load_row()),
-        update_sym_load_sparse(update_sym_load_row()),
-        update_sym_load_col(update_sym_load_sparse(update_sym_load_row())),
+        pytest.param(update_sym_load_row(), id="update_dense_row"),
+        pytest.param(update_sym_load_col(update_sym_load_row()), id="update_dense_col"),
+        pytest.param(update_sym_load_sparse(update_sym_load_row()), id="update_sparse_row"),
+        pytest.param(update_sym_load_col(update_sym_load_sparse(update_sym_load_row())), id="update_sparse_col"),
     ],
 )
 def test_update_ids_batch(minimal_update, minimal_input):
@@ -339,10 +342,10 @@ def test_update_ids_batch(minimal_update, minimal_input):
 @pytest.mark.parametrize(
     "minimal_update",
     [
-        update_sym_load_row_optional_id(),
-        update_sym_load_col(update_sym_load_row_optional_id()),
-        update_sym_load_sparse(update_sym_load_row_optional_id()),
-        update_sym_load_col(update_sym_load_sparse(update_sym_load_row_optional_id())),
+        pytest.param(update_sym_load_row_optional_id(), id="update_dense_row"),
+        pytest.param(update_sym_load_col(update_sym_load_row_optional_id()), id="update_dense_col"),
+        pytest.param(update_sym_load_sparse(update_sym_load_row_optional_id()), id="update_sparse_row"),
+        pytest.param(update_sym_load_col(update_sym_load_sparse(update_sym_load_row_optional_id())), id="update_sparse_col"),
     ],
 )
 def test_update_id_optional(minimal_update, minimal_input):

--- a/tests/unit/test_power_grid_model.py
+++ b/tests/unit/test_power_grid_model.py
@@ -15,13 +15,7 @@ from power_grid_model import (
     initialize_array,
 )
 from power_grid_model._utils import compatibility_convert_row_columnar_dataset
-from power_grid_model.errors import (
-    IDNotFound,
-    InvalidCalculationMethod,
-    IterationDiverge,
-    PowerGridBatchError,
-    PowerGridError,
-)
+from power_grid_model.errors import InvalidCalculationMethod, IterationDiverge, PowerGridBatchError, PowerGridError
 from power_grid_model.utils import get_dataset_scenario
 from power_grid_model.validation import assert_valid_input_data
 


### PR DESCRIPTION
Tests for https://github.com/PowerGridModel/power-grid-model/pull/813

### Changes proposed in this PR include:

- Minor refactoring in a0b2c09
- C++ Tests added in 9e24f85
-  Tests for optional ids removed e5d5670 as there is no way to skip or xfail specific params. The commit can be reverted when those tests are needed.
- Python tests added. (Remove xfail for new features)
- Tests for buffer handling

### Additional points

- The location doesn't seem right. Maybe we should only keep errors here and rest to main model tests. 
- The `self contained model update error` seems to repeated.
