### PR TITLE
Add launch file to run one validation test case

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug validation test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.buildDirectory}/bin/power_grid_model_validation_tests",
+            "args": [
+                "--test-case=Validation test single",
+                "--subcase=power_flow/1os2msr-sym-newton_raphson"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "linux": {
+                "MIMode": "gdb",
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+        }
+    ]
+}

--- a/.vscode/launch.json.license
+++ b/.vscode/launch.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
Add a `launch.json` so that developers can easily run one validation test case.