### PR TITLE
Resolve difference between input and update

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/voltage_sensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/voltage_sensor.hpp
@@ -75,19 +75,18 @@ template <symmetry_tag sym> class VoltageSensor : public GenericVoltageSensor {
     explicit VoltageSensor(VoltageSensorInput<sym> const& voltage_sensor_input, double u_rated)
         : GenericVoltageSensor{voltage_sensor_input},
           u_rated_{u_rated},
-          u_sigma_{voltage_sensor_input.u_sigma / (u_rated_ * u_scale<sym>)},
-          u_measured_{voltage_sensor_input.u_measured / (u_rated_ * u_scale<sym>)},
+          u_sigma_{voltage_sensor_input.u_sigma * inv_u_norm()},
+          u_measured_{voltage_sensor_input.u_measured * inv_u_norm()},
           u_angle_measured_{voltage_sensor_input.u_angle_measured} {};
 
     UpdateChange update(VoltageSensorUpdate<sym> const& update_data) {
         assert(update_data.id == this->id() || is_nan(update_data.id));
-        double const scalar = 1 / (u_rated_ * u_scale<sym>);
 
-        update_real_value<sym>(update_data.u_measured, u_measured_, scalar);
+        update_real_value<sym>(update_data.u_measured, u_measured_, inv_u_norm());
         update_real_value<sym>(update_data.u_angle_measured, u_angle_measured_, 1.0);
 
         if (!is_nan(update_data.u_sigma)) {
-            u_sigma_ = update_data.u_sigma * scalar;
+            u_sigma_ = update_data.u_sigma * inv_u_norm();
         }
 
         return {false, false};
@@ -109,6 +108,8 @@ template <symmetry_tag sym> class VoltageSensor : public GenericVoltageSensor {
     double u_sigma_;
     RealValue<sym> u_measured_;
     RealValue<sym> u_angle_measured_;
+
+    constexpr auto inv_u_norm() const { return 1.0 / (u_rated_ * u_scale<sym>); }
 
     bool has_angle() const {
         if constexpr (is_symmetric_v<sym>) {

--- a/tests/cpp_unit_tests/test_power_sensor.cpp
+++ b/tests/cpp_unit_tests/test_power_sensor.cpp
@@ -571,6 +571,34 @@ TEST_CASE("Test power sensor") {
         CHECK(result.q_residual[2] != r_nan[2]);
     }
 
+    SUBCASE("Construction and update") {
+        PowerSensorInput<symmetric_t> sym_power_sensor_input{.id = 7,
+                                                             .measured_object = 3,
+                                                             .measured_terminal_type =
+                                                                 MeasuredTerminalType::branch_from,
+                                                             .power_sigma = 269258.24035672517,
+                                                             .p_measured = -2e5,
+                                                             .q_measured = -1e6,
+                                                             .p_sigma = 2.5e5,
+                                                             .q_sigma = 1e5};
+        PowerSensorUpdate<symmetric_t> sym_power_sensor_update{.id = 7,
+                                                               .power_sigma = sym_power_sensor_input.power_sigma,
+                                                               .p_measured = sym_power_sensor_input.p_measured,
+                                                               .q_measured = sym_power_sensor_input.q_measured,
+                                                               .p_sigma = sym_power_sensor_input.p_sigma,
+                                                               .q_sigma = sym_power_sensor_input.q_sigma};
+
+        SymPowerSensor sym_power_sensor{sym_power_sensor_input};
+        auto const orig_calc_param = sym_power_sensor.calc_param<symmetric_t>();
+
+        sym_power_sensor.update(sym_power_sensor_update);
+        auto const updated_calc_param = sym_power_sensor.calc_param<symmetric_t>();
+
+        CHECK(orig_calc_param.value == updated_calc_param.value);
+        CHECK(orig_calc_param.p_variance == updated_calc_param.p_variance);
+        CHECK(orig_calc_param.q_variance == updated_calc_param.q_variance);
+    }
+
     SUBCASE("Update inverse - sym") {
         constexpr auto power_sigma = 1.0;
         constexpr auto p_measured = 2.0;

--- a/tests/cpp_unit_tests/test_voltage_sensor.cpp
+++ b/tests/cpp_unit_tests/test_voltage_sensor.cpp
@@ -496,6 +496,25 @@ TEST_CASE("Test voltage sensor") {
         }
     }
 
+    SUBCASE("Construction and update") {
+        VoltageSensorInput<symmetric_t> sym_voltage_sensor_input{
+            .id = 7, .measured_object = 3, .u_sigma = 1.0, .u_measured = 25000, .u_angle_measured = -0.2};
+        VoltageSensorUpdate<symmetric_t> sym_voltage_sensor_update{.id = 7,
+                                                                   .u_sigma = sym_voltage_sensor_input.u_sigma,
+                                                                   .u_measured = sym_voltage_sensor_input.u_measured,
+                                                                   .u_angle_measured =
+                                                                       sym_voltage_sensor_input.u_angle_measured};
+
+        SymVoltageSensor sym_voltage_sensor{sym_voltage_sensor_input, 31250};
+        auto const orig_calc_param = sym_voltage_sensor.calc_param<symmetric_t>();
+
+        sym_voltage_sensor.update(sym_voltage_sensor_update);
+        auto const updated_calc_param = sym_voltage_sensor.calc_param<symmetric_t>();
+
+        CHECK(orig_calc_param.value == updated_calc_param.value);
+        CHECK(orig_calc_param.variance == updated_calc_param.variance);
+    }
+
     SUBCASE("Update inverse - sym") {
         constexpr auto u_sigma = 1.0;
         constexpr auto u_measured = 2.0;


### PR DESCRIPTION
It turns out that input data and update data are not treated exactly the same way in power sensors.

When rounding errors caused by this propagate, a difference may occur between single calculations run with measurement data provided in input data, or (batch or single) calculations with power sensor measurements provided in (batch or permanent) update data.

NOTE: similar rounding errors introduced when calculating the inverse update may also propagate to other scenarios, so the result may even differ between different orderings of batch scenarios or threading levels

* [x] power sensor
  * [x] this fix works as is for the input vs update of power sensor
  * [x] ~but not yet for the inverse update~ EDIT: as mentioned below: we do not apply the propagation of inverse update calculation in this PR. It may not be as big of an issue as one would expect.
* [x] voltage sensor
  * [x] ~from a quick investigation, it turns out that the voltage sensor may also be prone to this, but no combination of values that reproduces this bug has been found yet~ EDIT: a combination of values was found and added to the unit tests.
* [x] other component types
  * [x] it seems that other component types are not prone to this bug, because their input/update values are directly stored without modifications.
  * [x] this suggests that doing so for the sensors as well provides a sustainable solution
