### PR TITLE
add conda-remove-defaults to setup miniforge in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3  # install miniforge instead
         with:
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: "true"
       
       - name: List conda
         run: |
@@ -256,6 +258,8 @@ jobs:
           activate-environment: conda-pgm-env
           environment-file: .github/conda_pgm_env.yml
           auto-activate-base: false
+          channels: conda-forge
+          conda-remove-defaults: "true"
       
       - name: List conda
         run: |


### PR DESCRIPTION
Attempt to fix the warning about conda default channels cfr. https://github.com/PowerGridModel/power-grid-model/actions/runs/14050295856

![image](https://github.com/user-attachments/assets/eeb5c074-3157-4c6d-a49f-868d79bb3d5b)
