### PR TITLE
Rename get_component_sequence in state_queries.hpp

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
@@ -41,7 +41,7 @@ constexpr Idx get_component_group_idx(MainModelState<ComponentContainer> const& 
 
 template <typename ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
-inline Idx get_component_sequence(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
+inline Idx get_component_sequence_idx(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
     return state.components.template get_seq<ComponentType>(id_or_index);
 }
 
@@ -97,19 +97,19 @@ constexpr auto get_component_citer(MainModelState<ComponentContainer> const& sta
 template <std::derived_from<Branch> ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
 constexpr auto get_topology_index(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
-    return get_component_sequence<Branch>(state, id_or_index);
+    return get_component_sequence_idx<Branch>(state, id_or_index);
 }
 
 template <std::derived_from<Branch3> ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
 constexpr auto get_topology_index(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
-    return get_component_sequence<Branch3>(state, id_or_index);
+    return get_component_sequence_idx<Branch3>(state, id_or_index);
 }
 
 template <std::derived_from<Regulator> ComponentType, class ComponentContainer>
     requires model_component_state_c<MainModelState, ComponentContainer, ComponentType>
 constexpr auto get_topology_index(MainModelState<ComponentContainer> const& state, auto const& id_or_index) {
-    return get_component_sequence<Regulator>(state, id_or_index);
+    return get_component_sequence_idx<Regulator>(state, id_or_index);
 }
 
 template <std::derived_from<Branch> ComponentType, class ComponentContainer>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topology.hpp
@@ -40,8 +40,8 @@ template <std::same_as<Branch> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.branch_node_idx, [&state](Branch const& branch) {
-        return BranchIdx{get_component_sequence<Node>(state, branch.from_node()),
-                         get_component_sequence<Node>(state, branch.to_node())};
+        return BranchIdx{get_component_sequence_idx<Node>(state, branch.from_node()),
+                         get_component_sequence_idx<Node>(state, branch.to_node())};
     });
 }
 
@@ -50,9 +50,9 @@ template <std::same_as<Branch3> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.branch3_node_idx, [&state](Branch3 const& branch3) {
-        return Branch3Idx{get_component_sequence<Node>(state, branch3.node_1()),
-                          get_component_sequence<Node>(state, branch3.node_2()),
-                          get_component_sequence<Node>(state, branch3.node_3())};
+        return Branch3Idx{get_component_sequence_idx<Node>(state, branch3.node_1()),
+                          get_component_sequence_idx<Node>(state, branch3.node_2()),
+                          get_component_sequence_idx<Node>(state, branch3.node_3())};
     });
 }
 
@@ -61,7 +61,7 @@ template <std::same_as<Source> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.source_node_idx, [&state](Source const& source) {
-        return get_component_sequence<Node>(state, source.node());
+        return get_component_sequence_idx<Node>(state, source.node());
     });
 }
 
@@ -70,7 +70,7 @@ template <std::same_as<Shunt> Component, class ComponentContainer>
 constexpr void register_topology_components(MainModelState<ComponentContainer> const& state,
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(state, comp_topo.shunt_node_idx, [&state](Shunt const& shunt) {
-        return get_component_sequence<Node>(state, shunt.node());
+        return get_component_sequence_idx<Node>(state, shunt.node());
     });
 }
 
@@ -80,7 +80,7 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(
         state, comp_topo.load_gen_node_idx,
-        [&state](GenericLoadGen const& load_gen) { return get_component_sequence<Node>(state, load_gen.node()); });
+        [&state](GenericLoadGen const& load_gen) { return get_component_sequence_idx<Node>(state, load_gen.node()); });
 
     detail::register_topo_components<Component>(state, comp_topo.load_gen_type,
                                                 [](GenericLoadGen const& load_gen) { return load_gen.type(); });
@@ -92,7 +92,7 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
                                             ComponentTopology& comp_topo) {
     detail::register_topo_components<Component>(
         state, comp_topo.voltage_sensor_node_idx, [&state](GenericVoltageSensor const& voltage_sensor) {
-            return get_component_sequence<Node>(state, voltage_sensor.measured_object());
+            return get_component_sequence_idx<Node>(state, voltage_sensor.measured_object());
         });
 }
 
@@ -110,21 +110,21 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
             case branch_from:
                 [[fallthrough]];
             case branch_to:
-                return get_component_sequence<Branch>(state, measured_object);
+                return get_component_sequence_idx<Branch>(state, measured_object);
             case source:
-                return get_component_sequence<Source>(state, measured_object);
+                return get_component_sequence_idx<Source>(state, measured_object);
             case shunt:
-                return get_component_sequence<Shunt>(state, measured_object);
+                return get_component_sequence_idx<Shunt>(state, measured_object);
             case load:
                 [[fallthrough]];
             case generator:
-                return get_component_sequence<GenericLoadGen>(state, measured_object);
+                return get_component_sequence_idx<GenericLoadGen>(state, measured_object);
             case branch3_1:
             case branch3_2:
             case branch3_3:
-                return get_component_sequence<Branch3>(state, measured_object);
+                return get_component_sequence_idx<Branch3>(state, measured_object);
             case node:
-                return get_component_sequence<Node>(state, measured_object);
+                return get_component_sequence_idx<Node>(state, measured_object);
             default:
                 throw MissingCaseForEnumError("Power sensor idx to seq transformation",
                                               power_sensor.get_terminal_type());
@@ -144,9 +144,9 @@ constexpr void register_topology_components(MainModelState<ComponentContainer> c
         state, comp_topo.regulated_object_idx, [&state](Regulator const& regulator) {
             switch (regulator.regulated_object_type()) {
             case ComponentType::branch:
-                return get_component_sequence<Branch>(state, regulator.regulated_object());
+                return get_component_sequence_idx<Branch>(state, regulator.regulated_object());
             case ComponentType::branch3:
-                return get_component_sequence<Branch3>(state, regulator.regulated_object());
+                return get_component_sequence_idx<Branch3>(state, regulator.regulated_object());
             default:
                 throw MissingCaseForEnumError("Regulator idx to seq transformation", regulator.regulated_object_type());
             }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -974,7 +974,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                 if constexpr (std::derived_from<ComponentType, Branch>) {
                     Idx2D const math_idx =
                         state.topo_comp_coup
-                            ->branch[main_core::get_component_sequence<Branch>(state, changed_component_idx)];
+                            ->branch[main_core::get_component_sequence_idx<Branch>(state, changed_component_idx)];
                     if (math_idx.group == isolated_component) {
                         return;
                     }
@@ -983,7 +983,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                 } else if constexpr (std::derived_from<ComponentType, Branch3>) {
                     Idx2DBranch3 const math_idx =
                         state.topo_comp_coup
-                            ->branch3[main_core::get_component_sequence<Branch3>(state, changed_component_idx)];
+                            ->branch3[main_core::get_component_sequence_idx<Branch3>(state, changed_component_idx)];
                     if (math_idx.group == isolated_component) {
                         return;
                     }
@@ -996,7 +996,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
                 } else if constexpr (std::same_as<ComponentType, Shunt>) {
                     Idx2D const math_idx =
                         state.topo_comp_coup
-                            ->shunt[main_core::get_component_sequence<Shunt>(state, changed_component_idx)];
+                            ->shunt[main_core::get_component_sequence_idx<Shunt>(state, changed_component_idx)];
                     if (math_idx.group == isolated_component) {
                         return;
                     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -82,8 +82,8 @@ template <class ComponentContainer>
 inline void add_to_edge(main_core::MainModelState<ComponentContainer> const& state, TrafoGraphEdges& edges,
                         TrafoGraphEdgeProperties& edge_props, ID const& start, ID const& end,
                         TrafoGraphEdge const& edge_prop) {
-    Idx const start_idx = main_core::get_component_sequence<Node>(state, start);
-    Idx const end_idx = main_core::get_component_sequence<Node>(state, end);
+    Idx const start_idx = main_core::get_component_sequence_idx<Node>(state, start);
+    Idx const end_idx = main_core::get_component_sequence_idx<Node>(state, end);
     edges.emplace_back(start_idx, end_idx);
     edge_props.emplace_back(edge_prop);
 }
@@ -218,7 +218,7 @@ inline auto build_transformer_graph(State const& state) -> TransformerGraph {
     // Mark sources
     for (auto const& source : state.components.template citer<Source>()) {
         // ignore disabled sources
-        trafo_graph[main_core::get_component_sequence<Node>(state, source.node())].is_source = source.status();
+        trafo_graph[main_core::get_component_sequence_idx<Node>(state, source.node())].is_source = source.status();
     }
 
     return trafo_graph;


### PR DESCRIPTION
Quick PR to rename `get_component_sequence` to `get_component_sequence_idx` from `state_queries.hpp` since it returns a sequence index, not a sequence itself.
