### PR TITLE
Adds check for test_workflow

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -91,7 +91,8 @@ jobs:
           DIFF=$(git diff origin/main -- .github/workflows/test_workflow.yml)
 
           if [ -n "$DIFF" ]; then
-            echo "The test_workflow.yml file has changed from main."
+            echo "The test-workflow.yml file has changed from main."
+            echo "Please revert test-workflow.yml to its original state after testing is completed."
             echo "$DIFF"
             exit 1
           else

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -85,10 +85,10 @@ jobs:
             echo "All the generated files are up to date."
           fi
 
-      - name: Check test_workflow.yml
+      - name: Check test-workflow.yml
         run: |
-          git fetch origin main:refs/remotes/origin/main
-          DIFF=$(git diff origin/main -- .github/workflows/test_workflow.yml)
+          git fetch origin/main
+          DIFF=$(git diff origin/main -- .github/workflows/test-workflow.yml)
 
           if [ -n "$DIFF" ]; then
             echo "The test-workflow.yml file has changed from main."

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -97,6 +97,6 @@ jobs:
             echo "$DIFF"
             exit 1
           else
-            echo "The test_workflow.yml file matches main."
+            echo "The test-workflow.yml file matches main."
           fi
           

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -85,9 +85,9 @@ jobs:
             echo "All the generated files are up to date."
           fi
 
-      - name: Check if test_workflow.yml is unchaged with respect to main
+      - name: Check test_workflow.yml
         run: |
-          git fetch origin main
+          git fetch origin main:refs/remotes/origin/main
           DIFF=$(git diff origin/main -- .github/workflows/test_workflow.yml)
 
           if [ -n "$DIFF" ]; then

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -86,8 +86,9 @@ jobs:
           fi
 
       - name: Check test-workflow.yml
+        if: success()
         run: |
-          git fetch origin/main
+          git fetch origin main
           DIFF=$(git diff origin/main -- .github/workflows/test-workflow.yml)
 
           if [ -n "$DIFF" ]; then

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -84,3 +84,17 @@ jobs:
             echo
             echo "All the generated files are up to date."
           fi
+
+      - name: Check if test_workflow.yml is unchaged with respect to main
+        run: |
+          git fetch origin main
+          DIFF=$(git diff origin/main -- .github/workflows/test_workflow.yml)
+
+          if [ -n "$DIFF" ]; then
+            echo "The test_workflow.yml file has changed from main."
+            echo "$DIFF"
+            exit 1
+          else
+            echo "The test_workflow.yml file matches main."
+          fi
+          

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Test step
-        run: echo "Let's break the code quality check!"
+        run: echo "Test workflow running"

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Test step
-        run: echo "Test workflow running"
+        run: echo "Let's break the code quality check!"


### PR DESCRIPTION
This PR adds a check to #945 so that the `test-workflow.yml` file, is not changed and then merged to main.

Testing:

- [x] Test workflow introduced in #945 [works as expected via workflow dispatch](https://github.com/PowerGridModel/power-grid-model/actions/workflows/test-workflow.yml) (It can be manually run to test new workflows).
- [x] [The new code quality check fails](https://github.com/PowerGridModel/power-grid-model/actions/runs/14402083799/job/40389900188) when `test-workflow.yml` is modified inside a PR (After testing is done, a new workflow must be created and `test-workflow.yml` is to be left in its original state).
- [x] [08ff350](https://github.com/PowerGridModel/power-grid-model/pull/946/commits/08ff350ea404d9b1c747985cc13e56a18d65a1e0) in `test-workflow.yml`.