### PR TITLE
Current sensor: remove experimental flag for ILSE

### DIFF
--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -108,7 +108,7 @@ In observable systems this helps better outputting correct results. On the other
 ```
 
 ```{warning}
-At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation). The support in the calculation of [Iterative Linear state estimation](#iterative-linear-state-estimation) is experimental.
+At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation). 
 ```
 
 ##### Necessary observability condition

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -864,10 +864,6 @@ $$
 ### Generic Current Sensor
 
 ```{warning}
-At the time of writing, this feature is still experimental and is not yet publicly available.
-```
-
-```{warning}
 At the time of writing, state estimation with current sensors is not supported by the Newton-Raphson calculation method.
 ```
 

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -895,10 +895,6 @@ However, such mixing of sensor types is allowed as long as they are on different
 #### Current Sensor Concrete Types
 
 ```{warning}
-At the time of writing, this feature is still experimental and is not yet publicly available.
-```
-
-```{warning}
 At the time of writing, state estimation with current sensors is not supported by the Newton-Raphson calculation method.
 ```
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -803,11 +803,9 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
 
     void check_no_experimental_features_used(Options const& options) const {
         if (options.calculation_type == CalculationType::state_estimation &&
-            state_.components.template size<GenericCurrentSensor>() > 0) {
-            if (options.calculation_method == CalculationMethod::newton_raphson) {
-                throw ExperimentalFeature{"Newton-Raphson state estimation is not implemented for current sensors"};
-            }
-            throw ExperimentalFeature{"State estimation with current sensors is experimental"};
+            state_.components.template size<GenericCurrentSensor>() > 0 &&
+            options.calculation_method == CalculationMethod::newton_raphson) {
+            throw ExperimentalFeature{"Newton-Raphson state estimation is not implemented for current sensors"};
         }
     }
 

--- a/tests/data/state_estimation/current-sensor/global-current-sensor/params.json
+++ b/tests/data/state_estimation/current-sensor/global-current-sensor/params.json
@@ -9,9 +9,6 @@
     ".+_residual": 5e-4
   },
   "extra_params": {
-    "iterative_linear": {
-      "experimental_features": "enabled"
-    },
     "newton_raphson": {
       "experimental_features": "enabled",
       "fail": {

--- a/tests/data/state_estimation/current-sensor/local-current-sensor/params.json
+++ b/tests/data/state_estimation/current-sensor/local-current-sensor/params.json
@@ -9,9 +9,6 @@
     ".+_residual": 5e-4
   },
   "extra_params": {
-    "iterative_linear": {
-      "experimental_features": "enabled"
-    },
     "newton_raphson": {
       "experimental_features": "enabled",
       "fail": {

--- a/tests/native_api_tests/test_api_model.cpp
+++ b/tests/native_api_tests/test_api_model.cpp
@@ -1063,7 +1063,7 @@ TEST_CASE("API Model") {
         }
     }
 
-    SUBCASE("Current sensor is experimental") {
+    SUBCASE("Current sensor for NRSE is experimental: not implemented") {
         auto const input_data_se_json = R"json({
   "version": "1.0",
   "type": "input",
@@ -1103,8 +1103,7 @@ TEST_CASE("API Model") {
                                      "Newton-Raphson state estimation is not implemented for current sensors",
                                      PowerGridRegularError);
             } else {
-                CHECK_THROWS_WITH_AS(run_se_with_current_sensor(method, PGM_experimental_features_disabled),
-                                     "State estimation with current sensors is experimental", PowerGridRegularError);
+                CHECK_NOTHROW(run_se_with_current_sensor(method, PGM_experimental_features_disabled));
             }
             CHECK_NOTHROW(run_se_with_current_sensor(method, PGM_experimental_features_enabled));
         }

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -14,7 +14,6 @@ from power_grid_model.enum import (
     LoadGenType,
     MeasuredTerminalType,
     TapChangingStrategy,
-    _ExperimentalFeatures,
 )
 from power_grid_model.errors import (
     AutomaticTapInputError,
@@ -422,7 +421,7 @@ def test_conflicting_angle_measurement_type() -> None:
     )
 
     with pytest.raises(ConflictingAngleMeasurementType):
-        model._calculate_state_estimation(decode_error=True, experimental_features=_ExperimentalFeatures.enabled)
+        model._calculate_state_estimation(decode_error=True)
 
 
 def test_global_current_measurement_without_voltage_angle() -> None:
@@ -470,7 +469,7 @@ def test_global_current_measurement_without_voltage_angle() -> None:
     )
 
     with pytest.raises(NotObservableError):
-        model._calculate_state_estimation(decode_error=True, experimental_features=_ExperimentalFeatures.enabled)
+        model._calculate_state_estimation(decode_error=True)
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
The experimental flag is removed for current sensor in ILSE:

- [x] API
- [x] test
- [x] doc
- [x] Current sensor remain 'not implemented' in NRSE (as an experimental flag error as agreed in https://github.com/PowerGridModel/power-grid-model/pull/998#discussion_r2095094003) 
- [x] remove experimental feature flag from ILSE current sensor validation cases