### PR TITLE
Add missing permissions to publish into PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # Required for Trusted Publishing
     needs: build-test-release
     if: (github.event_name == 'workflow_dispatch') || github.event_name == 'push'
 


### PR DESCRIPTION
Fixes a bug introduced in #965 where permissions to publish to PyPI via trusted publisher were not given. This adds the right permissions.

Don't merge until proven/tested to publish correctly. https://github.com/PowerGridModel/power-grid-model/pull/972 test passes.