### PR TITLE
Use cmake to build the DLL for conda package

### DIFF
--- a/.github/conda_pgm_env.yml
+++ b/.github/conda_pgm_env.yml
@@ -15,6 +15,8 @@ dependencies:
   - nlohmann_json
   - msgpack-cxx
   - numpy
+  - cmake
+  - ninja
   # test deps
   - pytest
   - pytest-cov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,7 @@ jobs:
           cmake --install build/
 
       - name: Build and install cmake target for Linux
-        if: matrix.os == 'windows'
+        if: matrix.os == 'linux'
         run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
           cmake --build build/ --verbose -j1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,10 +235,15 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "windows"] # We do not test conda for MacOS
+        include:
+          - os: ubuntu
+            shell: bash -el {0}
+          - os: windows
+            shell: powershell
   
-    # defaults:
-    #   run:
-    #     shell: bash -el {0}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - uses: actions/checkout@v4
 
@@ -250,7 +255,6 @@ jobs:
           auto-activate-base: false
       
       - name: List conda
-        shell: bash -el {0}
         run: |
           conda info
           conda list
@@ -269,7 +273,6 @@ jobs:
           cmake --install build/
 
       - name: Build and install cmake target for Linux
-        shell: bash -el {0}
         if: matrix.os == 'ubuntu'
         run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
@@ -277,11 +280,9 @@ jobs:
           cmake --install build/      
 
       - name: Build python
-        shell: bash -el {0}
         run: python -m pip install . -vv --no-build-isolation --no-deps   
 
       - name: Test
-        shell: bash -el {0}
         run: pytest
 
   publish-wheels:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,7 @@ jobs:
 
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S .
           cmake --build build/ --verbose -j1
-          cmake --install build/
+          cmake --install build/ --prefix ${env:CONDA_PREFIX}/Library
 
       - name: Build and install cmake target for Linux
         if: matrix.os == 'ubuntu'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,7 +240,10 @@ jobs:
             shell: bash -el {0}
           - os: windows
             shell: powershell
-  
+    
+    env:
+      POWER_GRID_MODEL_NO_BINARY_BUILD: 1
+
     defaults:
       run:
         shell: ${{ matrix.shell }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,6 +269,7 @@ jobs:
           cmake --install build/
 
       - name: Build and install cmake target for Linux
+        shell: bash -el {0}
         if: matrix.os == 'ubuntu'
         run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_PREFIX_PATH=$CONDA_PREFIX

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,21 +254,25 @@ jobs:
           conda info
           conda list
 
-      - name: Conda library path for Linux
-        if: matrix.os == 'ubuntu'
-        run: |
-          echo "LIBRARY_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
-
-      - name: Conda library path for Windows
+      - name: Build and install cmake target for Windows
         if: matrix.os == 'windows'
-        run: |
+        run: |          
+          $vsPath = &(Join-Path ${env:ProgramFiles(x86)} '\Microsoft Visual Studio\Installer\vswhere.exe') -property installationpath
+          Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+
           echo "LIBRARY_PREFIX=$CONDA_PREFIX\Library" >> $GITHUB_ENV
 
-      - name: Build and install cmake target
-        run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$LIBRARY_PREFIX -DCMAKE_PREFIX_PATH=$LIBRARY_PREFIX
           cmake --build build/ --verbose -j1
           cmake --install build/
+
+      - name: Build and install cmake target for Linux
+        if: matrix.os == 'windows'
+        run: |
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
+          cmake --build build/ --verbose -j1
+          cmake --install build/      
 
       - name: Build python
         run: python -m pip install . -vv --no-build-isolation --no-deps   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,7 @@ jobs:
           cmake --install build/
 
       - name: Build and install cmake target for Linux
-        if: matrix.os == 'linux'
+        if: matrix.os == 'ubuntu'
         run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
           cmake --build build/ --verbose -j1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=${env:CONDA_PREFIX}\Library -DCMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=${env:CONDA_PREFIX}\Library
           cmake --build build/ --verbose -j1
           cmake --install build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,8 +253,24 @@ jobs:
         run: |
           conda info
           conda list
-      
-      - name: Build
+
+      - name: Conda library path for Linux
+        if: matrix.os == 'ubuntu'
+        run: |
+          echo "LIBRARY_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
+
+      - name: Install conda environment
+        if: matrix.os == 'windows'
+        run: |
+          echo "LIBRARY_PREFIX=$CONDA_PREFIX\Library" >> $GITHUB_ENV
+
+      - name: Build and install cmake target
+        run: |
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$LIBRARY_PREFIX -DCMAKE_PREFIX_PATH=$LIBRARY_PREFIX
+          cmake --build build/ --verbose -j1
+          cmake --install build/
+
+      - name: Build python
         run: python -m pip install . -vv --no-build-isolation --no-deps   
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=${env:CONDA_PREFIX}\Library
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S .
           cmake --build build/ --verbose -j1
           cmake --install build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,9 +236,9 @@ jobs:
       matrix:
         os: ["ubuntu", "windows"] # We do not test conda for MacOS
   
-    defaults:
-      run:
-        shell: bash -el {0}
+    # defaults:
+    #   run:
+    #     shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
 
@@ -250,6 +250,7 @@ jobs:
           auto-activate-base: false
       
       - name: List conda
+        shell: bash -el {0}
         run: |
           conda info
           conda list
@@ -275,9 +276,11 @@ jobs:
           cmake --install build/      
 
       - name: Build python
+        shell: bash -el {0}
         run: python -m pip install . -vv --no-build-isolation --no-deps   
 
       - name: Test
+        shell: bash -el {0}
         run: pytest
 
   publish-wheels:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX\Library -DCMAKE_PREFIX_PATH=$CONDA_PREFIX\Library
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$env:CONDA_PREFIX\Library -DCMAKE_PREFIX_PATH=$env:CONDA_PREFIX\Library
           cmake --build build/ --verbose -j1
           cmake --install build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$env:CONDA_PREFIX\Library -DCMAKE_PREFIX_PATH=$env:CONDA_PREFIX\Library
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=${env:CONDA_PREFIX}\Library -DCMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library
           cmake --build build/ --verbose -j1
           cmake --install build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,9 +266,7 @@ jobs:
           Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          echo "LIBRARY_PREFIX=$CONDA_PREFIX\Library" >> $GITHUB_ENV
-
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$LIBRARY_PREFIX -DCMAKE_PREFIX_PATH=$LIBRARY_PREFIX
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S . -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX\Library -DCMAKE_PREFIX_PATH=$CONDA_PREFIX\Library
           cmake --build build/ --verbose -j1
           cmake --install build/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,7 @@ jobs:
         run: |
           echo "LIBRARY_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
 
-      - name: Install conda environment
+      - name: Conda library path for Windows
         if: matrix.os == 'windows'
         run: |
           echo "LIBRARY_PREFIX=$CONDA_PREFIX\Library" >> $GITHUB_ENV

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     if build_dir.exists():
         shutil.rmtree(build_dir)
     # remove binary
-    bin_files = list(chain(pkg_bin_dir.rglob("*.so"), pkg_bin_dir.rglob("*.dll")))
+    bin_files = list(chain(pkg_bin_dir.rglob("*.so"), pkg_bin_dir.rglob("*.dll"), pkg_bin_dir.rglob("*.dylib")))
     for bin_file in bin_files:
         print(f"Remove binary file: {bin_file}")
         bin_file.unlink()

--- a/setup.py
+++ b/setup.py
@@ -55,28 +55,6 @@ def get_pre_installed_header_include() -> list[str]:
         return []
 
 
-def get_conda_include() -> list[str]:
-    """
-    Get conda include path, if we are inside conda environment
-
-    Returns:
-        either empty list or a list of header paths
-    """
-    include_paths = []
-    # in the conda build system the system root is defined in CONDA_PREFIX or BUILD_PREFIX
-    for prefix in ["CONDA_PREFIX", "BUILD_PREFIX"]:
-        if prefix in os.environ:
-            conda_path = os.environ[prefix]
-            if if_win:
-                # windows has Library folder prefix
-                include_paths.append(os.path.join(conda_path, "Library", "include"))
-                include_paths.append(os.path.join(conda_path, "Library", "include", "eigen3"))
-            else:
-                include_paths.append(os.path.join(conda_path, "include"))
-                include_paths.append(os.path.join(conda_path, "include", "eigen3"))
-    return include_paths
-
-
 # custom class for ctypes
 class CTypesExtension(Extension):
     pass
@@ -150,6 +128,22 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     Returns:
 
     """
+    pkg_bin_dir = pkg_dir / "src" / pkg_name
+    # remove old extension build
+    build_dir = pkg_dir / "build"
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    # remove binary
+    bin_files = list(chain(pkg_bin_dir.rglob("*.so"), pkg_bin_dir.rglob("*.dll")))
+    for bin_file in bin_files:
+        print(f"Remove binary file: {bin_file}")
+        bin_file.unlink()
+
+    # if we are building this in conda enviroment
+    # we do not need extension module
+    if "CONDA_PREFIX" in os.environ:
+        return {}
+
     # fetch dependent headers
     pgm = Path("power_grid_model")
     pgm_c = Path("power_grid_model_c")
@@ -161,7 +155,6 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     ]
     include_dirs += get_required_dependency_include()
     include_dirs += get_pre_installed_header_include()
-    include_dirs += get_conda_include()
     # compiler and link flag
     cflags: list[str] = []
     lflags: list[str] = []
@@ -179,17 +172,6 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
     define_macros = [
         ("EIGEN_MPL2_ONLY", "1"),  # only MPL-2 part of eigen3
     ]
-    pkg_bin_dir = pkg_dir / "src" / pkg_name
-
-    # remove old extension build
-    build_dir = pkg_dir / "build"
-    if build_dir.exists():
-        shutil.rmtree(build_dir)
-    # remove binary
-    bin_files = list(chain(pkg_bin_dir.rglob("*.so"), pkg_bin_dir.rglob("*.dll")))
-    for bin_file in bin_files:
-        print(f"Remove binary file: {bin_file}")
-        bin_file.unlink()
 
     # build steps for Windows and Linux
     # different treat for windows and linux

--- a/setup.py
+++ b/setup.py
@@ -139,9 +139,10 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
         print(f"Remove binary file: {bin_file}")
         bin_file.unlink()
 
-    # if we are building this in conda enviroment
-    # we do not need extension module
-    if "CONDA_PREFIX" in os.environ:
+    # By setting POWER_GRID_MODEL_NO_BINARY_BUILD we do not build the extension.
+    # This is usually set in conda-build recipe, so conda build process only wraps the pure Python package.
+    # As a user or developer, DO NOT set this environment variable unless you really know what you are doing.
+    if "POWER_GRID_MODEL_NO_BINARY_BUILD" in os.environ:
         return {}
 
     # fetch dependent headers

--- a/src/power_grid_model/_core/power_grid_core.py
+++ b/src/power_grid_model/_core/power_grid_core.py
@@ -134,6 +134,8 @@ def _load_core() -> CDLL:
             dll_file = "libpower_grid_model_c.dylib"
         elif platform.system() == "Linux":
             dll_file = "libpower_grid_model_c.so"
+        else:
+            raise NotImplementedError(f"Unsupported platform: {platform.system()}")
         # the dll will be found through conda environment
         dll_path = dll_file
     else:

--- a/src/power_grid_model/_core/power_grid_core.py
+++ b/src/power_grid_model/_core/power_grid_core.py
@@ -6,6 +6,7 @@
 Loader for the dynamic library
 """
 
+import os
 import platform
 from ctypes import CDLL, POINTER, c_char, c_char_p, c_double, c_size_t, c_void_p
 from inspect import signature
@@ -125,11 +126,24 @@ def _load_core() -> CDLL:
     Returns: DLL/SO object
 
     """
-    if platform.system() == "Windows":
-        dll_file = "_power_grid_core.dll"
+    if "CONDA_PREFIX" in os.environ:
+        # if conda environment, use the dll file from the conda environment
+        if platform.system() == "Windows":
+            dll_file = "power_grid_model_c.dll"
+        elif platform.system() == "Darwin":
+            dll_file = "libpower_grid_model_c.dylib"
+        elif platform.system() == "Linux":
+            dll_file = "libpower_grid_model_c.so"
+        # the dll will be found through conda environment
+        dll_path = dll_file
     else:
-        dll_file = "_power_grid_core.so"
-    cdll = CDLL(str(Path(__file__).parent / dll_file))
+        # else use the dll file from the current directory
+        if platform.system() == "Windows":
+            dll_file = "_power_grid_core.dll"
+        else:
+            dll_file = "_power_grid_core.so"
+        dll_path = str(Path(__file__).parent / dll_file)
+    cdll = CDLL(dll_path)
     # assign return types
     # handle
     cdll.PGM_create_handle.argtypes = []

--- a/src/power_grid_model/_core/power_grid_core.py
+++ b/src/power_grid_model/_core/power_grid_core.py
@@ -126,8 +126,15 @@ def _load_core() -> CDLL:
     Returns: DLL/SO object
 
     """
-    if "CONDA_PREFIX" in os.environ:
-        # if conda environment, use the dll file from the conda environment
+    # first try to find the DLL local
+    if platform.system() == "Windows":
+        dll_file = "_power_grid_core.dll"
+    else:
+        dll_file = "_power_grid_core.so"
+    dll_path = Path(__file__).parent / dll_file
+
+    # if local DLL is not found, try to find the DLL from conda environment
+    if (not dll_path.exists()) and ("CONDA_PREFIX" in os.environ):
         if platform.system() == "Windows":
             dll_file = "power_grid_model_c.dll"
         elif platform.system() == "Darwin":
@@ -137,15 +144,9 @@ def _load_core() -> CDLL:
         else:
             raise NotImplementedError(f"Unsupported platform: {platform.system()}")
         # the dll will be found through conda environment
-        dll_path = dll_file
-    else:
-        # else use the dll file from the current directory
-        if platform.system() == "Windows":
-            dll_file = "_power_grid_core.dll"
-        else:
-            dll_file = "_power_grid_core.so"
-        dll_path = str(Path(__file__).parent / dll_file)
-    cdll = CDLL(dll_path)
+        dll_path = Path(dll_file)
+
+    cdll = CDLL(str(dll_path))
     # assign return types
     # handle
     cdll.PGM_create_handle.argtypes = []


### PR DESCRIPTION
Use `cmake` to build the DLL/SO for conda package. In runtime, if the `power_grid_core` detects that it is in conda environment, load the DLL/SO from `PATH`.