### PR TITLE
Adding message to `NotObservableError` when no voltage sensor present

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/exception.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/exception.hpp
@@ -112,7 +112,12 @@ class SparseMatrixError : public PowerGridError {
 
 class NotObservableError : public PowerGridError {
   public:
-    NotObservableError() { append_msg("Not enough measurements available for state estimation.\n"); }
+    NotObservableError(std::string const& msg = "") {
+        append_msg("Not enough measurements available for state estimation.\n");
+        if (!msg.empty()) {
+            append_msg(msg + "\n");
+        }
+    }
 };
 
 class IterationDiverge : public PowerGridError {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/observability.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/observability.hpp
@@ -68,7 +68,7 @@ inline void necessary_observability_check(MeasuredValues<sym> const& measured_va
 
     auto const [n_voltage_sensor, n_voltage_phasor_sensor] = detail::count_voltage_sensors(n_bus, measured_values);
     if (n_voltage_sensor < 1) {
-        throw NotObservableError{};
+        throw NotObservableError{"no voltage sensor found"};
     }
 
     Idx const n_injection_sensor = detail::count_bus_injection_sensors(n_bus, measured_values);


### PR DESCRIPTION
This PR adds message to the `NotObservableError` when no voltage sensor present.