### PR TITLE
Automatic release note generation: config YAML file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+changelog:
+  exclude:
+    labels:
+      - github-actions
+    authors:
+      - dependabot
+  categories:
+    - title: Features and improvements
+      labels:
+        - feature
+        - improvement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,11 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 changelog:
-  exclude:
-    labels:
-      - github-actions
-    authors:
-      - dependabot
   categories:
     - title: Features and improvements
       labels:
@@ -19,6 +14,8 @@ changelog:
     - title: Dependencies
       labels:
         - dependencies
+      authors:
+        - dependabot
     - title: Documentation
       labels:
         - documentation


### PR DESCRIPTION
This PR adds the configuration YAML file to the `/.github` directory. This enables the automatic release note generation for releases where the change log is listed based on labels. In the current configuration, all dependabot related changes are excluded.