### PR TITLE
Fix MacOS build for Xcode 16.3

### DIFF
--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -81,9 +81,11 @@ TEST_CASE("API Serialization and Deserialization") {
             Serializer msgpack_serializer{dataset, 1};
 
             SUBCASE("Round trip") {
-                std::vector<char> msgpack_data{};
+                std::vector<std::byte> msgpack_data{};
+                std::span<std::underlying_type_t<std::byte>> const msgpack_data_view{
+                    reinterpret_cast<std::underlying_type_t<std::byte>*>(msgpack_data.data()), msgpack_data.size()};
                 msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
-                auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data);
+                auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data_view);
                 auto const json_result = json_document.dump(-1);
                 CHECK(json_result == json_data);
             }

--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -82,9 +82,9 @@ TEST_CASE("API Serialization and Deserialization") {
 
             SUBCASE("Round trip") {
                 std::vector<std::byte> msgpack_data{};
+                msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
                 std::span<std::underlying_type_t<std::byte>> const msgpack_data_view{
                     reinterpret_cast<std::underlying_type_t<std::byte>*>(msgpack_data.data()), msgpack_data.size()};
-                msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
                 auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data_view);
                 auto const json_result = json_document.dump(-1);
                 CHECK(json_result == json_data);

--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -81,7 +81,7 @@ TEST_CASE("API Serialization and Deserialization") {
             Serializer msgpack_serializer{dataset, 1};
 
             SUBCASE("Round trip") {
-                std::vector<std::byte> msgpack_data{};
+                std::vector<char> msgpack_data{};
                 msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
                 auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data);
                 auto const json_result = json_document.dump(-1);

--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -14,14 +14,6 @@
 #include <string>
 #include <vector>
 
-namespace nlohmann::detail {
-template <> struct char_traits<std::byte> : char_traits<std::underlying_type_t<std::byte>> {
-    using char_type = std::byte;
-
-    // Redefine to_int_type function
-    static int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
-};
-} // namespace nlohmann::detail
 namespace power_grid_model_cpp {
 namespace {
 using namespace std::string_literals;
@@ -89,7 +81,9 @@ TEST_CASE("API Serialization and Deserialization") {
             SUBCASE("Round trip") {
                 std::vector<std::byte> msgpack_data{};
                 msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
-                auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data);
+                auto const char_start = reinterpret_cast<unsigned char const*>(msgpack_data.data());
+                auto const char_end = char_start + msgpack_data.size();
+                auto const json_document = nlohmann::ordered_json::from_msgpack(char_start, char_end);
                 auto const json_result = json_document.dump(-1);
                 CHECK(json_result == json_data);
             }

--- a/tests/native_api_tests/test_api_serialization.cpp
+++ b/tests/native_api_tests/test_api_serialization.cpp
@@ -14,10 +14,16 @@
 #include <string>
 #include <vector>
 
+namespace nlohmann::detail {
+template <> struct char_traits<std::byte> : char_traits<std::underlying_type_t<std::byte>> {
+    using char_type = std::byte;
+
+    // Redefine to_int_type function
+    static int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
+};
+} // namespace nlohmann::detail
 namespace power_grid_model_cpp {
-
 namespace {
-
 using namespace std::string_literals;
 
 constexpr char const* json_data =
@@ -83,9 +89,7 @@ TEST_CASE("API Serialization and Deserialization") {
             SUBCASE("Round trip") {
                 std::vector<std::byte> msgpack_data{};
                 msgpack_serializer.get_to_binary_buffer(0, msgpack_data);
-                std::span<std::underlying_type_t<std::byte>> const msgpack_data_view{
-                    reinterpret_cast<std::underlying_type_t<std::byte>*>(msgpack_data.data()), msgpack_data.size()};
-                auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data_view);
+                auto const json_document = nlohmann::ordered_json::from_msgpack(msgpack_data);
                 auto const json_result = json_document.dump(-1);
                 CHECK(json_result == json_data);
             }


### PR DESCRIPTION
As mentioned in [Xcode 16.3 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes): _The base template for std::char_traits has been removed. If you are using std::char_traits with types other than char, wchar_t, char8_t, char16_t, char32_t or a custom character type for which you specialized std::char_traits, your code will stop working. The Standard does not mandate that a base template is provided, and such a base template is bound to be incorrect for some types, which could previously cause unexpected behavior while going undetected._

This affects us indirectly as we use [nlohmann/json](https://github.com/nlohmann/json/tree/v3.12.0) and they still use `std::char_traits`, resulting in failed compilation attempt (only for MacOS devs with Xcode16.3) due to the usage of `std::vector<std::byte>` as an argument of `nlohmann::ordered_json::from_msgpack()` in our tests.

In this PR, we modify our tests such that this is not an issue anymore.

Note: There was a recent release of the [library](https://github.com/nlohmann/json/releases/tag/v3.12.0), but it didn't address this issue.