### PR TITLE
docs: add link to pgm-ds in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Currently, it supports the following calculations:
 
 See the [power-grid-model documentation](https://power-grid-model.readthedocs.io/en/stable/) for more information.
 For various conversions to the power-grid-model, refer to the [power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io) repository.
+For an extended python interface to the the power-grid-model, refer to the [power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds) repository.
 
 ```{note}
 Want to be updated on the latest news and releases? Subscribe to the Power Grid Model mailing list by sending an (empty) email to: powergridmodel+subscribe@lists.lfenergy.org

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Currently, it supports both symmetric and asymmetric calculations for the follow
 * Short Circuit
 
 For conversions from various data format to the power-grid-model, refer to the [power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io) repository.
+For an extended python interface to the the power-grid-model, refer to the [power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds) repository.
 
 ```{note}
 Do you wish to be updated on the latest news and releases? Subscribe to the Power Grid Model mailing list by sending an (empty) email to: powergridmodel+subscribe@lists.lfenergy.org


### PR DESCRIPTION
Adds a link to the power-grid-model-ds repository to the readme and docs