### PR TITLE
Automatic tap changer step up transformer support: Python validation

### DIFF
--- a/src/power_grid_model/validation/_rules.py
+++ b/src/power_grid_model/validation/_rules.py
@@ -66,7 +66,6 @@ from power_grid_model.validation.errors import (
     SameValueError,
     TransformerClockError,
     TwoValuesZeroError,
-    UnsupportedTransformerRegulationError,
     ValidationError,
 )
 from power_grid_model.validation.utils import (
@@ -907,51 +906,6 @@ def all_valid_fault_phases(
                 component=component,
                 fields=[fault_type_field, fault_phase_field],
                 ids=data[component]["id"][err].flatten().tolist(),
-            )
-        ]
-    return []
-
-
-def all_supported_tap_control_side(  # pylint: disable=too-many-arguments
-    data: SingleDataset,
-    component: ComponentType,
-    control_side_field: str,
-    regulated_object_field: str,
-    tap_side_fields: list[tuple[ComponentType, str]],
-    **filters: Any,
-) -> list[UnsupportedTransformerRegulationError]:
-    """
-    Args:
-        data (SingleDataset): The input/update data set for all components
-        component (ComponentType): The component of interest
-        control_side_field (str): The field of interest
-        regulated_object_field (str): The field that contains the regulated component ids
-        tap_side_fields (list[tuple[ComponentType, str]]): The fields of interest per regulated component,
-            formatted as [(component_1, field_1), (component_2, field_2)]
-        **filters: One or more filters on the dataset. E.g. regulated_object="transformer".
-
-    Returns:
-        A list containing zero or more InvalidAssociatedEnumValueErrors; listing all the ids
-        of components where the field of interest was invalid, given the referenced object's field.
-    """
-    mask = _get_mask(data=data, component=component, field=control_side_field, **filters)
-    values = data[component][control_side_field][mask]
-
-    invalid = np.zeros_like(mask)
-
-    for ref_component, ref_field in tap_side_fields:
-        if ref_component in data:
-            indices = _get_indexer(data[ref_component]["id"], data[component][regulated_object_field], default_value=-1)
-            found = indices != -1
-            ref_comp_values = data[ref_component][ref_field][indices[found]]
-            invalid[found] = np.logical_or(invalid[found], values[found] == ref_comp_values)
-
-    if invalid.any():
-        return [
-            UnsupportedTransformerRegulationError(
-                component=component,
-                fields=[control_side_field, regulated_object_field],
-                ids=data[component]["id"][invalid].flatten().tolist(),
             )
         ]
     return []

--- a/src/power_grid_model/validation/_rules.py
+++ b/src/power_grid_model/validation/_rules.py
@@ -70,7 +70,6 @@ from power_grid_model.validation.errors import (
 )
 from power_grid_model.validation.utils import (
     _eval_expression,
-    _get_indexer,
     _get_mask,
     _get_valid_ids,
     _nan_type,

--- a/src/power_grid_model/validation/_validation.py
+++ b/src/power_grid_model/validation/_validation.py
@@ -46,7 +46,6 @@ from power_grid_model.validation._rules import (
     all_less_than as _all_less_than,
     all_not_two_values_equal as _all_not_two_values_equal,
     all_not_two_values_zero as _all_not_two_values_zero,
-    all_supported_tap_control_side as _all_supported_tap_control_side,
     all_unique as _all_unique,
     all_valid_associated_enum_values as _all_valid_associated_enum_values,
     all_valid_clocks as _all_valid_clocks,
@@ -977,12 +976,5 @@ def validate_transformer_tap_regulator(data: SingleDataset) -> list[ValidationEr
     )
     errors += _all_greater_than_or_equal_to_zero(
         data, ComponentType.transformer_tap_regulator, "line_drop_compensation_x", 0.0
-    )
-    errors += _all_supported_tap_control_side(
-        data,
-        ComponentType.transformer_tap_regulator,
-        "control_side",
-        "regulated_object",
-        [(ComponentType.transformer, "tap_side"), (ComponentType.three_winding_transformer, "tap_side")],
     )
     return errors

--- a/src/power_grid_model/validation/errors.py
+++ b/src/power_grid_model/validation/errors.py
@@ -518,15 +518,3 @@ class InvalidAssociatedEnumValueError(MultiFieldValidationError):
 
     def __eq__(self, other):
         return super().__eq__(other) and self.enum == other.enum
-
-
-class UnsupportedTransformerRegulationError(MultiFieldValidationError):
-    """
-    The control side of a branch regulator is not supported for the regulated object
-    """
-
-    _message = (
-        "Unsupported control side for {n} {objects}. "
-        "The control side cannot be on the same side as the tap side. "
-        "The node at the control side must have the same or lower u_rated as the node at the tap side."
-    )

--- a/tests/unit/validation/test_input_validation.py
+++ b/tests/unit/validation/test_input_validation.py
@@ -34,7 +34,6 @@ from power_grid_model.validation.errors import (
     NotLessThanError,
     NotUniqueError,
     TwoValuesZeroError,
-    UnsupportedTransformerRegulationError,
 )
 from power_grid_model.validation.utils import _nan_type
 
@@ -640,10 +639,6 @@ def test_validate_input_data_transformer_tap_regulator(input_data):
     )
     assert (
         NotGreaterOrEqualError("transformer_tap_regulator", "line_drop_compensation_x", [1], 0.0) in validation_errors
-    )
-    assert (
-        UnsupportedTransformerRegulationError("transformer_tap_regulator", ["control_side", "regulated_object"], [54])
-        in validation_errors
     )
     assert NotUniqueError("transformer_tap_regulator", "regulated_object", [51, 54]) in validation_errors
 

--- a/tests/unit/validation/test_rules.py
+++ b/tests/unit/validation/test_rules.py
@@ -27,7 +27,6 @@ from power_grid_model.validation._rules import (
     all_less_than,
     all_not_two_values_equal,
     all_not_two_values_zero,
-    all_supported_tap_control_side,
     all_unique,
     all_valid_clocks,
     all_valid_enum_values,
@@ -55,7 +54,6 @@ from power_grid_model.validation.errors import (
     NotUniqueError,
     SameValueError,
     TwoValuesZeroError,
-    UnsupportedTransformerRegulationError,
 )
 
 
@@ -640,35 +638,3 @@ def test_all_valid_fault_phases():
     errors = all_valid_fault_phases(invalid, "fault", "foo", "bar")
     assert len(errors) == 1
     assert FaultPhaseError("fault", fields=["foo", "bar"], ids=list(range(26))) in errors
-
-
-def test_supported_tap_control_side():
-    valid = {
-        "foo": np.array([(0, 4)], dtype=[("id", "i4"), ("foofoo", "i1")]),
-        "bar": np.array([(1, 5)], dtype=[("id", "i4"), ("barbar", "i1")]),
-        "baz": np.array([], dtype=[("id", "i4"), ("bazbaz", "i1")]),
-        "regulator": np.array([(2, 0, 6), (3, 1, 7)], dtype=[("id", "i4"), ("regulated", "i4"), ("control", "i1")]),
-    }
-    errors = all_supported_tap_control_side(
-        valid,
-        "regulator",
-        "control",
-        "regulated",
-        [("foo", "foofoo"), ("bar", "barbar"), ("baz", "bazbaz"), ("bla", "blabla")],
-    )
-    assert not errors
-
-    invalid = {
-        "foo": np.array([(0, 4)], dtype=[("id", "i4"), ("foofoo", "i1")]),
-        "bar": np.array([(1, 5)], dtype=[("id", "i4"), ("barbar", "i1")]),
-        "regulator": np.array([(2, 0, 4), (3, 1, 5)], dtype=[("id", "i4"), ("regulated", "i4"), ("control", "i1")]),
-    }
-    errors = all_supported_tap_control_side(
-        invalid,
-        "regulator",
-        "control",
-        "regulated",
-        [("foo", "foofoo"), ("bar", "barbar"), ("baz", "bazbaz")],
-    )
-    assert len(errors) == 1
-    assert UnsupportedTransformerRegulationError(component="regulator", fields=["control", "regulated"], ids=[2, 3])

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -33,7 +33,6 @@ from power_grid_model.validation.errors import (
     MultiComponentNotUniqueError,
     NotUniqueError,
     PQSigmaPairError,
-    UnsupportedTransformerRegulationError,
 )
 
 NaN = power_grid_meta_data[DatasetType.input][ComponentType.node].nans["id"]
@@ -971,11 +970,11 @@ def test_validate_values__tap_regulator_control_side():
     transformer_tap_regulator["regulated_object"] = np.arange(7)
     transformer_tap_regulator["control_side"] = [
         BranchSide.to_side,  # OK
-        BranchSide.from_side,  # control side is same as tap side (unsupported)
+        BranchSide.from_side,  # OK
         Branch3Side.side_3,  # branch3 provided but it is a 2-winding transformer (invalid)
         10,  # control side entirely out of range (invalid)
         Branch3Side.side_3,  # OK
-        Branch3Side.side_1,  # control side is same as tap side (unsupported)
+        Branch3Side.side_1,  # OK
         10,  # control side entirely out of range (invalid)
     ]
 
@@ -991,7 +990,7 @@ def test_validate_values__tap_regulator_control_side():
     assert power_flow_errors == all_errors
     assert not state_estimation_errors
 
-    assert len(all_errors) == 4
+    assert len(all_errors) == 3
     assert (
         InvalidEnumValueError("transformer_tap_regulator", "control_side", [10, 13], [BranchSide, Branch3Side])
         in all_errors
@@ -1011,14 +1010,6 @@ def test_validate_values__tap_regulator_control_side():
             ["control_side", "regulated_object"],
             [13],
             [Branch3Side],
-        )
-        in all_errors
-    )
-    assert (
-        UnsupportedTransformerRegulationError(
-            "transformer_tap_regulator",
-            ["control_side", "regulated_object"],
-            [8, 12],
         )
         in all_errors
     )


### PR DESCRIPTION
Removed control side and tap side validation from python side. The same change was assumed to have happened during https://github.com/PowerGridModel/power-grid-model/pull/829.