### PR TITLE
Autogenerate class/module diagrams for Python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,8 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
   jobs:
     post_install:
       # Build package with doc requirements from pyproject.optional-dependencies
@@ -21,6 +23,11 @@ build:
       - find power_grid_model_c/power_grid_model_c/include -name *.h -exec sed -i -r "s/PGM_API //g" {} \;
       # build doxygen for C header
       - cd docs/doxygen && doxygen && cd ../..
+      # build class and package diagrams
+      - pyreverse --no-standalone -o dot src/power_grid_model
+      - ccomps -x classes.dot | dot -Grankdir=LR -Nfontsize=13 -Efontsize=13 | gvpack -m100 -array_l1 | neato -n2 -Tsvg -o docs/_static/classes.svg
+      - dot packages.dot -Grankdir=TD -Nfontsize=13 -Efontsize=13 -Tsvg -o docs/_static/packages.svg
+      - rm packages.dot classes.dot
       # download support
       - wget -P docs/release_and_support https://github.com/PowerGridModel/.github/raw/main/RELEASE.md
       - wget -P docs/release_and_support https://github.com/PowerGridModel/.github/raw/main/SUPPORT.md

--- a/docs/advanced_documentation/python-wrapper-design.md
+++ b/docs/advanced_documentation/python-wrapper-design.md
@@ -1,0 +1,37 @@
+<!--
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Design of the Python Wrapper Package
+
+The structure of the `power_grid_model` Python package is shown here below by means of the corresponding class and package diagrams.
+
+## Class Graph Diagram
+
+This is the class diagram of the `power_grid_model` package.
+
+```{note}
+Only classes that have connections to other classes are shown in this diagram.
+```
+
+```{raw} html
+<div style="overflow-x: auto; white-space: nowrap;">
+  <img src="../_static/classes.svg" style="max-width: none;" alt="Classe diagram">
+</div>.
+```
+
+## Package Graph Diagram
+
+This is the package diagram of the `power_grid_model` package.
+
+```{note}
+Only modules that import (or are impored by) other modules are shown in this diagram.
+```
+
+```{raw} html
+<div style="overflow-x: auto; white-space: nowrap;">
+  <img src="../_static/packages.svg" style="max-width: none;" alt="Package diagram">
+</div>.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ advanced_documentation/native-data-interface
 advanced_documentation/build-guide
 advanced_documentation/c-api
 advanced_documentation/core-design
+advanced_documentation/python-wrapper-design
 ```
 ```{toctree}
 :caption: "Contribution"


### PR DESCRIPTION
**Fixes issue**: `#695 [FEATURE] Autogenerate class/module diagrams for Python`

### Changes proposed in this PR include:

I added a new page to the docs, Advanced Documentation > Design of the Python Wrapper Package. I did not add much introductory text but I can do so if it's necessary.
The page contains:
- a class diagram. I excluded the classes that have no connections to other classes, as their structure is not really relevant (not that they are unimportant, but they don't provide meaningful info on the structure in my opinion).
- a package diagram. It's a bit crowded with many unordered connections. I have tried several options with graphviz layout engines to improve it, with no success.

### Could you please pay extra attention to the points below when reviewing the PR:
- The graphs are big, but the user is able to scroll the graph pictures to the right. Let me know if you have other suggestions to make the graphs better and more readable.
- I added the following settings to `.readthedocs.yaml` as `graphviz` is required to build the diagrams (see https://stackoverflow.com/a/77369269/23534352).
   ```YAML
    apt_packages:
    - graphviz
   ```
- I have noticed that pyreverse mistakes the module power_grid_model.enum as if it were the builtin Python enum module, that is why that block has an arrow looping over it. I am investigating this problem but I am not positive that a clean solution exists.