### PR TITLE
use link time optimization for CI release build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -254,7 +254,10 @@
     },
     {
       "name": "ci-clang-release",
-      "inherits": "clang-release"
+      "inherits": "clang-release",
+      "cacheVariables": {
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
+      }
     },
     {
       "name": "ci-gcc-debug",
@@ -270,7 +273,10 @@
       "name": "ci-gcc-release",
       "inherits": [
         "gcc-release"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
+      }
     },
     {
       "name": "ci-sonar",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,11 +129,7 @@
         "CMAKE_C_CLANG_TIDY": "clang-tidy",
         "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
         "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
-      },
-      "environment": {
-        "ASAN_OPTIONS": "detect_odr_violation=0"
+        "CMAKE_CXX_COMPILER": "clang++"
       },
       "inherits": "unix-base",
       "hidden": true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -276,6 +276,9 @@
       ],
       "cacheVariables": {
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_odr_violation=0"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,7 +129,11 @@
         "CMAKE_C_CLANG_TIDY": "clang-tidy",
         "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
         "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++"
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_odr_violation=0"
       },
       "inherits": "unix-base",
       "hidden": true

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
@@ -93,7 +93,7 @@ concept is_in_list_c = (std::same_as<std::remove_const_t<T>, Ts> || ...);
 
 // functor to include all
 struct IncludeAll {
-    constexpr bool operator()(Idx /*ignored*/) const { return true; }
+    template <class... T> constexpr bool operator()(T&&... /*ignored*/) const { return true; }
 };
 constexpr IncludeAll include_all{};
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
@@ -91,4 +91,10 @@ using IntSVector = std::vector<IntS>;
 template <class T, class... Ts>
 concept is_in_list_c = (std::same_as<std::remove_const_t<T>, Ts> || ...);
 
+// functor to include all
+struct IncludeAll {
+    constexpr bool operator()(Idx /*ignored*/) const { return true; }
+};
+constexpr IncludeAll include_all{};
+
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -1014,8 +1014,6 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         return math_param_increment;
     }
 
-    static constexpr auto include_all = [](Idx) { return true; };
-
     /** This is a heavily templated member function because it operates on many different variables of many
      *different types, but the essence is ever the same: filling one member (vector) of the calculation calc_input
      *struct (soa) with the right calculation symmetric or asymmetric calculation parameters, in the same order as
@@ -1068,7 +1066,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
      */
     template <calculation_input_type CalcStructOut, typename CalcParamOut,
               std::vector<CalcParamOut>(CalcStructOut::*comp_vect), class ComponentIn,
-              std::invocable<Idx> PredicateIn = decltype(include_all)>
+              std::invocable<Idx> PredicateIn = IncludeAll>
         requires std::convertible_to<std::invoke_result_t<PredicateIn, Idx>, bool>
     static void prepare_input(MainModelState const& state, std::vector<Idx2D> const& components,
                               std::vector<CalcStructOut>& calc_input, PredicateIn include = include_all) {
@@ -1087,7 +1085,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
 
     template <calculation_input_type CalcStructOut, typename CalcParamOut,
               std::vector<CalcParamOut>(CalcStructOut::*comp_vect), class ComponentIn,
-              std::invocable<Idx> PredicateIn = decltype(include_all)>
+              std::invocable<Idx> PredicateIn = IncludeAll>
         requires std::convertible_to<std::invoke_result_t<PredicateIn, Idx>, bool>
     static void prepare_input(MainModelState const& state, std::vector<Idx2D> const& components,
                               std::vector<CalcStructOut>& calc_input,

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
@@ -498,9 +498,16 @@ template <symmetry_tag sym> class MeasuredValues {
     }
 
     // process one object
-    static constexpr auto default_status_checker = [](auto x) -> bool { return x; };
+    struct DefaultStatusChecker {
+        template<class T>
+        bool operator()(T x) const {
+            return x;
+        }
+    };
 
-    template <class TS, class StatusChecker = decltype(default_status_checker)>
+    static constexpr DefaultStatusChecker default_status_checker{};
+
+    template <class TS, class StatusChecker = DefaultStatusChecker>
     static Idx process_one_object(Idx const object, grouped_idx_vector_type auto const& sensors_per_object,
                                   std::vector<TS> const& object_status,
                                   std::vector<PowerSensorCalcParam<sym>> const& input_data,

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp
@@ -499,10 +499,7 @@ template <symmetry_tag sym> class MeasuredValues {
 
     // process one object
     struct DefaultStatusChecker {
-        template<class T>
-        bool operator()(T x) const {
-            return x;
-        }
+        template <class T> bool operator()(T x) const { return x; }
     };
 
     static constexpr DefaultStatusChecker default_status_checker{};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
@@ -429,8 +429,6 @@ class Topology {
         }
     }
 
-    static constexpr auto include_all = [](Idx) { return true; };
-
     // proxy class to find the coupled object in math model in the coupling process to a single type object
     //    given a particular component index
     struct SingleTypeObjectFinder {
@@ -481,7 +479,7 @@ class Topology {
     // The coupling element should be pre-allocated in coupling
     // Only connect the component if include(component_i) returns true
     template <Idx (MathModelTopology::*n_obj_fn)() const, typename GetMathTopoComponent,
-              typename ObjectFinder = SingleTypeObjectFinder, typename Predicate = decltype(include_all)>
+              typename ObjectFinder = SingleTypeObjectFinder, typename Predicate = IncludeAll>
         requires std::invocable<std::remove_cvref_t<GetMathTopoComponent>, MathModelTopology&> &&
                  grouped_idx_vector_type<
                      std::remove_reference_t<std::invoke_result_t<GetMathTopoComponent, MathModelTopology&>>>


### PR DESCRIPTION
Use Link Time Optimization for CI release build for all targets. This is achieved by setting `CMAKE_INTERPROCEDURAL_OPTIMIZATION` in the preset.

In the user build, the C-API always enables LTO.