### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -5,6 +5,8 @@
 # This file works as a placeholder for new workflows to be tested
 # in the GitHub actions tab before being merged.
 # It is not intended to be used in the main branch, but rather in PRs.
+# After testing, this workflow should be returned to the original state;
+# this is checked by the check-code-quality workflow.
 name: Test workflow
 
 on:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# This file works as a placeholder for new workflows to be tested
+# in the GitHub actions tab before being merged.
+# It is not intended to be used in the main branch, but rather in PRs.
+name: Test workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test step
+        run: echo "Test workflow running"


### PR DESCRIPTION
This PR adds the `test_workflow.yml` workflow as a placeholder for new workflows such that they can be tested via the action tab without having to modify other workflows or merge to main.

Ideally, this workflow is always left as empty in main, and only used in other PRs.