### PR TITLE
Step-up transformer tap changer support: patch new transformer ranking error message

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/optimizer/tap_position_optimizer.hpp
@@ -326,7 +326,7 @@ inline auto get_edge_weights(TransformerGraph const& graph) -> TrafoGraphEdgePro
         // situations can happen.
         if (edge_src_rank != edge_tgt_rank - 1) {
             throw AutomaticTapInputError(
-                "Control side of a transformer should be the relatively closer side to a source.\n");
+                "Control side of a transformer should be the relatively further side to a source.\n");
         }
         if (!is_unreachable(edge_res)) {
             result.emplace_back(TrafoGraphEdge{graph[e].regulated_idx, edge_tgt_rank});


### PR DESCRIPTION
The error message in the new ranking algorithm is wrong: when checking if control side is exactly one larger, it should be phrased as "further" instead of "closer".