### PR TITLE
bump macos min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ def generate_build_ext(pkg_dir: Path, pkg_name: str):
         # extra flag for Mac
         if platform.system() == "Darwin":
             # compiler flag to set version
-            cflags.append("-mmacosx-version-min=10.15")
+            cflags.append("-mmacosx-version-min=13.3")
 
     # list of extensions
     exts = [


### PR DESCRIPTION
Some modern C++ features, like `std::format`, require MacOS>=13.3. That is also shown in this experiment:
* [x] Without `macos>=13.3` and with `std::format`: https://github.com/PowerGridModel/power-grid-model/actions/runs/13899518259/job/38887744614 (Fails)
* [x] With `macos>=13.3` and with `std::format`: https://github.com/PowerGridModel/power-grid-model/actions/runs/13901040632 (Passes)
