### PR TITLE
Feature/clang tidy

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
@@ -44,7 +44,7 @@ using nlohmann::json;
 // visitor for json conversion
 struct JsonMapArrayData {
     size_t size{};
-    msgpack::sbuffer buffer{};
+    msgpack::sbuffer buffer;
 };
 
 struct JsonSAXVisitor {
@@ -130,8 +130,8 @@ struct JsonSAXVisitor {
         throw SerializationError{ss.str()};
     }
 
-    std::stack<JsonMapArrayData> data_buffers{};
-    msgpack::sbuffer root_buffer{};
+    std::stack<JsonMapArrayData> data_buffers;
+    msgpack::sbuffer root_buffer;
 };
 
 // visitors for parsing
@@ -192,8 +192,15 @@ struct MapArrayVisitor : DefaultErrorVisitor<MapArrayVisitor<map_array>> {
         std::same_as<map_array, visit_map_t> || std::same_as<map_array, visit_map_array_t>;
     static constexpr bool enable_array =
         std::same_as<map_array, visit_array_t> || std::same_as<map_array, visit_map_array_t>;
-    static constexpr std::string_view static_err_msg =
-        enable_map ? (enable_array ? "Map or an array expected." : "Map expected.") : "Array expected.";
+    static constexpr std::string_view static_err_msg = [] {
+        if constexpr (enable_map && enable_array) {
+            return "Map or an array expected.";
+        } else if constexpr (enable_map) {
+            return "Map expected.";
+        } else {
+            return "Array expected.";
+        }
+    }();
 
     Idx size{};
     bool is_map{};
@@ -228,7 +235,7 @@ struct MapArrayVisitor : DefaultErrorVisitor<MapArrayVisitor<map_array>> {
 struct StringVisitor : DefaultErrorVisitor<StringVisitor> {
     static constexpr std::string_view static_err_msg = "String expected.";
 
-    std::string_view str{};
+    std::string_view str;
     bool visit_str(const char* v, uint32_t size) {
         str = {v, size};
         return true;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/serializer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/serializer.hpp
@@ -78,8 +78,8 @@ struct JsonConverter : msgpack::null_visitor {
 
     Idx indent;
     Idx max_indent_level;
-    std::stringstream ss{};
-    std::stack<MapArray> map_array{};
+    std::stringstream ss;
+    std::stack<MapArray> map_array;
 
     void print_indent() {
         if (indent < 0) {
@@ -293,7 +293,7 @@ class Serializer {
     std::vector<ComponentBuffer> component_buffers_; // list of components, then all scenario flatten
 
     // msgpack pakcer
-    msgpack::sbuffer msgpack_buffer_{};
+    msgpack::sbuffer msgpack_buffer_;
     msgpack::packer<msgpack::sbuffer> packer_;
     bool use_compact_list_{};
     std::map<MetaComponent const*, std::vector<MetaAttribute const*>> attributes_;
@@ -606,9 +606,8 @@ class Serializer {
         });
     }
     void pack_attribute(AttributeBuffer<void const> const& attribute_buffer, Idx idx) {
-        return ctype_func_selector(attribute_buffer.meta_attribute->ctype, [&]<class T> {
-            packer_.pack(*(reinterpret_cast<T const*>(attribute_buffer.data) + idx));
-        });
+        ctype_func_selector(attribute_buffer.meta_attribute->ctype,
+                            [&]<class T> { packer_.pack(*(reinterpret_cast<T const*>(attribute_buffer.data) + idx)); });
     }
 
     static constexpr BufferView advance(BufferView buffer_view, Idx offset) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_parameters.hpp
@@ -53,7 +53,7 @@ template <symmetry_tag sym_type> struct BranchShortCircuitSolverOutput {
 
 // fault math calculation parameters and math output
 struct FaultCalcParam {
-    DoubleComplex y_fault{};
+    DoubleComplex y_fault;
     FaultType fault_type{};
     FaultPhase fault_phase{};
 };
@@ -136,7 +136,7 @@ static_assert(sensor_calc_param_type<PowerSensorCalcParam<asymmetric_t>>);
 struct TransformerTapRegulatorCalcParam {
     double u_set{};
     double u_band{};
-    DoubleComplex z_compensation{};
+    DoubleComplex z_compensation;
     IntS status{};
 };
 
@@ -203,7 +203,7 @@ struct SourceCalcParam {
     DoubleComplex y1;
     DoubleComplex y0;
 
-    template <symmetry_tag sym> inline ComplexTensor<sym> y_ref() const {
+    template <symmetry_tag sym> ComplexTensor<sym> y_ref() const {
         if constexpr (is_symmetric_v<sym>) {
             return y1;
         } else {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
@@ -93,7 +93,10 @@ concept is_in_list_c = (std::same_as<std::remove_const_t<T>, Ts> || ...);
 
 // functor to include all
 struct IncludeAll {
-    template <class... T> constexpr bool operator()(T&&... /*ignored*/) const { return true; }
+    template <class... T> constexpr bool operator()(T&&... ignored) const {
+        ((void)std::forward<T>(ignored), ...);
+        return true;
+    }
 };
 constexpr IncludeAll include_all{};
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
@@ -161,7 +161,7 @@ class DenseGroupedIdxVector {
 
         IdxVector const* dense_vector_{};
         Idx group_{};
-        std::pair<group_iterator, group_iterator> group_range_{};
+        std::pair<group_iterator, group_iterator> group_range_;
 
         friend class boost::iterator_core_access;
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/iterator_like_concepts.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/iterator_like_concepts.hpp
@@ -16,14 +16,14 @@ concept iterator_like = requires(T const t) {
 
 template <typename T, typename ElementType>
 concept forward_iterator_like = std::regular<T> && iterator_like<T, ElementType> && requires(T t) {
-    { t++ } -> std::same_as<T>;
-    { ++t } -> std::same_as<T&>;
+    { t++ } -> std::same_as<T>;  // NOLINT(bugprone-inc-dec-in-conditions)
+    { ++t } -> std::same_as<T&>; // NOLINT(bugprone-inc-dec-in-conditions)
 };
 
 template <typename T, typename ElementType>
 concept bidirectional_iterator_like = forward_iterator_like<T, ElementType> && requires(T t) {
-    { t-- } -> std::same_as<T>;
-    { --t } -> std::same_as<T&>;
+    { t-- } -> std::same_as<T>;  // NOLINT(bugprone-inc-dec-in-conditions)
+    { --t } -> std::same_as<T&>; // NOLINT(bugprone-inc-dec-in-conditions)
 };
 
 template <typename T, typename ElementType>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/three_phase_tensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/three_phase_tensor.hpp
@@ -281,7 +281,7 @@ inline void add_diag(Eigen::ArrayBase<DerivedA>& x, Eigen::ArrayBase<DerivedB> c
 }
 template <rk2_tensor DerivedA, column_vector DerivedB>
 inline void add_diag(Eigen::ArrayBase<DerivedA>&& x, Eigen::ArrayBase<DerivedB> const& y) {
-    x.matrix().diagonal() += y.matrix();
+    std::move(x).matrix().diagonal() += y.matrix();
 }
 
 // zero tensor
@@ -351,13 +351,14 @@ template <symmetry_tag sym, class Proxy>
 inline void update_real_value(RealValue<sym> const& new_value, Proxy&& current_value, double scalar) {
     if constexpr (is_symmetric_v<sym>) {
         if (!is_nan(new_value)) {
-            current_value = scalar * new_value;
+            std::forward<Proxy>(current_value) = scalar * new_value;
         }
     } else {
         for (size_t i = 0; i != 3; ++i) {
             if (!is_nan(new_value(i))) {
-                current_value(i) = scalar * new_value(i);
+                current_value(i) = scalar * new_value(i); // can't forward due to runtime element access
             }
+            (void)std::forward<Proxy>(current_value);
         }
     }
 }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/fault.hpp
@@ -193,7 +193,7 @@ class Fault final : public Base {
     double r_f_;
     double x_f_;
 
-    void check_sanity() {
+    void check_sanity() const {
         using enum FaultPhase;
 
         auto const check_supported = [&](auto const& iterable) {
@@ -203,15 +203,19 @@ class Fault final : public Base {
         };
         switch (fault_type_) {
         case FaultType::three_phase:
-            return check_supported(std::array{FaultPhase::nan, default_value, abc});
+            check_supported(std::array{FaultPhase::nan, default_value, abc});
+            return;
         case FaultType::single_phase_to_ground:
-            return check_supported(std::array{FaultPhase::nan, default_value, a, b, c});
+            check_supported(std::array{FaultPhase::nan, default_value, a, b, c});
+            return;
         case FaultType::two_phase:
             [[fallthrough]];
         case FaultType::two_phase_to_ground:
-            return check_supported(std::array{FaultPhase::nan, default_value, ab, ac, bc});
+            check_supported(std::array{FaultPhase::nan, default_value, ab, ac, bc});
+            return;
         case FaultType::nan:
-            return check_supported(std::array{FaultPhase::nan, default_value, abc, a, b, c, ab, ac, bc});
+            check_supported(std::array{FaultPhase::nan, default_value, abc, a, b, c, ab, ac, bc});
+            return;
         default:
             throw InvalidShortCircuitType(fault_type_);
         }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
@@ -110,8 +110,8 @@ class Source : public Appliance {
     double u_ref_;
     double u_ref_angle_;
     // positive and zero sequence ref
-    DoubleComplex y1_ref_{};
-    DoubleComplex y0_ref_{};
+    DoubleComplex y1_ref_;
+    DoubleComplex y0_ref_;
 
     template <symmetry_tag sym_calc> ApplianceSolverOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
         ApplianceSolverOutput<sym_calc> appliance_solver_output;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/transformer.hpp
@@ -193,7 +193,7 @@ class Transformer : public Branch {
         y_series = (1.0 / z_series) / base_y_to;
         // shunt
         DoubleComplex y_shunt;
-        // Y = I0_2 / (U2/sqrt(3)) = i0 * (S / sqrt(3) / U2) / (U2/sqrt(3)) = i0 * S * / U2 / U2
+        // Y = I0_2 / (U2/sqrt3) = i0 * (S / sqrt3 / U2) / (U2/sqrt3) = i0 * S * / U2 / U2
         double const y_shunt_abs = i0_ * sn_ / u2 / u2;
         // G = P0 / (U2^2)
         y_shunt.real(p0_ / u2 / u2);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/output.hpp
@@ -87,7 +87,7 @@ template <typename Component, typename IndexType, class ComponentContainer, type
                                  decltype(*comp_base_sequence_cbegin<Component>(MainModelState<ComponentContainer>{}))>
 constexpr ResIt produce_output(MainModelState<ComponentContainer> const& state, ResIt res_it, ResFunc&& func) {
     return std::transform(get_component_citer<Component>(state).begin(), get_component_citer<Component>(state).end(),
-                          comp_base_sequence_cbegin<Component>(state), res_it, func);
+                          comp_base_sequence_cbegin<Component>(state), res_it, std::forward<ResFunc>(func));
 }
 
 } // namespace detail

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/update.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/update.hpp
@@ -29,6 +29,7 @@ inline void iterate_component_sequence(Func&& func, ForwardIterator begin, Forwa
         // get component directly using sequence id
         func(*it, sequence_idx[seq]);
     }
+    (void)std::forward<Func>(func);
 }
 
 template <typename T> bool check_id_na(T const& obj) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
@@ -191,6 +191,7 @@ inline void calculate_pf_result(YBus<sym> const& y_bus, PowerFlowInput<sym> cons
         calculate_load_gen_result<sym>(load_gens, bus_number, input, output, load_gen_func);
         calculate_source_result<sym>(sources, bus_number, y_bus, input, output, load_gens);
     }
+    (void)std::forward<LoadGenFunc>(load_gen_func);
 }
 
 template <symmetry_tag sym>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/common_solver_functions.hpp
@@ -167,6 +167,7 @@ inline void calculate_load_gen_result(IdxRange const& load_gens, Idx bus_number,
         }
         output.load_gen[load_gen].i = conj(output.load_gen[load_gen].s / output.u[bus_number]);
     }
+    (void)std::forward<LoadGenFunc>(load_gen_func);
 }
 
 template <symmetry_tag sym, typename LoadGenFunc>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -93,17 +93,17 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
     static constexpr auto is_iterative = true;
 
   private:
-    enum class Order { row_major = 0, column_major = 1 };
+    enum class Order : IntS { row_major = 0, column_major = 1 };
 
     struct NRSEVoltageState {
-        ComplexTensor<sym> ui_ui_conj{};
-        ComplexTensor<sym> uj_uj_conj{};
-        ComplexTensor<sym> ui_uj_conj{};
-        ComplexTensor<sym> uj_ui_conj{};
-        ComplexValue<sym> ui{};
-        ComplexValue<sym> uj{};
-        RealDiagonalTensor<sym> abs_ui_inv{};
-        RealDiagonalTensor<sym> abs_uj_inv{};
+        ComplexTensor<sym> ui_ui_conj;
+        ComplexTensor<sym> uj_uj_conj;
+        ComplexTensor<sym> ui_uj_conj;
+        ComplexTensor<sym> uj_ui_conj;
+        ComplexValue<sym> ui;
+        ComplexValue<sym> uj;
+        RealDiagonalTensor<sym> abs_ui_inv;
+        RealDiagonalTensor<sym> abs_uj_inv;
 
         auto const& u_chi_u_chi_conj(Order ij_voltage_order) const {
             return ij_voltage_order == Order::row_major ? ui_ui_conj : uj_uj_conj;
@@ -120,10 +120,10 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
     };
 
     struct NRSEJacobian {
-        RealTensor<sym> dP_dt{};
-        RealTensor<sym> dP_dv{};
-        RealTensor<sym> dQ_dt{};
-        RealTensor<sym> dQ_dv{};
+        RealTensor<sym> dP_dt;
+        RealTensor<sym> dP_dv;
+        RealTensor<sym> dQ_dt;
+        RealTensor<sym> dQ_dv;
 
         NRSEJacobian& operator+=(NRSEJacobian const& other) {
             this->dP_dt += other.dP_dt;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -138,6 +138,7 @@ template <rk2_tensor Matrix> class DenseLUFactor {
                 throw SparseMatrixError{}; // can not specify error code
             }
         }
+        (void)std::move(matrix);
     }
 };
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -527,12 +527,12 @@ template <symmetry_tag sym> class YBus {
     std::shared_ptr<MathModelParam<sym> const> math_model_param_;
 
     // cache the branch and shunt parameters in sequence_idx_map
-    IdxVector branch_param_idx_{};
-    IdxVector shunt_param_idx_{};
+    IdxVector branch_param_idx_;
+    IdxVector shunt_param_idx_;
 
     // map index between admittance entries and parameter entries
-    std::vector<IdxVector> map_admittance_param_branch_{};
-    std::vector<IdxVector> map_admittance_param_shunt_{};
+    std::vector<IdxVector> map_admittance_param_branch_;
+    std::vector<IdxVector> map_admittance_param_shunt_;
 
     std::unordered_map<uint64_t, ParamChangedCallback> parameters_changed_callbacks_;
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -228,7 +228,7 @@ inline void process_edges_dijkstra(Idx v, std::vector<EdgeWeight>& vertex_distan
     using TrafoGraphElement = std::pair<EdgeWeight, TrafoGraphIdx>;
     std::priority_queue<TrafoGraphElement, std::vector<TrafoGraphElement>, std::greater<>> pq;
     vertex_distances[v] = 0;
-    pq.push({0, v});
+    pq.emplace(0, v);
 
     while (!pq.empty()) {
         auto [dist, u] = pq.top();
@@ -246,10 +246,10 @@ inline void process_edges_dijkstra(Idx v, std::vector<EdgeWeight>& vertex_distan
             // We can not use BGL_FORALL_OUTEDGES here because our grid is undirected
             if (u == s && vertex_distances[s] + weight < vertex_distances[t]) {
                 vertex_distances[t] = vertex_distances[s] + weight;
-                pq.push({vertex_distances[t], t});
+                pq.emplace(vertex_distances[t], t);
             } else if (u == t && vertex_distances[t] + weight < vertex_distances[s]) {
                 vertex_distances[s] = vertex_distances[t] + weight;
-                pq.push({vertex_distances[s], s});
+                pq.emplace(vertex_distances[s], s);
             }
         }
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -70,8 +70,8 @@ using TrafoGraphEdges = std::vector<std::pair<TrafoGraphIdx, TrafoGraphIdx>>;
 using TrafoGraphEdgeProperties = std::vector<TrafoGraphEdge>;
 
 struct RegulatedObjects {
-    std::set<Idx> transformers{};
-    std::set<Idx> transformers3w{};
+    std::set<Idx> transformers;
+    std::set<Idx> transformers3w;
 };
 
 using TransformerGraph = boost::compressed_sparse_row_graph<boost::directedS, TrafoGraphVertex, TrafoGraphEdge,
@@ -603,7 +603,7 @@ class TapPositionOptimizerImpl<std::tuple<TransformerTypes...>, StateCalculator,
     using TransformerRanker = TransformerRanker_;
 
   private:
-    std::vector<uint64_t> max_tap_ranges_per_rank{};
+    std::vector<uint64_t> max_tap_ranges_per_rank;
     using ComponentContainer = typename State::ComponentContainer;
     using RegulatedTransformer = TapRegulatorRef<TransformerTypes...>;
     using UpdateBuffer = std::tuple<std::vector<typename TransformerTypes::UpdateType>...>;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/sparse_ordering.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/sparse_ordering.hpp
@@ -208,7 +208,8 @@ inline std::pair<IdxVector, std::vector<std::pair<Idx, Idx>>> minimum_degree_ord
             alpha.push_back(alpha.back() == from ? to : from);
             return {alpha, fills};
         }
-        std::ranges::copy(detail::remove_vertices_update_degrees(u, d, dgd, fills), std::back_inserter(alpha));
+        auto result = detail::remove_vertices_update_degrees(u, d, dgd, fills);
+        alpha.insert(alpha.end(), result.begin(), result.end());
         if (d.empty()) {
             return {alpha, fills};
         }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
@@ -329,7 +329,7 @@ class Topology {
             permuted_node_indices[reordered[idx]] = n_non_cyclic_nodes + idx;
         }
 
-        std::ranges::copy(reordered, std::back_inserter(dfs_node));
+        dfs_node.insert(dfs_node.end(), reordered.begin(), reordered.end());
         for (auto [from, to] : fills) {
             auto from_reordered = permuted_node_indices[from];
             auto to_reordered = permuted_node_indices[to];
@@ -530,6 +530,7 @@ class Topology {
                 coupling[topo_comp_i] = Idx2D{topo_idx, new_math_comp_i};
             }
         }
+        (void)std::forward<GetMathTopoComponent>(get_component_topo);
     }
 
     void couple_all_appliance() {

--- a/power_grid_model_c/power_grid_model_c/include/power_grid_model_c/basics.h
+++ b/power_grid_model_c/power_grid_model_c/include/power_grid_model_c/basics.h
@@ -141,6 +141,8 @@ typedef struct PGM_DatasetInfo PGM_DatasetInfo;
 
 // NOLINTEND(modernize-use-using)
 
+// NOLINTBEGIN(performance-enum-size)
+
 // enums
 /**
  * @brief Enumeration for calculation type.
@@ -243,6 +245,8 @@ enum PGM_ExperimentalFeatures {
     PGM_experimental_features_disabled = 0, /**< disable experimental features */
     PGM_experimental_features_enabled = 1,  /**< enable experimental features */
 };
+
+// NOLINTEND(performance-enum-size)
 
 #ifdef __cplusplus
 }

--- a/tests/cpp_unit_tests/test_fault.cpp
+++ b/tests/cpp_unit_tests/test_fault.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Test fault") {
 
         // Connected to source
         param = fault.calc_param(u_rated);
-        double const base_y = base_i / (u_rated / sqrt(3));
+        double const base_y = base_i / (u_rated / sqrt3);
         DoubleComplex const y_f = 1.0 / (3.0 + 1.0i * 4.0) / base_y;
         CHECK(cabs(param.y_fault - y_f) < numerical_tolerance);
         CHECK(param.fault_type == FaultType::two_phase_to_ground);
@@ -288,10 +288,12 @@ TEST_CASE("Test fault") {
         }
 
         SUBCASE("Invalid fault type") {
-            CHECK_THROWS_AS((Fault{{1, 1, static_cast<FaultType>(-127), FaultPhase::nan, 4, 3.0, 4.0}}),
-                            InvalidShortCircuitType);
+            constexpr auto bad_value{
+                static_cast<FaultType>(-127)}; // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
 
-            FaultUpdate const fault_update{1, 0, static_cast<FaultType>(-127), FaultPhase::nan, 10, nan, nan};
+            CHECK_THROWS_AS((Fault{{1, 1, bad_value, FaultPhase::nan, 4, 3.0, 4.0}}), InvalidShortCircuitType);
+
+            FaultUpdate const fault_update{1, 0, bad_value, FaultPhase::nan, 10, nan, nan};
             CHECK_THROWS_AS(fault.update(fault_update), InvalidShortCircuitType);
         }
     }
@@ -300,7 +302,7 @@ TEST_CASE("Test fault") {
         FaultUpdate const fault_update_rx{1, na_IntS, FaultType::nan, FaultPhase::nan, na_IntID, 10.0, 20.0};
         fault.update(fault_update_rx);
         FaultCalcParam const param = fault.calc_param(u_rated);
-        double const base_y = base_i / (u_rated / sqrt(3));
+        double const base_y = base_i / (u_rated / sqrt3);
         DoubleComplex const y_f = 1.0 / (10.0 + 20.0i) / base_y;
         CHECK(cabs(param.y_fault - y_f) < numerical_tolerance);
         CHECK(param.fault_type == FaultType::two_phase_to_ground);

--- a/tests/cpp_unit_tests/test_grouped_index_vector.cpp
+++ b/tests/cpp_unit_tests/test_grouped_index_vector.cpp
@@ -170,7 +170,7 @@ TEST_CASE_TEMPLATE("Enumerated zip iterator for grouped index data structures", 
         // Test single zipped iteration
         IdxRanges actual_ranges_a{};
         Idx current_index{};
-        for (auto [index, element_range] : enumerated_zip_sequence(idx_vector_a)) {
+        for (auto const& [index, element_range] : enumerated_zip_sequence(idx_vector_a)) {
             actual_ranges_a.push_back(element_range);
 
             CHECK(index == current_index++);
@@ -184,7 +184,7 @@ TEST_CASE_TEMPLATE("Enumerated zip iterator for grouped index data structures", 
         IdxRanges actual_ranges_a{};
         IdxRanges actual_ranges_b{};
         Idx current_index{};
-        for (auto const [index, first_group, second_group] : enumerated_zip_sequence(idx_vector_a, idx_vector_b)) {
+        for (auto const& [index, first_group, second_group] : enumerated_zip_sequence(idx_vector_a, idx_vector_b)) {
             for (auto& element : first_group) {
                 actual_idx_counts_a.push_back(element);
             }
@@ -209,7 +209,7 @@ TEST_CASE_TEMPLATE("Enumerated zip iterator for grouped index data structures", 
         IdxRanges actual_ranges_b{};
         IdxRanges actual_ranges_c{};
         Idx current_index{};
-        for (auto [index, element_range_1, element_range_2, element_range_3] :
+        for (auto const& [index, element_range_1, element_range_2, element_range_3] :
              enumerated_zip_sequence(idx_vector_a, idx_vector_b, idx_vector_c)) {
             actual_ranges_a.push_back(element_range_1);
             actual_ranges_b.push_back(element_range_2);

--- a/tests/cpp_unit_tests/test_line.cpp
+++ b/tests/cpp_unit_tests/test_line.cpp
@@ -57,9 +57,9 @@ TEST_CASE("Test line") {
 
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
-    DoubleComplex const it_sc{2.0, 2.0 * sqrt(3)};
+    DoubleComplex const it_sc{2.0, 2.0 * sqrt3};
     ComplexValue<asymmetric_t> const if_sc_asym{1.0 + 1.0i};
-    ComplexValue<asymmetric_t> const it_sc_asym{2.0 + (2.0i * sqrt(3))};
+    ComplexValue<asymmetric_t> const it_sc_asym{2.0 + (2.0i * sqrt3)};
 
     CHECK(line.math_model_type() == ComponentType::branch);
 

--- a/tests/cpp_unit_tests/test_link.cpp
+++ b/tests/cpp_unit_tests/test_link.cpp
@@ -27,9 +27,9 @@ TEST_CASE("Test link") {
 
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
-    DoubleComplex const it_sc{2.0, 2.0 * sqrt(3)};
+    DoubleComplex const it_sc{2.0, 2.0 * sqrt3};
     ComplexValue<asymmetric_t> const if_sc_asym{1.0 + 1.0i};
-    ComplexValue<asymmetric_t> const it_sc_asym{2.0 + (2.0i * sqrt(3))};
+    ComplexValue<asymmetric_t> const it_sc_asym{2.0 + (2.0i * sqrt3)};
 
     CHECK(link.math_model_type() == ComponentType::branch);
 

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -13,6 +13,8 @@ TYPE_TO_STRING_AS("AsymLoad", power_grid_model::AsymLoad);
 
 namespace power_grid_model {
 namespace {
+using std::numbers::sqrt2;
+
 void check_nan_preserving_equality(std::floating_point auto actual, std::floating_point auto expected) {
     if (is_nan(expected)) {
         is_nan(actual);
@@ -48,16 +50,16 @@ TEST_CASE("Test load generator") {
     double const base_i = base_power_1p / (10e3 / sqrt3);
     DoubleComplex const u{1.1 * std::exp(1.0i * 10.0)};
     ComplexValue<asymmetric_t> const ua{1.1 * std::exp(1.0i * 10.0)};
-    double const pf = 1 / sqrt(2.0);
-    double const s_pq = sqrt(2.0) * 3e6;
+    double const pf = 1 / sqrt2;
+    double const s_pq = sqrt2 * 3e6;
     double const p_pq = 3e6;
     double const q_pq = 3e6;
     double const i_pq = s_pq / (1.1 * 10e3) / sqrt3;
-    double const s_y = sqrt(2.0) * 3e6 * 1.1 * 1.1;
+    double const s_y = sqrt2 * 3e6 * 1.1 * 1.1;
     double const p_y = 3e6 * 1.1 * 1.1;
     double const q_y = 3e6 * 1.1 * 1.1;
     double const i_y = s_y / (1.1 * 10e3) / sqrt3;
-    double const s_i = sqrt(2.0) * 3e6 * 1.1;
+    double const s_i = sqrt2 * 3e6 * 1.1;
     double const p_i = 3e6 * 1.1;
     double const q_i = 3e6 * 1.1;
     double const i_i = s_i / (1.1 * 10e3) / sqrt3;

--- a/tests/cpp_unit_tests/test_math_solver_common.hpp
+++ b/tests/cpp_unit_tests/test_math_solver_common.hpp
@@ -112,6 +112,7 @@ template <symmetry_tag sym_type> struct SteadyStateSolverTestGrid {
     static constexpr double v1 = 0.97;
     static constexpr double v2 = 0.90;
     static constexpr double deg = deg_30 / 30.0;
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members) // should be constexpr but cant due to std::exp
     DoubleComplex const u0 = v0 * std::exp(-1.0i * deg);
     DoubleComplex const u1 = v1 * std::exp(-4.0i * deg);
     DoubleComplex const u2 = v2 * std::exp(-37.0i * deg);
@@ -136,6 +137,7 @@ template <symmetry_tag sym_type> struct SteadyStateSolverTestGrid {
     // injection of shunt0 at bus2
     DoubleComplex const i2_shunt_inj = branch1_i_t;
     DoubleComplex const ys = -i2_shunt_inj / u2; // output
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
     SolverOutput<sym> output_ref() const {
         if constexpr (is_symmetric_v<sym>) {

--- a/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
+++ b/tests/cpp_unit_tests/test_tap_position_optimizer.cpp
@@ -712,8 +712,9 @@ TEST_CASE("Test Tap position optimizer") {
     };
 
     auto const get_optimizer = [&](OptimizerStrategy strategy, SearchMethod tap_search) {
-        return pgm_tap::TapPositionOptimizer<MockStateCalculator, decltype(updater), MockState, MockTransformerRanker>{
-            test::mock_state_calculator, updater, strategy, meta_data, tap_search};
+        return pgm_tap::TapPositionOptimizer<MockStateCalculator, std::remove_const_t<decltype(updater)>, MockState,
+                                             MockTransformerRanker>{test::mock_state_calculator, updater, strategy,
+                                                                    meta_data, tap_search};
     };
 
     SUBCASE("empty state") {

--- a/tests/cpp_unit_tests/test_voltage_sensor.cpp
+++ b/tests/cpp_unit_tests/test_voltage_sensor.cpp
@@ -114,8 +114,8 @@ TEST_CASE("Test voltage sensor") {
         VoltageSensorCalcParam<asymmetric_t> param = voltage_sensor.calc_param<asymmetric_t>();
         CHECK(param.variance == doctest::Approx(6.75));
 
-        ComplexValue<asymmetric_t> expected_param_value{0.5 * sqrt(3) * exp(1i * 2.0), 0.55 * sqrt(3) * exp(1i * 2.1),
-                                                        0.6 * sqrt(3) * exp(1i * 2.2)};
+        ComplexValue<asymmetric_t> expected_param_value{0.5 * sqrt3 * exp(1i * 2.0), 0.55 * sqrt3 * exp(1i * 2.1),
+                                                        0.6 * sqrt3 * exp(1i * 2.2)};
         CHECK(cabs(param.value[0]) == doctest::Approx(cabs(expected_param_value[0])));
         CHECK(cabs(param.value[1]) == doctest::Approx(cabs(expected_param_value[1])));
         CHECK(cabs(param.value[2]) == doctest::Approx(cabs(expected_param_value[2])));
@@ -126,8 +126,7 @@ TEST_CASE("Test voltage sensor") {
 
         update = voltage_sensor.update(vs_update);
         param = voltage_sensor.calc_param<asymmetric_t>();
-        expected_param_value = {1.5 * sqrt(3) * exp(1i * 4.0), 0.55 * sqrt(3) * exp(1i * 4.1),
-                                1.6 * sqrt(3) * exp(1i * 2.2)};
+        expected_param_value = {1.5 * sqrt3 * exp(1i * 4.0), 0.55 * sqrt3 * exp(1i * 4.1), 1.6 * sqrt3 * exp(1i * 2.2)};
 
         CHECK(cabs(param.value[0]) == doctest::Approx(cabs(expected_param_value[0])));
         CHECK(cabs(param.value[1]) == doctest::Approx(cabs(expected_param_value[1])));


### PR DESCRIPTION
Ensures `clang-tidy` runs on Visual Studio 2022 latest version.

Relates to #267 .

**Note:** I had to go from `std::ranges::copy(foo, std::back_inserter(bar));` to `bar.insert(bar.end(), foo.begin(), foo.end());` due to https://github.com/llvm/llvm-project/issues/120151 . I prefer to keep using the former but I first wanted to do a full build
