### PR TITLE
Fix quality issue

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/short_circuit_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/short_circuit_solver.hpp
@@ -62,7 +62,6 @@ template <symmetry_tag sym> class ShortCircuitSolver {
 
   private:
     Idx n_bus_;
-    Idx n_fault_;
     Idx n_source_;
     // shared topo data
     std::shared_ptr<DenseGroupedIdxVector const> sources_per_bus_;


### PR DESCRIPTION
Fixes https://sonarcloud.io/summary/new_code?id=PowerGridModel_power-grid-model

`n_fault_` (`private` member of `ShortCircuitSolver`) was never initialized, but it was never used either. This triggered a sonar cloud flag and hence the decreased rating. I am removing the unused member variable.