### PR TITLE
disable cmake policy that removes FindBoost.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include(GNUInstallDirs)
 
-find_package(Eigen3 CONFIG REQUIRED)
+cmake_policy(SET CMP0167 OLD)  # libboost-headers packaged by conda does not come with BoostConfig.cmake
 find_package(Boost REQUIRED)
+find_package(Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(msgpack-cxx REQUIRED)
 


### PR DESCRIPTION
Workaround for compatibility with CMake >= 3.30 due to https://cmake.org/cmake/help/latest/policy/CMP0167.html#policy:CMP0167

Depending on the outcome of https://github.com/conda-forge/boost-feedstock/issues/226 and when CMake actually removes the deprecated functionality, we may need to move to `libboost-devel` for Windows instead in the future.