### PR TITLE
fix clang-tidy

### DIFF
--- a/tests/cpp_unit_tests/test_current_sensor.cpp
+++ b/tests/cpp_unit_tests/test_current_sensor.cpp
@@ -48,12 +48,13 @@ TEST_CASE("Test current sensor") {
             ComplexValue<symmetric_t> const i_sym = (1.0 * 1e3 + 1i * 0.0) / base_current;
             ComplexValue<asymmetric_t> const i_asym = i_sym * RealValue<asymmetric_t>{1.0};
 
-            CurrentSensor<symmetric_t> sym_current_sensor{sym_current_sensor_input, u_rated};
+            CurrentSensor<symmetric_t> const sym_current_sensor{sym_current_sensor_input, u_rated};
 
             CurrentSensorCalcParam<symmetric_t> sym_sensor_param = sym_current_sensor.calc_param<symmetric_t>();
             CurrentSensorCalcParam<asymmetric_t> asym_sensor_param = sym_current_sensor.calc_param<asymmetric_t>();
 
-            CurrentSensorOutput<symmetric_t> sym_sensor_output = sym_current_sensor.get_output<symmetric_t>(i_sym);
+            CurrentSensorOutput<symmetric_t> const sym_sensor_output =
+                sym_current_sensor.get_output<symmetric_t>(i_sym);
             CurrentSensorOutput<asymmetric_t> sym_sensor_output_asym_param =
                 sym_current_sensor.get_output<asymmetric_t>(i_asym);
 

--- a/tests/cpp_unit_tests/test_power_sensor.cpp
+++ b/tests/cpp_unit_tests/test_power_sensor.cpp
@@ -572,21 +572,21 @@ TEST_CASE("Test power sensor") {
     }
 
     SUBCASE("Construction and update") {
-        PowerSensorInput<symmetric_t> sym_power_sensor_input{.id = 7,
-                                                             .measured_object = 3,
-                                                             .measured_terminal_type =
-                                                                 MeasuredTerminalType::branch_from,
-                                                             .power_sigma = 269258.24035672517,
-                                                             .p_measured = -2e5,
-                                                             .q_measured = -1e6,
-                                                             .p_sigma = 2.5e5,
-                                                             .q_sigma = 1e5};
-        PowerSensorUpdate<symmetric_t> sym_power_sensor_update{.id = 7,
-                                                               .power_sigma = sym_power_sensor_input.power_sigma,
-                                                               .p_measured = sym_power_sensor_input.p_measured,
-                                                               .q_measured = sym_power_sensor_input.q_measured,
-                                                               .p_sigma = sym_power_sensor_input.p_sigma,
-                                                               .q_sigma = sym_power_sensor_input.q_sigma};
+        PowerSensorInput<symmetric_t> const sym_power_sensor_input{.id = 7,
+                                                                   .measured_object = 3,
+                                                                   .measured_terminal_type =
+                                                                       MeasuredTerminalType::branch_from,
+                                                                   .power_sigma = 269258.24035672517,
+                                                                   .p_measured = -2e5,
+                                                                   .q_measured = -1e6,
+                                                                   .p_sigma = 2.5e5,
+                                                                   .q_sigma = 1e5};
+        PowerSensorUpdate<symmetric_t> const sym_power_sensor_update{.id = 7,
+                                                                     .power_sigma = sym_power_sensor_input.power_sigma,
+                                                                     .p_measured = sym_power_sensor_input.p_measured,
+                                                                     .q_measured = sym_power_sensor_input.q_measured,
+                                                                     .p_sigma = sym_power_sensor_input.p_sigma,
+                                                                     .q_sigma = sym_power_sensor_input.q_sigma};
 
         SymPowerSensor sym_power_sensor{sym_power_sensor_input};
         auto const orig_calc_param = sym_power_sensor.calc_param<symmetric_t>();

--- a/tests/cpp_unit_tests/test_voltage_sensor.cpp
+++ b/tests/cpp_unit_tests/test_voltage_sensor.cpp
@@ -497,13 +497,13 @@ TEST_CASE("Test voltage sensor") {
     }
 
     SUBCASE("Construction and update") {
-        VoltageSensorInput<symmetric_t> sym_voltage_sensor_input{
+        VoltageSensorInput<symmetric_t> const sym_voltage_sensor_input{
             .id = 7, .measured_object = 3, .u_sigma = 1.0, .u_measured = 25000, .u_angle_measured = -0.2};
-        VoltageSensorUpdate<symmetric_t> sym_voltage_sensor_update{.id = 7,
-                                                                   .u_sigma = sym_voltage_sensor_input.u_sigma,
-                                                                   .u_measured = sym_voltage_sensor_input.u_measured,
-                                                                   .u_angle_measured =
-                                                                       sym_voltage_sensor_input.u_angle_measured};
+        VoltageSensorUpdate<symmetric_t> const sym_voltage_sensor_update{
+            .id = 7,
+            .u_sigma = sym_voltage_sensor_input.u_sigma,
+            .u_measured = sym_voltage_sensor_input.u_measured,
+            .u_angle_measured = sym_voltage_sensor_input.u_angle_measured};
 
         SymVoltageSensor sym_voltage_sensor{sym_voltage_sensor_input, 31250};
         auto const orig_calc_param = sym_voltage_sensor.calc_param<symmetric_t>();


### PR DESCRIPTION
Fixes the Nightly that has been broken for a couple days because clang-tidy fails

* [x] Full Clang-Tidy run passes again: https://github.com/PowerGridModel/power-grid-model/actions/runs/12863274808
