### PR TITLE
disable mypy call-overload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ ignore_missing_imports = true
 show_column_numbers = true
 non_interactive = true
 install_types = true
-
+disable_error_code = ["call-overload"]  # mypy 1.14.0 does not like PGM's data_types
 
 # CI build options
 [tool.cibuildwheel]


### PR DESCRIPTION
Mypy 1.14.0 cannot handle PGM's data_types.

For now, let's ignore this. We need to investigate after the holidays