### PR TITLE
voltage sensor angle residual mod 2pi

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -627,9 +627,11 @@ A sensor only has output for state estimation. For other calculation types, sens
 $$
    \begin{eqnarray}
         & u_{\text{residual}} = u_{\text{measured}} - u_{\text{state}} \\
-        & \theta_{\text{residual}} = \theta_{\text{measured}} - \theta_{\text{state}}
+        & \theta_{\text{residual}} = \theta_{\text{measured}} - \theta_{\text{state}} \pmod{2 \pi}
    \end{eqnarray}
 $$
+
+The $\pmod{2\pi}$ is handled such that $-\pi \lt \theta_{\text{angle},\text{residual}} \leq \pi$.
 
 ### Generic Power Sensor
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/voltage_sensor.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/voltage_sensor.hpp
@@ -151,7 +151,7 @@ template <symmetry_tag sym> class VoltageSensor : public GenericVoltageSensor {
         } else {
             value.u_residual = (real(u1_measured) - cabs(u)) * u_rated_;
         }
-        value.u_angle_residual = arg(u1_measured) - arg(u);
+        value.u_angle_residual = arg(ComplexValue<symmetric_t>{exp(1.0i * (arg(u1_measured) - arg(u)))});
         return value;
     }
 
@@ -160,7 +160,7 @@ template <symmetry_tag sym> class VoltageSensor : public GenericVoltageSensor {
         value.id = id();
         value.energized = 1;
         value.u_residual = (u_measured_ - cabs(u)) * u_rated_ / sqrt3;
-        value.u_angle_residual = u_angle_measured_ - arg(u);
+        value.u_angle_residual = arg(ComplexValue<asymmetric_t>{exp(1.0i * (u_angle_measured_ - arg(u)))});
         return value;
     }
 };


### PR DESCRIPTION
voltage angle residuals currently can be in the range `[-2pi, 2pi]`. This PR restricts it to the range `(-pi, pi]`, effectively doing `mod 2pi`. This is also cfr. #962 