### PR TITLE
MacOS build still fails when using clang-17

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -186,7 +186,7 @@ jobs:
             os: ubuntu-24.04-arm
             cibw_build: "*_aarch64"
           - platform: macos
-            os: macos-14
+            os: macos-15
             cibw_build: "*"
           - platform: windows
             os: windows-latest
@@ -204,7 +204,7 @@ jobs:
           path: .
 
       - name: Set up XCode
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ musllinux-x86_64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-environment = { CC = "clang", CXX = "clang++", MACOSX_DEPLOYMENT_TARGET = "13.3" }
+environment = { CC = "clang", CXX = "clang++", MACOSX_DEPLOYMENT_TARGET = "13.4" }
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if platform.system() == "Windows":
 elif platform.system() in ["Linux", "Darwin"]:
     if_win = False
     if platform.system() == "Darwin":
-        os.environ["MACOSX_DEPLOYMENT_TARGET"] = "13.3"
+        os.environ["MACOSX_DEPLOYMENT_TARGET"] = "13.4"
 else:
     raise SystemError("Only Windows, Linux, or MacOS is supported!")
 


### PR DESCRIPTION
We have bumped the minimum MacOS version for the coming `clang-17`. It seems that it is still not sufficient.

Bump to `13.4` as minimum required deployment target is okay.