### PR TITLE
The public CPP API from PGM should rely on c++17 standard

### DIFF
--- a/power_grid_model_c/power_grid_model_cpp/CMakeLists.txt
+++ b/power_grid_model_c/power_grid_model_cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(power_grid_model_cpp PUBLIC
 set_target_properties(power_grid_model_cpp PROPERTIES
   VERSION ${PGM_VERSION}
   SOVERSION ${PGM_VERSION}
+  CXX_STANDARD 17
 )
 
 

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/handle.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/handle.hpp
@@ -71,8 +71,8 @@ class Handle {
             auto const* const failed_scenario_seqs = PGM_failed_scenarios(handle_ptr);
             auto const* const failed_scenario_messages = PGM_batch_errors(handle_ptr);
             for (Idx i = 0; i < n_failed_scenarios; ++i) {
-                failed_scenarios[i] = PowerGridBatchError::FailedScenario{.scenario = failed_scenario_seqs[i],
-                                                                          .error_message = failed_scenario_messages[i]};
+                failed_scenarios[i] =
+                    PowerGridBatchError::FailedScenario{failed_scenario_seqs[i], failed_scenario_messages[i]};
             }
             clear_error();
             throw PowerGridBatchError{error_message, std::move(failed_scenarios)};

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/serialization.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/serialization.hpp
@@ -116,7 +116,7 @@ inline OwningDataset create_owning_dataset(DatasetWritable& writable_dataset) {
         writable_dataset.set_buffer(component_name, indptr, current_buffer);
         dataset_mutable.add_buffer(component_name, elements_per_scenario, component_size, indptr, current_buffer);
     }
-    return OwningDataset{.dataset = std::move(dataset_mutable), .storage = std::move(storage)};
+    return OwningDataset{std::move(dataset_mutable), std::move(storage)};
 }
 } // namespace power_grid_model_cpp
 

--- a/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/utils.hpp
+++ b/power_grid_model_c/power_grid_model_cpp/include/power_grid_model_cpp/utils.hpp
@@ -31,10 +31,19 @@ constexpr double nan = std::numeric_limits<double>::quiet_NaN();
 constexpr int8_t na_IntS = std::numeric_limits<int8_t>::min();
 constexpr ID na_IntID = std::numeric_limits<ID>::min();
 
-template <std::same_as<double> T> constexpr T nan_value() { return nan; }
-template <std::same_as<std::array<double, 3>> T> constexpr T nan_value() { return {nan, nan, nan}; }
-template <std::same_as<ID> T> constexpr T nan_value() { return na_IntID; }
-template <std::same_as<int8_t> T> constexpr T nan_value() { return na_IntS; }
+template <typename T> constexpr T nan_value() {
+    if constexpr (std::is_same_v<T, double>) {
+        return nan;
+    } else if constexpr (std::is_same_v<T, ID>) {
+        return na_IntID;
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+        return na_IntS;
+    } else if constexpr (std::is_same_v<T, std::array<double, 3>>) {
+        return std::array<double, 3>{nan, nan, nan};
+    } else {
+        static_assert(false, "Unsupported type for nan_value");
+    }
+}
 
 class UnsupportedPGM_CType : public PowerGridError {
   public:

--- a/tests/package_tests/CMakeLists.txt
+++ b/tests/package_tests/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required (VERSION 3.23)
 
 project(power_grid_model_package_tests)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
The public CPP API of PGM should rely on  c++17 standard as decided by the TSC. However, there are c++20 features used. In this PR we force the package test to build in c++17. And the error will show up.