### PR TITLE
docs: markdown line length 120

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -14,7 +14,7 @@ MD013:
   # # Number of characters for code blocks
   # code_block_line_length: 80
   # # Include code blocks
-  code_blocks: false
+  code_blocks: true
   # # Include tables
   tables: false
   # # Include headings

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,24 +5,24 @@
 # MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md001.md
 MD001: false
 
-# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md013.md
-MD013: false
+# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md013.md
+MD013:
   # # Number of characters
-  # line_length: 80
+  line_length: 120
   # # Number of characters for headings
   # heading_line_length: 80
   # # Number of characters for code blocks
   # code_block_line_length: 80
   # # Include code blocks
-  # code_blocks: true
+  code_blocks: false
   # # Include tables
-  # tables: true
+  tables: false
   # # Include headings
   # headings: true
   # # Strict length checking
   # strict: false
   # # Stern length checking
-  # stern: false
+  stern: true
 
 # MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md024.md
 MD024: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: clang-format
         types_or: [ c++, c ]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
     - id: markdownlint
       args: ["--fix"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,11 @@
         "projectKey": "PowerGridModel_power-grid-model"
     },
     "C_Cpp.formatting": "clangFormat",
-    "C_Cpp.clang_format_fallbackStyle": "LLVM"
+    "C_Cpp.clang_format_fallbackStyle": "LLVM",
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+        "editor.rulers": [
+            120
+        ]
+    }
 }

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 
 # Build Guide
 
-This document explains how you can build this library from source, including some examples of build environment. In this
+This document explains how you can build this library from source, including some examples of build environment.
+In this
 repository there are three builds:
 
 * A `power-grid-model` [pip](https://pypi.org/project/power-grid-model/) Python package with C++ extension as the calculation core.
@@ -22,22 +23,27 @@ repository there are three builds:
 
 ## Build Requirements
 
-To build the library from source, you need to first prepare the compiler toolchains and the build dependencies. In this
-section a list of general requirements are given. After this section there are examples of setup in Linux (Ubuntu 22.04),
+To build the library from source, you need to first prepare the compiler toolchains and the build dependencies.
+In this
+section a list of general requirements are given.
+After this section there are examples of setup in Linux (Ubuntu 22.04),
 Windows 10, and macOS (Big Sur).
 
 ### Architecture Support
 
-This library is written and tested on `x86_64` and `arm64` architecture. Building the library in `IA-32` might be working, but is
+This library is written and tested on `x86_64` and `arm64` architecture.
+Building the library in `IA-32` might be working, but is
 not tested.
 
 The source code is written with the mindset of ISO standard C++ only, i.e. avoid compiler-extension or platform-specific
-features as much as possible. In this way the effort to port the library to other platform/architecture might be
+features as much as possible.
+In this way the effort to port the library to other platform/architecture might be
 minimum.
 
 ### Compiler Support
 
-You need a C++ compiler with C++20 support. Below is a list of tested compilers:
+You need a C++ compiler with C++20 support.
+Below is a list of tested compilers:
 
 #### Linux
 
@@ -110,7 +116,8 @@ Then you can run the tests.
 pytest
 ```
 
-A basic `self_test` function is provided to check if the installation was successful and ensures there are no build errors, segmentation violations, undefined symbols, etc. It performs multiple C API calls, runs through the main data flow, and verifies the integrity of serialization and deserialization.
+A basic `self_test` function is provided to check if the installation was successful and ensures there are no build errors, segmentation violations, undefined symbols, etc.
+It performs multiple C API calls, runs through the main data flow, and verifies the integrity of serialization and deserialization.
 
 ```python
 from power_grid_model.utils import self_test
@@ -151,7 +158,8 @@ cmake --install build/ --config Release --prefix install/
 ### Developer build
 
 If you opt for a developer build of Power Grid Model,
-you can use the pre-defined CMake presets to enable developer build, including all the tests, warnings, examples, and benchmark. In the presets the [Ninja](https://ninja-build.org/) generator is used.
+you can use the pre-defined CMake presets to enable developer build, including all the tests, warnings, examples, and benchmark.
+In the presets the [Ninja](https://ninja-build.org/) generator is used.
 In principle, you can use any C++ IDE with cmake and ninja support to develop the C++ project.
 It is also possible to use the bare CMake CLI to set up the project.
 Supported presets for your development platform can be listed using `cmake --list-presets`.
@@ -165,23 +173,32 @@ In the developer build the following build targets (directories) are enabled:
 * `tests/benchmark_cpp`: the C++ benchmark target for performance measure.
 * `power_grid_model_c_example`: an example C program to call the dynamic library
 
-On Linux/macOS, the presets will use command `clang`/`clang++` or `gcc`/`g++` to find the relevant `clang` or `gcc` compiler. It is the developer's reponsiblity to properly define symbolic links (which should be discoverable through `PATH` environment variable) of `clang` or `gcc` compiler in your system. If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` executable of your system.
+On Linux/macOS, the presets will use command `clang`/`clang++` or `gcc`/`g++` to find the relevant `clang` or `gcc` compiler.
+It is the developer's reponsiblity to properly define symbolic links (which should be discoverable through `PATH` environment variable) of `clang` or `gcc` compiler in your system.
+If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` executable of your system.
 
-Similar also applies to Windows: the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler. Developer needs to make sure the they are discoverable in `PATH`. For x64 Windows native development using MSVC or Clang CL, please use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set up the appropriate build environment.
+Similar also applies to Windows: the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler.
+Developer needs to make sure the they are discoverable in `PATH`.
+For x64 Windows native development using MSVC or Clang CL, please use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set up the appropriate build environment.
 
 ## Visual Studio Code Support
 
-You can use any IDE to develop this project. As a popular cross-platform IDE, the settings for Visual Studio Code is preconfigured in the folder `.vscode`. You can open the repository folder with VSCode and the configuration will be loaded automatically.
+You can use any IDE to develop this project.
+As a popular cross-platform IDE, the settings for Visual Studio Code is preconfigured in the folder `.vscode`.
+You can open the repository folder with VSCode and the configuration will be loaded automatically.
 
 ```{note}
-VSCode (as well as some other IDEs) does not set its own build environment itself. For optimal usage, open the folder
-using `code <project_dir>` from a terminal that has the environment set up. See above section for tips.
+VSCode (as well as some other IDEs) does not set its own build environment itself.
+For optimal usage, open the folder
+using `code <project_dir>` from a terminal that has the environment set up.
+See above section for tips.
 ```
 
 ## Build Script for Linux/macOS
 
 There is a convenient shell script to build the cmake project in Linux or macOS:
-{{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}. You can study the file and write your own build script.
+{{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
+You can study the file and write your own build script.
 The following options are supported in the build script.
 
 ```shell
@@ -196,8 +213,8 @@ To list the available presets, run `./build.sh -h`.
 
 ## Example Setup for Ubuntu 24.04 (in WSL or physical/virtual machine)
 
-In this section an example is given for setup in Ubuntu 24.04. You can use this example in Windows Subsystem for Linux (
-WSL), or in a physical/virtual machine.
+In this section an example is given for setup in Ubuntu 24.04.
+You can use this example in Windows Subsystem for Linux (WSL), or in a physical/virtual machine.
 
 ### Environment variables
 
@@ -258,7 +275,8 @@ pytest
 
 There is a convenient shell script to build the cmake project: {{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
 
-As an example, go to the root folder of repo. Use the following command to build the project in release mode:
+As an example, go to the root folder of repo.
+Use the following command to build the project in release mode:
 
 ```shell
 ./build.sh -p <preset>
@@ -296,11 +314,13 @@ Define the following environment variable user-wide:
 
 ### Software Toolchains
 
-You need to install the MSVC compiler. You can either install the whole Visual Studio IDE or just the build tools.
+You need to install the MSVC compiler.
+You can either install the whole Visual Studio IDE or just the build tools.
 
 * [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) (free)
   * Select C++ build tools
-* Full [Visual Studio](https://visualstudio.microsoft.com/vs/) (All three versions are suitable. Check the license!)
+* Full [Visual Studio](https://visualstudio.microsoft.com/vs/) (All three versions are suitable.
+  Check the license!)
   * Select Desktop Development with C++
     * [Optional] Select `C++ Clang tools for Windows`
 
@@ -310,7 +330,8 @@ Other toolchains:
 * [Git](https://git-scm.com/downloads)
 
 ```{note}
-It is also possible to use any other `conda` provider like [Miniconda](https://docs.conda.io/en/latest/miniconda.html). However, we recommend using [Miniforge](https://github.com/conda-forge/miniforge), because it is published under BSD License and by default does not have any references to commercially licensed software.
+It is also possible to use any other `conda` provider like [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+However, we recommend using [Miniforge](https://github.com/conda-forge/miniforge), because it is published under BSD License and by default does not have any references to commercially licensed software.
 ```
 
 ```{note}
@@ -320,7 +341,8 @@ It is possible to enable long paths in Windows by following the steps in the [Mi
 
 ### C++ packages
 
-The recommended way to get C++ package is via `conda`. Open a miniconda console.
+The recommended way to get C++ package is via `conda`.
+Open a miniconda console.
 
 ```shell
 conda create --yes -p C:\conda_envs\cpp_pkgs -c conda-forge libboost-headers eigen nlohmann_json msgpack-cxx doctest
@@ -359,7 +381,9 @@ It is possible to enable long paths in Windows by following the steps in the [Mi
 
 If you have installed Visual Studio 2019/2022 (not the build tools), you can open the repo folder as a cmake project.
 The IDE should be able to automatically detect the Visual Studio cmake configuration file
-`CMakePresets.json`. Several configurations are pre-defined. It includes debug and release builds.
+`CMakePresets.json`.
+Several configurations are pre-defined.
+It includes debug and release builds.
 
 * `msvc-debug`, displayed as `Debug (MSVC)`
 * `msvc-release`, displayed as `Release (MSVC)`.
@@ -398,8 +422,10 @@ brew install ninja cmake boost eigen nlohmann-json msgpack-cxx doctest
 
 ### Build Python Library from Source
 
-It is recommended to create a virtual environment. Clone repository, create and activate virtual environment, and
-install the build dependency. go to a root folder you prefer to save the repositories.
+It is recommended to create a virtual environment.
+Clone repository, create and activate virtual environment, and
+install the build dependency.
+go to a root folder you prefer to save the repositories.
 
 ```shell
 git clone https://github.com/PowerGridModel/power-grid-model.git 
@@ -421,7 +447,8 @@ There is a convenient shell script to build the cmake project: {{ "[`build.sh`](
 
 **Note: the test coverage option is not supported in macOS.**
 
-As an example, go to the root folder of repo. Use the following command to build the project in release mode:
+As an example, go to the root folder of repo.
+Use the following command to build the project in release mode:
 
 ```shell
 ./build.sh -p <preset>
@@ -455,17 +482,23 @@ The {{ "[package tests]({}/tests/package_tests)".format(gh_link_head_blob) }} pr
 project contained in {{ "[`tests/package_tests`]({}/tests/package_tests)".format(gh_link_head_blob) }}.
 
 This project is designed to test and illustrate finding and linking to the installed package from the Power Grid Model
-project. Setup of this project is done the same way as the setup of the main project mentioned in the above, but with
+project.
+Setup of this project is done the same way as the setup of the main project mentioned in the above, but with
 the {{ "[`tests/package_tests`]({}/tests/package_tests)".format(gh_link_head_blob) }} directory as its root folder.
 
 ```{note}
-This project has the main project as a required dependency. Configuration will fail if the main project has not been
+This project has the main project as a required dependency.
+Configuration will fail if the main project has not been
 built and installed, e.g. using `cmake --build --preset <preset> --target install` for the current preset.
 ```
 
 ## Documentation
 
-The documentation is built in [Sphinx](https://github.com/sphinx-doc/sphinx). It can be built locally in a Python environment. The packages required for building it can be found under the `[doc]` optional dependencies. In addition, the `power-grid-model` Python package needs to be built by following the steps mentioned [above](#build-python-package). After that, the documentation specific packages can be installed via:
+The documentation is built in [Sphinx](https://github.com/sphinx-doc/sphinx).
+It can be built locally in a Python environment.
+The packages required for building it can be found under the `[doc]` optional dependencies.
+In addition, the `power-grid-model` Python package needs to be built by following the steps mentioned [above](#build-python-package).
+After that, the documentation specific packages can be installed via:
 
 ```shell
 pip install -e .[doc]
@@ -475,7 +508,8 @@ pip install -e .[doc]
 The `pip install .` part of the command installs the complete package from scratch.
 ```
 
-The C API documentation is generated using [Doxygen](https://www.doxygen.nl). If you do not have Doxygen installed, it can also be temporarily bypassed by commenting out the `breathe` settings in  `docs/conf.py`.
+The C API documentation is generated using [Doxygen](https://www.doxygen.nl).
+If you do not have Doxygen installed, it can also be temporarily bypassed by commenting out the `breathe` settings in  `docs/conf.py`.
 
 The documentation can be built with the following commands, resulting in HTML files of the webpages which can be found in `docs/_build/html` directory.
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -7,38 +7,36 @@ SPDX-License-Identifier: MPL-2.0
 # Build Guide
 
 This document explains how you can build this library from source, including some examples of build environment.
-In this
-repository there are three builds:
+In this repository there are three builds:
 
-* A `power-grid-model` [pip](https://pypi.org/project/power-grid-model/) Python package with C++ extension as the calculation core.
-* A [CMake](https://cmake.org/) project consisting of the C++ header-only calculation core, and the following build targets:
-  * A dynamic library (`.dll` or `.so`) with stable pure C API/ABI which can be used by any application (enabled by default)
+* A `power-grid-model` [pip](https://pypi.org/project/power-grid-model/) Python package with C++ extension as the
+  calculation core.
+* A [CMake](https://cmake.org/) project consisting of the C++ header-only calculation core, and the following build
+  targets:
+  * A dynamic library (`.dll` or `.so`) with stable pure C API/ABI which can be used by any application (enabled by
+    default)
   * An install target that installs the package containing the dynamic library (enabled by default)
   * Native C++ unit tests
   * C API tests
   * A performance benchmark program
   * An example C program to call the shared library
-* A separate example [CMake](https://cmake.org/) project with a small C++ program that shows how to find and use the installable
-  package.
+* A separate example [CMake](https://cmake.org/) project with a small C++ program that shows how to find and use the
+  installable package.
 
 ## Build Requirements
 
 To build the library from source, you need to first prepare the compiler toolchains and the build dependencies.
-In this
-section a list of general requirements are given.
-After this section there are examples of setup in Linux (Ubuntu 22.04),
-Windows 10, and macOS (Big Sur).
+In this section a list of general requirements are given.
+After this section there are examples of setup in Linux (Ubuntu 22.04), Windows 10, and macOS (Big Sur).
 
 ### Architecture Support
 
 This library is written and tested on `x86_64` and `arm64` architecture.
-Building the library in `IA-32` might be working, but is
-not tested.
+Building the library in `IA-32` might be working, but is not tested.
 
 The source code is written with the mindset of ISO standard C++ only, i.e. avoid compiler-extension or platform-specific
 features as much as possible.
-In this way the effort to port the library to other platform/architecture might be
-minimum.
+In this way the effort to port the library to other platform/architecture might be minimum.
 
 ### Compiler Support
 
@@ -116,8 +114,10 @@ Then you can run the tests.
 pytest
 ```
 
-A basic `self_test` function is provided to check if the installation was successful and ensures there are no build errors, segmentation violations, undefined symbols, etc.
-It performs multiple C API calls, runs through the main data flow, and verifies the integrity of serialization and deserialization.
+A basic `self_test` function is provided to check if the installation was successful and ensures there are no build
+errors, segmentation violations, undefined symbols, etc.
+It performs multiple C API calls, runs through the main data flow, and verifies the integrity of serialization and
+deserialization.
 
 ```python
 from power_grid_model.utils import self_test
@@ -158,7 +158,8 @@ cmake --install build/ --config Release --prefix install/
 ### Developer build
 
 If you opt for a developer build of Power Grid Model,
-you can use the pre-defined CMake presets to enable developer build, including all the tests, warnings, examples, and benchmark.
+you can use the pre-defined CMake presets to enable developer build, including all the tests, warnings, examples, and
+benchmark.
 In the presets the [Ninja](https://ninja-build.org/) generator is used.
 In principle, you can use any C++ IDE with cmake and ninja support to develop the C++ project.
 It is also possible to use the bare CMake CLI to set up the project.
@@ -166,20 +167,25 @@ Supported presets for your development platform can be listed using `cmake --lis
 
 In the developer build the following build targets (directories) are enabled:
 
-* `power_grid_model_c`: a dynamic library (`.dll` or `.so`) with stable pure C API/ABI which can be used by any application
+* `power_grid_model_c`: a dynamic library (`.dll` or `.so`) with stable pure C API/ABI which can be used by any
+  application
 * `tests/cpp_unit_tests`: the unit test target for the C++ core using the `doctest` framework.
 * `tests/cpp_validation_tests`: the validation test target using the `doctest` framework
 * `tests/native_api_tests`: the C API test target using the `doctest` framework
 * `tests/benchmark_cpp`: the C++ benchmark target for performance measure.
 * `power_grid_model_c_example`: an example C program to call the dynamic library
 
-On Linux/macOS, the presets will use command `clang`/`clang++` or `gcc`/`g++` to find the relevant `clang` or `gcc` compiler.
-It is the developer's reponsiblity to properly define symbolic links (which should be discoverable through `PATH` environment variable) of `clang` or `gcc` compiler in your system.
-If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual `clang-tidy` executable of your system.
+On Linux/macOS, the presets will use command `clang`/`clang++` or `gcc`/`g++` to find the relevant `clang` or `gcc`
+compiler.
+It is the developer's reponsiblity to properly define symbolic links (which should be discoverable through `PATH`
+environment variable) of `clang` or `gcc` compiler in your system.
+If you want to build with `clang-tidy`, you also need to define symbolic link of `clang-tidy` to point to the actual
+`clang-tidy` executable of your system.
 
 Similar also applies to Windows: the presets will use command `cl.exe` or `clang-cl.exe` to find the compiler.
 Developer needs to make sure the they are discoverable in `PATH`.
-For x64 Windows native development using MSVC or Clang CL, please use the `x64 Native Command Prompt`, which uses `vcvarsall.bat` to set up the appropriate build environment.
+For x64 Windows native development using MSVC or Clang CL, please use the `x64 Native Command Prompt`, which uses
+`vcvarsall.bat` to set up the appropriate build environment.
 
 ## Visual Studio Code Support
 
@@ -189,8 +195,7 @@ You can open the repository folder with VSCode and the configuration will be loa
 
 ```{note}
 VSCode (as well as some other IDEs) does not set its own build environment itself.
-For optimal usage, open the folder
-using `code <project_dir>` from a terminal that has the environment set up.
+For optimal usage, open the folder using `code <project_dir>` from a terminal that has the environment set up.
 See above section for tips.
 ```
 
@@ -273,7 +278,8 @@ pytest
 
 ### Build CMake Project
 
-There is a convenient shell script to build the cmake project: {{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
+There is a convenient shell script to build the cmake project:
+{{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
 
 As an example, go to the root folder of repo.
 Use the following command to build the project in release mode:
@@ -331,12 +337,15 @@ Other toolchains:
 
 ```{note}
 It is also possible to use any other `conda` provider like [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
-However, we recommend using [Miniforge](https://github.com/conda-forge/miniforge), because it is published under BSD License and by default does not have any references to commercially licensed software.
+However, we recommend using [Miniforge](https://github.com/conda-forge/miniforge), because it is published under BSD
+License and by default does not have any references to commercially licensed software.
 ```
 
 ```{note}
-Long paths for (dependencies in) the installation environment might exceed the `maximum path length limitation` set by Windows, causing the installation to fail.
-It is possible to enable long paths in Windows by following the steps in the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
+Long paths for (dependencies in) the installation environment might exceed the `maximum path length limitation` set by
+Windows, causing the installation to fail.
+It is possible to enable long paths in Windows by following the steps in the
+[Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
 ```
 
 ### C++ packages
@@ -358,7 +367,8 @@ Go to a root folder you prefer to save the repositories, open a Git Bash Console
 git clone https://github.com/PowerGridModel/power-grid-model.git
 ```
 
-Then open a Miniforge PowerShell Prompt (or equivalent if you use a different `conda` provider), go to the repository folder.
+Then open a Miniforge PowerShell Prompt (or equivalent if you use a different `conda` provider), go to the repository
+folder.
 
 ```shell
 conda create -n power-grid-env python=3.11
@@ -373,15 +383,16 @@ pytest
 ```
 
 ```{note}
-Long paths for (dependencies in) the conda installation environment might exceed the `maximum path length limitation` set by Windows, causing the installation to fail.
-It is possible to enable long paths in Windows by following the steps in the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
+Long paths for (dependencies in) the conda installation environment might exceed the `maximum path length limitation`
+set by Windows, causing the installation to fail.
+It is possible to enable long paths in Windows by following the steps in the
+[Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
 ```
 
 ### Build CMake Project
 
 If you have installed Visual Studio 2019/2022 (not the build tools), you can open the repo folder as a cmake project.
-The IDE should be able to automatically detect the Visual Studio cmake configuration file
-`CMakePresets.json`.
+The IDE should be able to automatically detect the Visual Studio cmake configuration file `CMakePresets.json`.
 Several configurations are pre-defined.
 It includes debug and release builds.
 
@@ -393,9 +404,8 @@ It includes debug and release builds.
 ```{note}
 - The `Release` presets are compiled with debug symbols.
 - The `Clang CL` presets require `clang-cl` to be installed, e.g. by installing `C++ Clang tools for Windows`.
-- When using an IDE that does not automatically set the toolchain environment using `vcvarsall.bat`, e.g. Visual
-  Studio Code, make sure to open that IDE from a terminal that does so instead (e.g. `x64 Native Tools Command
-  Prompt`).
+- When using an IDE that does not automatically set the toolchain environment using `vcvarsall.bat`, e.g. Visual Studio
+  Code, make sure to open that IDE from a terminal that does so instead (e.g. `x64 Native Tools Command Prompt`).
 ```
 
 ## Example Setup for macOS (Sequoia)
@@ -423,8 +433,7 @@ brew install ninja cmake boost eigen nlohmann-json msgpack-cxx doctest
 ### Build Python Library from Source
 
 It is recommended to create a virtual environment.
-Clone repository, create and activate virtual environment, and
-install the build dependency.
+Clone repository, create and activate virtual environment, and install the build dependency.
 go to a root folder you prefer to save the repositories.
 
 ```shell
@@ -443,7 +452,8 @@ pytest
 
 ### Build CMake Project
 
-There is a convenient shell script to build the cmake project: {{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
+There is a convenient shell script to build the cmake project:
+{{ "[`build.sh`]({}/build.sh)".format(gh_link_head_blob) }}.
 
 **Note: the test coverage option is not supported in macOS.**
 
@@ -483,13 +493,13 @@ project contained in {{ "[`tests/package_tests`]({}/tests/package_tests)".format
 
 This project is designed to test and illustrate finding and linking to the installed package from the Power Grid Model
 project.
-Setup of this project is done the same way as the setup of the main project mentioned in the above, but with
-the {{ "[`tests/package_tests`]({}/tests/package_tests)".format(gh_link_head_blob) }} directory as its root folder.
+Setup of this project is done the same way as the setup of the main project mentioned in the above, but with the
+{{ "[`tests/package_tests`]({}/tests/package_tests)".format(gh_link_head_blob) }} directory as its root folder.
 
 ```{note}
 This project has the main project as a required dependency.
-Configuration will fail if the main project has not been
-built and installed, e.g. using `cmake --build --preset <preset> --target install` for the current preset.
+Configuration will fail if the main project has not been built and installed, e.g. using
+`cmake --build --preset <preset> --target install` for the current preset.
 ```
 
 ## Documentation
@@ -497,7 +507,8 @@ built and installed, e.g. using `cmake --build --preset <preset> --target instal
 The documentation is built in [Sphinx](https://github.com/sphinx-doc/sphinx).
 It can be built locally in a Python environment.
 The packages required for building it can be found under the `[doc]` optional dependencies.
-In addition, the `power-grid-model` Python package needs to be built by following the steps mentioned [above](#build-python-package).
+In addition, the `power-grid-model` Python package needs to be built by following the steps mentioned
+[above](#build-python-package).
 After that, the documentation specific packages can be installed via:
 
 ```shell
@@ -509,9 +520,11 @@ The `pip install .` part of the command installs the complete package from scrat
 ```
 
 The C API documentation is generated using [Doxygen](https://www.doxygen.nl).
-If you do not have Doxygen installed, it can also be temporarily bypassed by commenting out the `breathe` settings in  `docs/conf.py`.
+If you do not have Doxygen installed, it can also be temporarily bypassed by commenting out the `breathe` settings in
+`docs/conf.py`.
 
-The documentation can be built with the following commands, resulting in HTML files of the webpages which can be found in `docs/_build/html` directory.
+The documentation can be built with the following commands, resulting in HTML files of the webpages which can be found
+in `docs/_build/html` directory.
 
 ```shell
 cd docs/doxygen
@@ -521,6 +534,8 @@ sphinx-build -b html . _build/html
 ```
 
 ```{note}
-The user documentation generated by [Sphinx](https://github.com/sphinx-doc/sphinx) only contains the C API documentation.
-Doxygen, however, also builds the documentation for the Power Grid Model core implementation, which can be accessed after building the documentation locally via `docs/_build/html/index.html`.
+The user documentation generated by [Sphinx](https://github.com/sphinx-doc/sphinx) only contains the C API
+documentation.
+Doxygen, however, also builds the documentation for the Power Grid Model core implementation, which can be accessed
+after building the documentation locally via `docs/_build/html/index.html`.
 ```

--- a/docs/advanced_documentation/c-api.md
+++ b/docs/advanced_documentation/c-api.md
@@ -26,7 +26,8 @@ In this documentation, the main design choices and concepts of the C API are pre
 
 ## Finding and linking the package
 
-The package can be loaded using the Config mode of the `find_package` CMake command. An
+The package can be loaded using the Config mode of the `find_package` CMake command.
+An
 {{ "[example project]({}/tests/package_tests/CMakeLists.txt)".format(gh_link_head_blob) }} is provided by the
 {{ "[Git project]({})".format(gh_link_head_tree) }}, which is also used for testing the package.
 
@@ -64,7 +65,9 @@ However, due to the lack of default argument in C,
 this would mean that the C API has a breaking change everytime we add a new option,
 which happends very often.
 
-To solve this issue, we use another opaque object `PGM_Options`. The user creates an object with default options by `PGM_create_options`. You can then specify individual options by `PGM_set_*`.
+To solve this issue, we use another opaque object `PGM_Options`.
+The user creates an object with default options by `PGM_create_options`.
+You can then specify individual options by `PGM_set_*`.
 In the `PGM_calculate` function you need to pass a pointer to `PGM_Options`.
 In this way, we can ensure the API backwards compatibility.
 If we add a new option, it will get a default value in the `PGM_create_options` function.
@@ -80,7 +83,8 @@ We define the following concepts in the data hierarchy:
 * Dataset: a collection of data buffers for a given purpose.
   At this moment, we have four dataset types: `input`, `update`, `sym_output`, `asym_output`.
 * Component: a data buffer with the representation of all attributes of a physical grid component in our [data model](../user_manual/components.md), e.g., `node`.
-* Attribute: a property of given component. For example, `u_rated` attribute of `node` is the rated voltage of the node.
+* Attribute: a property of given component.
+  For example, `u_rated` attribute of `node` is the rated voltage of the node.
 
 Additionally, at this time, we distinguish two buffer types: [component buffers](#component-buffers) and [attribute buffers](#attribute-buffers).
 
@@ -122,7 +126,8 @@ iiiift  iiiift  iiiift     <-- data: 6 bytes per line: 4 bytes for the ID, 1 for
 
 #### Create and destroy buffer
 
-Data buffers are almost always allocated and freed in the heap. We provide two ways of doing so.
+Data buffers are almost always allocated and freed in the heap.
+We provide two ways of doing so.
 
 * You can use the function `PGM_create_buffer` and `PGM_destroy_buffer` to create and destroy buffer.
   In this way, the library is handling the memory (de-)allocation.
@@ -137,7 +142,8 @@ You cannot use `PGM_destroy_buffer` to release a buffer created in your own code
 
 #### Set and get attribute
 
-Once you have the data buffer, you need to set or get attributes. We provide two ways of doing so.
+Once you have the data buffer, you need to set or get attributes.
+We provide two ways of doing so.
 
 * You can use the function `PGM_buffer_set_value` and `PGM_buffer_get_value` to get and set values.
 * You can do pointer cast directly on the buffer pointer, by shifting the pointer to proper offset
@@ -145,7 +151,8 @@ Once you have the data buffer, you need to set or get attributes. We provide two
   You need to first call `PGM_meta_*` functions to retrieve the correct offset.
 
 Pointer cast is generally more efficient and flexible because you are not calling into the
-dynamic library everytime. But it requires the user to retrieve the offset information first.
+dynamic library everytime.
+But it requires the user to retrieve the offset information first.
 Using the buffer helper function is more convenient but with some overhead.
 
 #### Set NaN function
@@ -183,7 +190,8 @@ A combination of attribute buffers with the same amount of elements has the powe
 The type (implying the size) of each attribute can be found using the `PGM_meta_attribute_ctype`.
 
 Since all attributes consist of primitive types, operations are straightforward.
-We therefore do not provide explicit interface functionality to create an attribute buffer. Instead, you should use `PGM_dataset_const_add_buffer` or `PGM_dataset_mutable_add_buffer` with empty data (`NULL`) to set a component buffer for data in columnar-format, and use the functions `PGM_dataset_const_add_attribute_buffer` and `PGM_dataset_mutable_add_attribute_buffer` to add the attribute buffers directly to a dataset.
+We therefore do not provide explicit interface functionality to create an attribute buffer.
+Instead, you should use `PGM_dataset_const_add_buffer` or `PGM_dataset_mutable_add_buffer` with empty data (`NULL`) to set a component buffer for data in columnar-format, and use the functions `PGM_dataset_const_add_attribute_buffer` and `PGM_dataset_mutable_add_attribute_buffer` to add the attribute buffers directly to a dataset.
 
 ## Dataset views
 

--- a/docs/advanced_documentation/c-api.md
+++ b/docs/advanced_documentation/c-api.md
@@ -8,27 +8,26 @@ SPDX-License-Identifier: MPL-2.0
 
 While many users use Python API for Power Grid Model.
 This library also provides a C API.
-The main use case of C API is to integrate Power Grid Model into a non-Python application/library, namely, C, C++, JAVA, C#, etc.
+The main use case of C API is to integrate Power Grid Model into a non-Python application/library, namely, C, C++, JAVA,
+C#, etc.
 
 The C API consists of some
-{{ "[header files]({}/power_grid_model_c/power_grid_model_c/include)".format(gh_link_head_blob) }}
-and a dynamic library (`.so` or `.dll`) built by a
+{{ "[header files]({}/power_grid_model_c/power_grid_model_c/include)".format(gh_link_head_blob) }} and a dynamic library
+(`.so` or `.dll`) built by a
 {{ "[cmake project]({}/power_grid_model_c/power_grid_model_c/CMakeLists.txt)".format(gh_link_head_blob) }}.
 Please refer to the [Build Guide](./build-guide.md) about how to build the library.
 
-You can refer to the [C API Reference](../api_reference/power-grid-model-c-api-reference.rst)
-for a detailed documentation of the API.
-Please also have a look at an
-{{ "[example]({}/power_grid_model_c_example/main.c)".format(gh_link_head_blob) }}
-of C program to use this C API.
+You can refer to the [C API Reference](../api_reference/power-grid-model-c-api-reference.rst) for a detailed
+documentation of the API.
+Please also have a look at an {{ "[example]({}/power_grid_model_c_example/main.c)".format(gh_link_head_blob) }} of C
+program to use this C API.
 
 In this documentation, the main design choices and concepts of the C API are presented.
 
 ## Finding and linking the package
 
 The package can be loaded using the Config mode of the `find_package` CMake command.
-An
-{{ "[example project]({}/tests/package_tests/CMakeLists.txt)".format(gh_link_head_blob) }} is provided by the
+An {{ "[example project]({}/tests/package_tests/CMakeLists.txt)".format(gh_link_head_blob) }} is provided by the
 {{ "[Git project]({})".format(gh_link_head_tree) }}, which is also used for testing the package.
 
 ```{note}
@@ -51,19 +50,19 @@ Moreover, we might want to also retrieve some meta information from the calculat
 The C API uses a handle opaque object `PGM_Handle` to store all these kinds of error messages and information.
 You need to pass a handle pointer to most of the functions in the C API.
 
-For example, after calling `PGM_create_model`, you can use `PGM_error_code` and `PGM_error_message`
-to check if there is error during the creation and the error message.
+For example, after calling `PGM_create_model`, you can use `PGM_error_code` and `PGM_error_message` to check if there is
+error during the creation and the error message.
 
-If you are calling the C API in multiple threads, each thread should have its own handle object created by `PGM_create_handle`.
+If you are calling the C API in multiple threads, each thread should have its own handle object created by
+`PGM_create_handle`.
 
 ## Calculation options
 
-To execute a power grid calculation you need to specify many options,
-e.g., maximum number of iterations, error tolerance, etc.
+To execute a power grid calculation you need to specify many options, e.g., maximum number of iterations, error
+tolerance, etc.
 We could have declared all the calculation options as individual arguments in the `PGM_calculate` function.
 However, due to the lack of default argument in C,
-this would mean that the C API has a breaking change everytime we add a new option,
-which happends very often.
+this would mean that the C API has a breaking change everytime we add a new option, which happends very often.
 
 To solve this issue, we use another opaque object `PGM_Options`.
 The user creates an object with default options by `PGM_create_options`.
@@ -75,29 +74,35 @@ If we add a new option, it will get a default value in the `PGM_create_options` 
 ## Buffers and attributes
 
 The biggest challenge in the design of the C API is the handling of input/output/update data communication.
-To this end, data is communicated using buffers, which are contiguous blocks of memory that represent data in a given format.
-For compatibility reasons, that format is dictated by the C API using the `PGM_meta_*` functions and `PGM_def_*` dataset definitions.
+To this end, data is communicated using buffers, which are contiguous blocks of memory that represent data in a given
+format.
+For compatibility reasons, that format is dictated by the C API using the `PGM_meta_*` functions and `PGM_def_*` dataset
+definitions.
 
 We define the following concepts in the data hierarchy:
 
 * Dataset: a collection of data buffers for a given purpose.
   At this moment, we have four dataset types: `input`, `update`, `sym_output`, `asym_output`.
-* Component: a data buffer with the representation of all attributes of a physical grid component in our [data model](../user_manual/components.md), e.g., `node`.
+* Component: a data buffer with the representation of all attributes of a physical grid component in our
+  [data model](../user_manual/components.md), e.g., `node`.
 * Attribute: a property of given component.
   For example, `u_rated` attribute of `node` is the rated voltage of the node.
 
-Additionally, at this time, we distinguish two buffer types: [component buffers](#component-buffers) and [attribute buffers](#attribute-buffers).
+Additionally, at this time, we distinguish two buffer types: [component buffers](#component-buffers) and
+[attribute buffers](#attribute-buffers).
 
 ### Component buffers
 
 These buffers represent component data in a row-based format.
 I.e., all attributes of the same component are represented sequentially.
-The individual components are represented in the buffer with a given size and alignment,
-which can be retrieved from the C API via the `PGM_meta_component_size` and `PGM_meta_component_alignment` functions.
-The type (implying the size) and offset of each attribute can be found using the `PGM_meta_attribute_ctype` and `PGM_meta_attribute_offset`.
+The individual components are represented in the buffer with a given size and alignment, which can be retrieved from the
+C API via the `PGM_meta_component_size` and `PGM_meta_component_alignment` functions.
+The type (implying the size) and offset of each attribute can be found using the `PGM_meta_attribute_ctype` and
+`PGM_meta_attribute_offset`.
 
-While we recommend users to create their own buffers using the `PGM_meta_component_size` and `PGM_meta_component_alignment`,
-we do provide functionality to ease the burden (see below), while also providing backwards compatibility by design.
+While we recommend users to create their own buffers using the `PGM_meta_component_size` and
+`PGM_meta_component_alignment`, we do provide functionality to ease the burden (see below), while also providing
+backwards compatibility by design.
 
 #### Component buffer layout example
 
@@ -105,8 +110,8 @@ The following example shows how `line` update data may be represented in the buf
 
 ```{note}
 These values are for illustration purposes only.
-These may not be the actual values retrieved by the `PGM_meta_*` functions,
-and may vary between power grid model versions, compilers, operating systems and architectures.
+These may not be the actual values retrieved by the `PGM_meta_*` functions, and may vary between power grid model
+versions, compilers, operating systems and architectures.
 ```
 
 * an unaligned size of 6 bytes consisting of:
@@ -131,8 +136,8 @@ We provide two ways of doing so.
 
 * You can use the function `PGM_create_buffer` and `PGM_destroy_buffer` to create and destroy buffer.
   In this way, the library is handling the memory (de-)allocation.
-* You can call some memory (de-)allocation function in your own code according to your platform,
-  e.g., `aligned_alloc` and `free`.
+* You can call some memory (de-)allocation function in your own code according to your platform,   e.g., `aligned_alloc`
+  and `free`.
   You need to first call `PGM_meta_*` functions to retrieve the size and alignment of a component.
 
 ```{warning}
@@ -146,12 +151,11 @@ Once you have the data buffer, you need to set or get attributes.
 We provide two ways of doing so.
 
 * You can use the function `PGM_buffer_set_value` and `PGM_buffer_get_value` to get and set values.
-* You can do pointer cast directly on the buffer pointer, by shifting the pointer to proper offset
-  and cast it to a certain value type.
+* You can do pointer cast directly on the buffer pointer, by shifting the pointer to proper offset and cast it to a
+  certain value type.
   You need to first call `PGM_meta_*` functions to retrieve the correct offset.
 
-Pointer cast is generally more efficient and flexible because you are not calling into the
-dynamic library everytime.
+Pointer cast is generally more efficient and flexible because you are not calling into the dynamic library everytime.
 But it requires the user to retrieve the offset information first.
 Using the buffer helper function is more convenient but with some overhead.
 
@@ -160,8 +164,8 @@ Using the buffer helper function is more convenient but with some overhead.
 In the C API we have a function `PGM_buffer_set_nan` which sets all the attributes in a buffer to `NaN`.
 In the calculation core, if an optional attribute is `NaN`, it will use the default value.
 
-If you just want to set some attributes and keep everything else as `NaN`,
-calling `PGM_buffer_set_nan` before you set attribute is convenient.
+If you just want to set some attributes and keep everything else as `NaN`, calling `PGM_buffer_set_nan` before you set
+attribute is convenient.
 This is useful especially in `update` dataset because you do not always update all the mutable attributes.
 
 #### Backwards compatibility
@@ -170,8 +174,8 @@ If you do want to set all the attributes in a component, you can skip the functi
 This will provide better performance as there is no use of setting `NaN`.
 
 However, this is at the cost of backwards compatibility.
-If we add a new optional attribute for this component in the future,
-the new version of the library will not be backwards compatible to your current code.
+If we add a new optional attribute for this component in the future, the new version of the library will not be
+backwards compatible to your current code.
 Because you do not set everything to `NaN` and you only set values to the previously known attributes.
 The newly added attribute will have rubbish value in the memory.
 
@@ -184,19 +188,22 @@ because the buffer will be overwritten in the calculation core with the real out
 
 ### Attribute buffers
 
-An attribute buffer contains data for a single component attribute and represents one column in a columnar representation of component data.
-A combination of attribute buffers with the same amount of elements has the power to carry the same information as row-based [component buffers](#component-buffers).
+An attribute buffer contains data for a single component attribute and represents one column in a columnar
+representation of component data.
+A combination of attribute buffers with the same amount of elements has the power to carry the same information as
+row-based [component buffers](#component-buffers).
 
 The type (implying the size) of each attribute can be found using the `PGM_meta_attribute_ctype`.
 
 Since all attributes consist of primitive types, operations are straightforward.
 We therefore do not provide explicit interface functionality to create an attribute buffer.
-Instead, you should use `PGM_dataset_const_add_buffer` or `PGM_dataset_mutable_add_buffer` with empty data (`NULL`) to set a component buffer for data in columnar-format, and use the functions `PGM_dataset_const_add_attribute_buffer` and `PGM_dataset_mutable_add_attribute_buffer` to add the attribute buffers directly to a dataset.
+Instead, you should use `PGM_dataset_const_add_buffer` or `PGM_dataset_mutable_add_buffer` with empty data (`NULL`) to
+set a component buffer for data in columnar-format, and use the functions `PGM_dataset_const_add_attribute_buffer` and
+`PGM_dataset_mutable_add_attribute_buffer` to add the attribute buffers directly to a dataset.
 
 ## Dataset views
 
-For large datasets that cannot or should not be treated independently,
-`PGM_dataset_*` interfaces are provided.
+For large datasets that cannot or should not be treated independently, `PGM_dataset_*` interfaces are provided.
 Currently implemented are `PGM_dataset_const`, `PGM_dataset_mutable`, and `PGM_dataset_writable`.
 These three dataset types expose a dataset to the power-grid-model with the following permissions on buffers:
 

--- a/docs/advanced_documentation/core-design.md
+++ b/docs/advanced_documentation/core-design.md
@@ -7,8 +7,10 @@ SPDX-License-Identifier: MPL-2.0
 # Design of the Power Grid Model core
 
 The Power Grid Model at its core is a header-only C++ interface library, wrapped by a dynamic/shared C API library.
-The core itself is an engine called the `MainModel` that provides the C++ interface and exhibits logic for the various aspects that play a role in power grid calculations.
-The `MainModel` itself can be deconstructed into an API part, a dispatch part, the grid model and the actual [calculation logic](#calculation-logic-and-data-flow).
+The core itself is an engine called the `MainModel` that provides the C++ interface and exhibits logic for the various
+aspects that play a role in power grid calculations.
+The `MainModel` itself can be deconstructed into an API part, a dispatch part, the grid model and the actual
+[calculation logic](#calculation-logic-and-data-flow).
 
 ## Calculation logic and data flow
 
@@ -24,7 +26,8 @@ Coincidentally, those phases also translate to fields of expertise, which enable
 | Solving                                            | Abstract solution to the system of equations                                                                      | Mathematics            |
 
 ```{note}
-Software Engineering obviously also plays a role in the general design, but that general design does not involve the logic/control flow and therefore is not listed in this table.
+Software Engineering obviously also plays a role in the general design, but that general design does not involve the
+logic/control flow and therefore is not listed in this table.
 ```
 
 The data flow can be visualized as such:
@@ -51,5 +54,7 @@ graph TD
 
 ## Detailed Power Grid Model core design
 
-The sheer size and complexity of the Power Grid Model core implementation makes it hard to generate an up-to-date and comprehensive graph of its design.
-For a full overview of the core, it is recommended to build and access the Power Grid Model core documentation by following the steps in the [build guide](./build-guide.md#documentation).
+The sheer size and complexity of the Power Grid Model core implementation makes it hard to generate an up-to-date and
+comprehensive graph of its design.
+For a full overview of the core, it is recommended to build and access the Power Grid Model core documentation by
+following the steps in the [build guide](./build-guide.md#documentation).

--- a/docs/advanced_documentation/high-level-design.md
+++ b/docs/advanced_documentation/high-level-design.md
@@ -6,16 +6,15 @@ SPDX-License-Identifier: MPL-2.0
 
 # High-level design
 
-The power-grid-model follows a typical dynamic/shared library approach, in which the user
-interface is separated from the core implementation using a strict system boundary.
-Depending
-on the use case and programming language used by the user to call the interface, the user can
-opt to interface with the C API in different ways.
+The power-grid-model follows a typical dynamic/shared library approach, in which the user interface is separated from
+the core implementation using a strict system boundary.
+Depending on the use case and programming language used by the user to call the interface, the user can opt to interface
+with the C API in different ways.
 
 ## Layers of abstraction
 
-For the sake of explanation, we consider the
-following layers of abstraction, in increasing order of ease-of-use and abstraction.
+For the sake of explanation, we consider the following layers of abstraction, in increasing order of ease-of-use and
+abstraction.
 
 * Raw system interface
   * System symbols only
@@ -42,9 +41,8 @@ The following library interfaces are currently included in the power-grid-model.
 | C++ headers    | Experimental | Wrapper            | Handles memory management and basic error handling              | C++                                                 |
 | Python library | Stable       | Feature-rich layer | Library with useful functions, conversions and extensive checks | Python                                              |
 
-Note that the Python library in turn also follows the pattern of a feature-rich library that uses a
-module-internal wrapper layer core module, that wraps the exposition-only core module, that exposes
-the raw interface.
+Note that the Python library in turn also follows the pattern of a feature-rich library that uses a module-internal
+wrapper layer core module, that wraps the exposition-only core module, that exposes the raw interface.
 
 This can be visualized graphically as follows.
 
@@ -98,41 +96,34 @@ flowchart TD
 
 ## Creating a custom library or interface
 
-We seek to provide an optimal user experience, but with the sheer amount of programming languages and
-features, it would be impossible to provide a full feature-rich library for every single one.
-We,
-being a {{ "[community-driven]({}/GOVERNANCE.md)".format(pgm_project_contribution) }} project strongly in
-favor of modern software engineering practices, therefore encourage people to create their own
-libraries and interfaces to improve their own experience.
-There are several possible reasons a user
-may want to create their own library or interface, e.g.:
+We seek to provide an optimal user experience, but with the sheer amount of programming languages and features, it would
+be impossible to provide a full feature-rich library for every single one.
+We, being a {{ "[community-driven]({}/GOVERNANCE.md)".format(pgm_project_contribution) }} project strongly in favor of
+modern software engineering practices, therefore encourage people to create their own libraries and interfaces to
+improve their own experience.
+There are several possible reasons a user may want to create their own library or interface, e.g.:
 
 * Support for a new programming language
 * Extending library support for a specific programming language
 * A custom wrapper that provides extra features or useful commands for specific custom requirements
 
 In all cases, it is recommended that the user determines their own desired
-[layer of abstraction](#layers-of-abstraction) and then creates internal wrappers for all
-lower-level ones, following the same pattern as the power-grid-model
-[uses internally](#existing-library-interfaces) for the custom interfaces.
+[layer of abstraction](#layers-of-abstraction) and then creates internal wrappers for all lower-level ones, following
+the same pattern as the power-grid-model [uses internally](#existing-library-interfaces) for the custom interfaces.
 
 ### Hosting a custom library or interface
 
-The Power Grid Model organization supports people creating and hosting custom libraries and
-interfaces.
+The Power Grid Model organization supports people creating and hosting custom libraries and interfaces.
 If you are doing so and are willing to notify us, please create an item on our
 [discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub.
-The Power Grid
-Model organization will review your item and we may decide to mention your custom library on our
-project website and documentation.
+The Power Grid Model organization will review your item and we may decide to mention your custom library on our project
+website and documentation.
 
 ### Contributing a custom library or interface
 
-When a custom library or interface becomes mature enough and the circumstances allow making it
-publicly available, please consider contributing it to the Power Grid Model organization.
-If you are
-considering contributing your custom library or interface, please read and follow our
-{{ "[contributing guidelines]({}/CONTRIBUTING.md)".format(pgm_project_contribution) }} and open an
-item on our [discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub.
-The
-Power Grid Model organization will review your item and contact you accordingly.
+When a custom library or interface becomes mature enough and the circumstances allow making it publicly available,
+please consider contributing it to the Power Grid Model organization.
+If you are considering contributing your custom library or interface, please read and follow our
+{{ "[contributing guidelines]({}/CONTRIBUTING.md)".format(pgm_project_contribution) }} and open an item on our
+[discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub.
+The Power Grid Model organization will review your item and contact you accordingly.

--- a/docs/advanced_documentation/high-level-design.md
+++ b/docs/advanced_documentation/high-level-design.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: MPL-2.0
 # High-level design
 
 The power-grid-model follows a typical dynamic/shared library approach, in which the user
-interface is separated from the core implementation using a strict system boundary. Depending
+interface is separated from the core implementation using a strict system boundary.
+Depending
 on the use case and programming language used by the user to call the interface, the user can
 opt to interface with the C API in different ways.
 
@@ -98,10 +99,12 @@ flowchart TD
 ## Creating a custom library or interface
 
 We seek to provide an optimal user experience, but with the sheer amount of programming languages and
-features, it would be impossible to provide a full feature-rich library for every single one. We,
+features, it would be impossible to provide a full feature-rich library for every single one.
+We,
 being a {{ "[community-driven]({}/GOVERNANCE.md)".format(pgm_project_contribution) }} project strongly in
 favor of modern software engineering practices, therefore encourage people to create their own
-libraries and interfaces to improve their own experience. There are several possible reasons a user
+libraries and interfaces to improve their own experience.
+There are several possible reasons a user
 may want to create their own library or interface, e.g.:
 
 * Support for a new programming language
@@ -116,16 +119,20 @@ lower-level ones, following the same pattern as the power-grid-model
 ### Hosting a custom library or interface
 
 The Power Grid Model organization supports people creating and hosting custom libraries and
-interfaces. If you are doing so and are willing to notify us, please create an item on our
-[discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub. The Power Grid
+interfaces.
+If you are doing so and are willing to notify us, please create an item on our
+[discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub.
+The Power Grid
 Model organization will review your item and we may decide to mention your custom library on our
 project website and documentation.
 
 ### Contributing a custom library or interface
 
 When a custom library or interface becomes mature enough and the circumstances allow making it
-publicly available, please consider contributing it to the Power Grid Model organization. If you are
+publicly available, please consider contributing it to the Power Grid Model organization.
+If you are
 considering contributing your custom library or interface, please read and follow our
 {{ "[contributing guidelines]({}/CONTRIBUTING.md)".format(pgm_project_contribution) }} and open an
-item on our [discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub. The
+item on our [discussion board](https://github.com/orgs/PowerGridModel/discussions) on GitHub.
+The
 Power Grid Model organization will review your item and contact you accordingly.

--- a/docs/advanced_documentation/native-data-interface.md
+++ b/docs/advanced_documentation/native-data-interface.md
@@ -64,7 +64,9 @@ node['u_rated'] = [150e3, 10e3]
 ## Columnar data format
 
 Additionally, we can represent the contents mentioned `NodeInput` struct in [Structured Array](#structured-array) for only specific attributes.
-This is especially useful when the component in question, e.g., a transformer, has many default attributes. In that case, the user can save significantly on memory usage. Hence, we can term it into `NodeInputURated` which is of `double` type.
+This is especially useful when the component in question, e.g., a transformer, has many default attributes.
+In that case, the user can save significantly on memory usage.
+Hence, we can term it into `NodeInputURated` which is of `double` type.
 (note again, its representation in C++ core might be different than that of `NodeInputURated`).
 
 One can create a `std::vector<NodeInputURated>` to hold input for multiple nodes.
@@ -123,7 +125,8 @@ The basic data types used in the interface between C++ and Python are shown in t
 | `double[3]` | `'(3, )f8'`   | NaN ([IEEE 754](https://en.wikipedia.org/wiki/NaN)) | three-phase asymmetric physical quantities (e.g. voltage)                               |
 
 *The [endianness](https://en.wikipedia.org/wiki/Endianness)
-of C++ and Python side is also matched. For `x86-64` platform the little endian is used, so that
+of C++ and Python side is also matched.
+For `x86-64` platform the little endian is used, so that
 the `numpy.dtype` is `'<i4'` for `int32_t` in C++.*
 
 In the input and update dataset there are some optional attributes.
@@ -192,7 +195,8 @@ and initialize all the values to null value as above.
 So you only have to assign meaningful values into the array.
 See [Python API Reference](../api_reference/python-api-reference.md) for detailed documentation.
 
-In the code below, a line update dataset is created. It sets the `from_status` of all the lines to `1`,
+In the code below, a line update dataset is created.
+It sets the `from_status` of all the lines to `1`,
 but leave the `to_status` unchanged (it will have the null value `-128`).
 
 ```python

--- a/docs/advanced_documentation/native-data-interface.md
+++ b/docs/advanced_documentation/native-data-interface.md
@@ -7,18 +7,18 @@ SPDX-License-Identifier: MPL-2.0
 # Native Data Interface
 
 The calculation core of `power-grid-model` is written in C++.
-To interface with Python side, a format is needed to exchange the input/output data
-between Python and native C++ compiled code.
-This library chooses dictionary of
-[numpy structured arrays](https://numpy.org/doc/stable/user/basics.rec.html) as the data format.
-Each entry in the dictionary represents one type of components:
-the key is the component type, the value is a `numpy` structured array.
+To interface with Python side, a format is needed to exchange the input/output data between Python and native C++
+compiled code.
+This library chooses dictionary of [numpy structured arrays](https://numpy.org/doc/stable/user/basics.rec.html) as the
+data format.
+Each entry in the dictionary represents one type of components: the key is the component type, the value is a `numpy`
+structured array.
 Each element in the array represents one single physical component.
 
 ## Structured Array
 
-To use the component type `node` as an example, the input data of a `node` is defined in C++ as follows
-(not exactly the definition in real code, only a demonstration example).
+To use the component type `node` as an example, the input data of a `node` is defined in C++ as follows (not exactly the
+definition in real code, only a demonstration example).
 A node input data contains two attributes: `id` and `u_rated`.
 
 ```C++
@@ -63,7 +63,8 @@ node['u_rated'] = [150e3, 10e3]
 
 ## Columnar data format
 
-Additionally, we can represent the contents mentioned `NodeInput` struct in [Structured Array](#structured-array) for only specific attributes.
+Additionally, we can represent the contents mentioned `NodeInput` struct in [Structured Array](#structured-array) for
+only specific attributes.
 This is especially useful when the component in question, e.g., a transformer, has many default attributes.
 In that case, the user can save significantly on memory usage.
 Hence, we can term it into `NodeInputURated` which is of `double` type.
@@ -77,9 +78,10 @@ using NodeInputURated = double;
 std::vector<NodeInputURated> node_u_rated_input{ 150.0e3 , 10.0e3 };
 ```
 
-Similar would be the case for `NodeInputId` and `std::vector<NodeNodeInputId>`
+Similar would be the case for `NodeInputId` and `std::vector<NodeNodeInputId>`.
 
-To recreate this in Python using NumPy arrays, we should create it with the correct dtype - as mentioned in [Structured Array](#structured-array) - for each attribute.
+To recreate this in Python using NumPy arrays, we should create it with the correct dtype - as mentioned in
+[Structured Array](#structured-array) - for each attribute.
 
 ```python
 node_id = np.empty(shape=2, dtype=node_dtype["id"])
@@ -91,8 +93,8 @@ node_u_rated['u_rated'] = [150e3, 10e3]
 ## Creating Dataset
 
 We further save this array into a dictionary.
-With other types of components, the dictionary is a valid input dataset for the constructor of `PowerGridModel`,
-see [Python API Reference](../api_reference/python-api-reference.md).
+With other types of components, the dictionary is a valid input dataset for the constructor of `PowerGridModel`, see
+[Python API Reference](../api_reference/python-api-reference.md).
 
 For a row based data format,
 
@@ -124,17 +126,15 @@ The basic data types used in the interface between C++ and Python are shown in t
 | `double`    | `'f8'`        | NaN ([IEEE 754](https://en.wikipedia.org/wiki/NaN)) | physical quantities (e.g. voltage)                                                      |
 | `double[3]` | `'(3, )f8'`   | NaN ([IEEE 754](https://en.wikipedia.org/wiki/NaN)) | three-phase asymmetric physical quantities (e.g. voltage)                               |
 
-*The [endianness](https://en.wikipedia.org/wiki/Endianness)
-of C++ and Python side is also matched.
-For `x86-64` platform the little endian is used, so that
-the `numpy.dtype` is `'<i4'` for `int32_t` in C++.*
+*The [endianness](https://en.wikipedia.org/wiki/Endianness) of C++ and Python side is also matched.
+For `x86-64` platform the little endian is used, so that the `numpy.dtype` is `'<i4'` for `int32_t` in C++.*
 
 In the input and update dataset there are some optional attributes.
 Therefore, for each data type, an entry has to be reserved for null value.
-When the C++ code sees the null value in an attribute,
-it will treat this attribute (of the relevant component) as not available.
-For example, the following update dataset will set `from_status` of the line #5 to `0`,
-and keep the `to_status` as unchanged (change not available).
+When the C++ code sees the null value in an attribute, it will treat this attribute (of the relevant component) as not
+available.
+For example, the following update dataset will set `from_status` of the line #5 to `0`, and keep the `to_status` as
+unchanged (change not available).
 
 ```python
 from power_grid_model import ComponentType, DatasetType, power_grid_meta_data
@@ -150,25 +150,23 @@ line_update['to_status'] = [-128]
 
 ### Enumerations
 
-All the enumeration types are defined as 8-bit signed integer as underlying type:
-`int8_t` in C++ and `'i1'` in Python.
+All the enumeration types are defined as 8-bit signed integer as underlying type: `int8_t` in C++ and `'i1'` in Python.
 The enumerations are defined in the Python module `power_grid_model.enum`.
 In C++ the enumeration is defined with the same integer values.
 Please refer the [Enum](../api_reference/python-api-reference.md#enum) for list of enumerations.
 
 For updateable enums, we choose to always use `-128` as a special NaN value, representing unspecified values.
-In case an explicit option for default behaviour is desired,
-that value shall be different from the NaN value `-128`, e.g. `-1`.
-This prevents conflicts when updating, because providing the default value shall override the existing value,
-while an unspecified value (which is also the initial value when creating a new update data set) does not.
+In case an explicit option for default behaviour is desired, that value shall be different from the NaN value `-128`,
+e.g. `-1`.
+This prevents conflicts when updating, because providing the default value shall override the existing value, while an
+unspecified value (which is also the initial value when creating a new update data set) does not.
 
 ## Meta-data Helper Module
 
-Carefully mapping between the C++ `struct` and `numpy.dtype`
-is needed to have exactly the same memory layout.
+Carefully mapping between the C++ `struct` and `numpy.dtype` is needed to have exactly the same memory layout.
 Fortunately, the user do not have to worry about this.
-The module `power_grid_model.power_grid_meta_data`
-retrieves the exact memory layout of all the input/update/output dataset from C++
+The module `power_grid_model.power_grid_meta_data` retrieves the exact memory layout of all the input/update/output
+dataset from C++
 and predefines all the corresponding `numpy.dtype`.
 The detailed explanation of all attributes of each component is given in
 [Graph Data model](../user_manual/data-model.md#attributes-of-components).
@@ -189,15 +187,14 @@ transformer_tap_pos = np.empty(shape=5, dtype=transformer_dtype["tap_pos"])
 # transformer = np.empty(shape=5, dtype=power_grid_meta_data[DatasetType.input][ComponentType.transformer].dtype)
 ```
 
-Furthermore, there is an even more convenient function `initialize_array`
-to directly create a `numpy` array with specified data type,
-and initialize all the values to null value as above.
+Furthermore, there is an even more convenient function `initialize_array` to directly create a `numpy` array with
+specified data type, and initialize all the values to null value as above.
 So you only have to assign meaningful values into the array.
 See [Python API Reference](../api_reference/python-api-reference.md) for detailed documentation.
 
 In the code below, a line update dataset is created.
-It sets the `from_status` of all the lines to `1`,
-but leave the `to_status` unchanged (it will have the null value `-128`).
+It sets the `from_status` of all the lines to `1`, but leave the `to_status` unchanged (it will have the null value
+`-128`).
 
 ```python
 from power_grid_model import initialize_array

--- a/docs/advanced_documentation/python-wrapper-design.md
+++ b/docs/advanced_documentation/python-wrapper-design.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 
 # Design of the Python Wrapper Package
 
-The structure of the `power_grid_model` Python package is shown here below by means of the corresponding class and package diagrams.
+The structure of the `power_grid_model` Python package is shown here below by means of the corresponding class and
+package diagrams.
 
 ## Class Graph Diagram
 

--- a/docs/algorithms/lu-solver.md
+++ b/docs/algorithms/lu-solver.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 
 # LU Solver
 
-Power system equations can be modeled as matrix equations. A matrix equation solver is therefore
-key to the power grid model.
+Power system equations can be modeled as matrix equations.
+A matrix equation solver is therefore key to the power grid model.
 
 This section documents the need for a custom sparse LU solver and its implementation.
 
@@ -19,64 +19,84 @@ This section documents the need for a custom sparse LU solver and its implementa
 The choice for the matrix equation solver type heavily leans on the need for
 [performance](#performance-considerations), the
 [topological structure](#topological-structure) of the grid, and the
-[properties of the equations](#power-system-equations-properties). They are documented here.
+[properties of the equations](#power-system-equations-properties).
+They are documented here.
 
 ### Performance considerations
 
 There is a large variety of applications of the power grid model that requires high performance.
 This imposes some limitations on the algorithms that can be used.
 
-* Highly accurate and fast calculations are needed for very large grids. This means that direct
+* Highly accurate and fast calculations are needed for very large grids.
+  This means that direct
   methods are strongly preferred, and approximate methods can only be used when there is no other
   alternative, and only if they can be iteratively refined with a fast convergence rate.
-* In applications like time series, repetitive calculations are required. In those cases, separating
+* In applications like time series, repetitive calculations are required.
+  In those cases, separating
   the decomposition (also known as factorization) step of a matrix and the solving step can bring
   major performance benefits, as the decomposition remains the same across the entire set of
   calculations.
 
 ### Topological structure
 
-Distribution grids consist of substations that distribute power in a region. This can be represented
-in a topological way as graphs containing vertices and edges. As a consequence of the locality of
+Distribution grids consist of substations that distribute power in a region.
+This can be represented
+in a topological way as graphs containing vertices and edges.
+As a consequence of the locality of
 Kirchoff's laws, power system equations also take on the same topological structure in block-matrix
 equation form.
 
 #### Sparsity
 
 It is common that a substation is fed by a single upstream substation, i.e., most grids are operated
-in a tree-like structure. Meshed grid operations are relatively rare and are generally restricted
-to small sub-sections of the grid, although exceptions exist. All this gives rise to extremely
+in a tree-like structure.
+Meshed grid operations are relatively rare and are generally restricted
+to small sub-sections of the grid, although exceptions exist.
+All this gives rise to extremely
 sparse topologies and, as a result, extremely
 [sparse matrix equations](https://en.wikipedia.org/wiki/Sparse_matrix) with a
 [block structure](https://en.wikipedia.org/wiki/Block_matrix).
 
 Sparse matrix equations can be solved efficiently: they can be solved in linear time complexity, as
 opposed to the cubic complexity of naive
-[Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination). As a result, a sparse
-matrix solver is key to the performance of the power grid model. QR decomposition therefore is not a
+[Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination).
+As a result, a sparse
+matrix solver is key to the performance of the power grid model.
+QR decomposition therefore is not a
 good candidate.
 
 #### Pivot operations
 
 In matrix solvers, it is very common practice to use the top-left diagonal element as the pivot
-point of all consequitive operations. This allows in-place operations and enhances computational
-performance. This, however, does not guarantee numerical stability. Instead, a different pivot
+point of all consequitive operations.
+This allows in-place operations and enhances computational
+performance.
+This, however, does not guarantee numerical stability.
+Instead, a different pivot
 element (often the matrix element with the largest norm) may be selected and moved to the top-left
-diagonal element by permuting the rows and columns of the matrix. This so-called _pivoting_ enhances
+diagonal element by permuting the rows and columns of the matrix.
+This so-called _pivoting_ enhances
 the numerical stability of consequtive operations.
 
-Pivoting of blocks in sparse matrices is expensive, both time-wise and memory-wise. During the
+Pivoting of blocks in sparse matrices is expensive, both time-wise and memory-wise.
+During the
 process of [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination), the pivoted
 sparse block structure of the matrix equations contains newly-introduced, potentially non-zero
-elements, called _fill-ins_. To this end, a pre-fixed permutation can be chosen to avoid block
+elements, called _fill-ins_.
+To this end, a pre-fixed permutation can be chosen to avoid block
 pivoting at a later stage, at the cost of some numerical stability.
 
 The [topological structure](#topological-structure) of the grid does not change during the
-solving phase. The permutation can be obtained from just topology alone. This is typically done with
+solving phase.
+The permutation can be obtained from just topology alone.
+This is typically done with
 the [minimum degree algorithm](https://en.wikipedia.org/wiki/Minimum_degree_algorithm), which seeks
-to minimize the amount of fill-ins. Note that matrix blocks that contribute topologically to the
-matrix equation can still contain zeros. It is possible that such zeros result in
-[ill-conditioned pivot elements](#pivot-perturbation). Handling of such ill-conditioned cases is
+to minimize the amount of fill-ins.
+Note that matrix blocks that contribute topologically to the
+matrix equation can still contain zeros.
+It is possible that such zeros result in
+[ill-conditioned pivot elements](#pivot-perturbation).
+Handling of such ill-conditioned cases is
 discussed in the [section on pivot perturbation](#pivot-perturbation).
 
 ### Power system equations properties
@@ -85,33 +105,44 @@ discussed in the [section on pivot perturbation](#pivot-perturbation).
 
 The matrices involved in
 [power flow equations](../user_manual/calculations.md#power-flow-algorithms) are not Hermitian,
-nor positive (semi-)definite. As a result, methods that depend on that property cannot be used.
+nor positive (semi-)definite.
+As a result, methods that depend on that property cannot be used.
 
 The matrices involved in
 [state estimation equations](../user_manual/calculations.md#state-estimation-algorithms),
-instead, are, in fact, intrinsically both positive definite and Hermitian. However, for
+instead, are, in fact, intrinsically both positive definite and Hermitian.
+However, for
 [performance reasons](#performance-considerations), the matrix equation is augmented to achieve
-a consistent structure across the entire topology using Lagrange multipliers. This augmented
+a consistent structure across the entire topology using Lagrange multipliers.
+This augmented
 structure causes the matrix to no longer be positive definite (but still Hermitian).
 
 It is in principle possible to use different solvers for power flow equations and state estimation
-equations. The power grid model, however, opts for one single implementation that can handle both
-power flow equations and state estimation equations. This reduces the overall complexity of the code
+equations.
+The power grid model, however, opts for one single implementation that can handle both
+power flow equations and state estimation equations.
+This reduces the overall complexity of the code
 base.
 
 #### Element size properties of power system equations
 
-Power system equations may contain elements of several orders of magnitude. However, many matrix
+Power system equations may contain elements of several orders of magnitude.
+However, many matrix
 solvers are inherently unstable under such extreme conditions, as a reslt of non-linearly propagated
-numerical errors under such ill-conditioned matrices. It is therefore essential that the solvers
+numerical errors under such ill-conditioned matrices.
+It is therefore essential that the solvers
 function under extreme conditions by limiting numerical errors and checking for stability.
 
 ### Block-sparsity considerations
 
 The power flow and state estimation equations involve block-sparse matrices containing typically
-dense blocks. The dimensionality of such blocks varies between different calculation types, methods
-and symmetries. The blocks are typically arranged in extremely sparse fashion. The sparse structure
-can be pre-calculated, but the dense blocks need to be inverted separately. To make matters worse,
+dense blocks.
+The dimensionality of such blocks varies between different calculation types, methods
+and symmetries.
+The blocks are typically arranged in extremely sparse fashion.
+The sparse structure
+can be pre-calculated, but the dense blocks need to be inverted separately.
+To make matters worse,
 the dense blocks may differ heavily in structure and contents between different nodes, and are often
 not solvable without pivoting.
 
@@ -144,13 +175,15 @@ The LU solver implemented in the power grid model consists of 3 components:
 
 The power grid model uses a modified version of the
 [`LUFullPiv` defined in Eigen](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/LU/FullPivLU.h)
-(credits go to the original author). The modification adds opt-in support for
+(credits go to the original author).
+The modification adds opt-in support for
 [pivot perturbation](#pivot-perturbation).
 
 #### Dense LU factorization process
 
 The [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) process is identical
-and iterating over all pivot elements $p$. Let the full matrix be as follows.
+and iterating over all pivot elements $p$.
+Let the full matrix be as follows.
 
 $$
 \mathbf{M} = \begin{bmatrix}
@@ -177,15 +210,18 @@ $$
 \end{bmatrix}
 $$
 
-Here, $\underline{p}$ denotes the fact that it is partially processed. Furthermore,
+Here, $\underline{p}$ denotes the fact that it is partially processed.
+Furthermore,
 $\mathbf{M}_{\underline{p}}$ is the partially processed matrix up to pivot $p$;
 $\mathbf{U}_{\underline{p}}$ and $\mathbf{L}_{\underline{p}}$ are the upper and lower part of the
 matrix up to pivot $p$;
 $\mathbf{M}_p\equiv\begin{bmatrix} m_p && \boldsymbol{r}_p^T \\ \boldsymbol{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
 is the remaining $\left(N-p\right)\times\left(N-p\right)$ part of the matrix that is yet to be
-LU factorized. In addition, $m_p$ is the pivot element value, $\boldsymbol{q}$ and
+LU factorized.
+In addition, $m_p$ is the pivot element value, $\boldsymbol{q}$ and
 $\boldsymbol{r}_p^T$ are the associated column and row vectors containing the rest of the pivot
-column and row; and $\hat{\mathbf{M}}_p$ is the remaining bottom-right block of the matrix. Plugging
+column and row; and $\hat{\mathbf{M}}_p$ is the remaining bottom-right block of the matrix.
+Plugging
 all definitions into the full matrix yields the following.
 
 $$
@@ -218,7 +254,8 @@ $$
 $$
 
 where $\mathbf{1}$ is the matrix with ones on the diagonal and zeros off-diagonal, and
-$\mathbf{M}_{p+1}$ is the start of the next iteration. $\mathbf{L}_p$, $\mathbf{U}_p$,
+$\mathbf{M}_{p+1}$ is the start of the next iteration.
+$\mathbf{L}_p$, $\mathbf{U}_p$,
 $\mathbf{M}_{p+1}$ and $\mathbf{M}_{p}$ are related as follows.
 
 $$
@@ -286,7 +323,8 @@ $$
 in which $\boldsymbol{l}_p$ is the first column of the lower triangle of $\mathbf{L}_p$ and
 $\boldsymbol{u}_p^T$ is the first row of the upper triangle of $\mathbf{U}_p$.
 
-The process described in the above assumes no pivot permutations were necessary. If permutations
+The process described in the above assumes no pivot permutations were necessary.
+If permutations
 are required, they are kept track of in separate row-permution and column-permutation matrices
 $\mathbf{P}$ and $\mathbf{Q}$, such that $\mathbf{P}\mathbf{M}\mathbf{Q} = \mathbf{L}\mathbf{U}$,
 which can be rewritten as
@@ -297,12 +335,14 @@ $$
 
 #### Dense LU factorization algorithm
 
-The power grid model uses an in-place LU decomposition approach. Permutations are separately stored.
+The power grid model uses an in-place LU decomposition approach.
+Permutations are separately stored.
 Below is the algorithm of LU decomposition with pivot perturbation
 ([see below](#pivot-perturbation)) used in the power grid model.
 
 Let $\mathbf{M}$ be the $N\times N$-matrix and
-$\mathbf{M}\left[i,j\right]$ its element at (0-based) indices $(i,j)$, where $i,j = 0..(N-1)$. For
+$\mathbf{M}\left[i,j\right]$ its element at (0-based) indices $(i,j)$, where $i,j = 0..(N-1)$.
+For
 readbility, we use $:$ to denote a range slicing operation to along a dimension of matrix
 $\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
 
@@ -311,7 +351,8 @@ $\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
 3. Loop over all rows: $p = 0..(N-1)$:
    1. Set the remaining matrix: $\mathbf{M}_p \gets \mathbf{M}\left[p:N,p:N\right]$ with size
       $N_p\times N_p$, where $N_p := N - p$.
-   2. Find largest element $\mathbf{M}_p\left[i_p,j_p\right]$ in $\mathbf{M}_p$ by magnitude. This
+   2. Find largest element $\mathbf{M}_p\left[i_p,j_p\right]$ in $\mathbf{M}_p$ by magnitude.
+      This
       is the pivot element.
    3. If the magnitude of the pivot element is too small:
       1. If pivot perturbation is enabled, then:
@@ -336,7 +377,8 @@ $\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
    8. Continue with the next $p$ to factorize the the bottom-right block.
 
 $\mathbf{L}$ is now the matrix containing the lower triangle of $\mathbf{M}$, ones on the diagonal
-and zeros in the upper triangle. Similarly, $\mathbf{U}$ is the matrix containing the upper triangle
+and zeros in the upper triangle.
+Similarly, $\mathbf{U}$ is the matrix containing the upper triangle
 of $\mathbf{M}$ including the diagonal elements and zeros in the lower triangle.
 
 ```{note}
@@ -352,7 +394,8 @@ Permutations are only allowed within each dense block, for the reasons described
 ### Block-sparse LU factorization
 
 The LU factorization process for block-sparse matrices is similar to that for
-[dense matrices](#dense-lu-factorization). Only in this case, $m_p$ refers to a block element.
+[dense matrices](#dense-lu-factorization).
+Only in this case, $m_p$ refers to a block element.
 $\boldsymbol{q}_p$, $\boldsymbol{r}_p^T$ and $\hat{\mathbf{M}}_p$ consist of block elements as well.
 Notice that the block-wise inverse $m_p^{-1}$ can be calculated using its LU decomposition, which
 can be obtained from the [dense LU factorization process](#dense-lu-factorization-process).
@@ -360,20 +403,25 @@ can be obtained from the [dense LU factorization process](#dense-lu-factorizatio
 #### Block-sparse LU factorization process
 
 The block-sparse LU factorization process differs slightly from the
-[dense counterpart](#dense-lu-factorization-process). Below, we first
+[dense counterpart](#dense-lu-factorization-process).
+Below, we first
 [describe the naive approach](#naive-block-sparse-lu-factorization-process), followed by the
 rationale and proof of the alternative approach.
 
 ##### Naive block-sparse LU factorization process
 
-A naïve approach towards block-sparse LU factorization is done as follows. The
+A naïve approach towards block-sparse LU factorization is done as follows.
+The
 [dense LU factorization process](#dense-lu-factorization-process) is followed but on blocks instead
-of single elements. Let
+of single elements.
+Let
 $\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
-be the block-sparse sub-matrix yet to be decomposed. $\mathbf{m}_p$ is a dense block that can be
+be the block-sparse sub-matrix yet to be decomposed.
+$\mathbf{m}_p$ is a dense block that can be
 [LU factorized](#dense-lu-factorization-process):
 $\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$, where
-the lower-case helps avoiding confusion with the block-sparse matrix components. The matrices
+the lower-case helps avoiding confusion with the block-sparse matrix components.
+The matrices
 constructed with [LU decomposition](https://en.wikipedia.org/wiki/LU_decomposition) for
 [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) are constructed
 accordingly.
@@ -390,7 +438,8 @@ Here, $\overrightarrow{\mathbf{m}_p^{-1}\mathbf{q}_p}$ is symbolic notation for 
 solutions to the equation $\mathbf{m}_p x_{p;k} = \mathbf{q}_{p;k}$, where $k = 0..(p-1)$.
 Similarly, $\widehat{\mathbf{m}_p^{-1}\mathbf{q}_p \mathbf{r}_p^T}$ is symbolic notation for the
 block-matrix of solutions to the equation
-$\mathbf{m}_p x_{p;k,l} = \mathbf{q}_{p;k} \mathbf{r}_{p;l}^T$, where $k,l = 0..(p-1)$. That is:
+$\mathbf{m}_p x_{p;k,l} = \mathbf{q}_{p;k} \mathbf{r}_{p;l}^T$, where $k,l = 0..(p-1)$.
+That is:
 
 $$
 \begin{align*}
@@ -411,24 +460,30 @@ Iteratively applying above factorization process yields $\mathbf{L}$ and $\mathb
 $\mathbf{P}$ and $\mathbf{Q}$.
 
 Unfortunately, the process of obtaining $\mathbf{m}_p^{-1} \boldsymbol{x}_p$ can be numerically
-unstable, even if it is split into multiple solving steps. Instead, the process below is used.
+unstable, even if it is split into multiple solving steps.
+Instead, the process below is used.
 
 ##### Partially solved block-sparse LU factorization process
 
 A more numerically stable approach compared to the
 [naïve approach](#naive-block-sparse-lu-factorization-process) is equivalent to single-element
-pivot. Instead of applying the full pivot decomposition in the $L$-matrix and delaying the solve
+pivot.
+Instead of applying the full pivot decomposition in the $L$-matrix and delaying the solve
 process until the final solving phase, we only apply a partial pivoting step to both $L$ matrix and
-the $U$ matrix. This is equivalent to single-element pivoting without block-pivoting. In the
+the $U$ matrix.
+This is equivalent to single-element pivoting without block-pivoting.
+In the
 following sections, we provide the
 [rationale](#rationale-of-the-block-sparse-lu-factorization-process) and
 [proof](#proof-of-block-sparse-lu-factorization-process).
 
 Following the same conventions as [above](#naive-block-sparse-lu-factorization-process), let
 $\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
-be the block-sparse matrix to decompose. $\mathbf{m}_p$ is a dense block that can be
+be the block-sparse matrix to decompose.
+$\mathbf{m}_p$ is a dense block that can be
 [LU factorized](#dense-lu-factorization-process):
-$\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$. Partial Gaussian
+$\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$.
+Partial Gaussian
 elimination constructs the following matrices.
 
 $$
@@ -533,7 +588,8 @@ equations above.
 If, during the LU decomposition of the pivot block, a row- and column-permutation was used,
 $\mathbf{a} = \mathbf{p}_a^{-1} \mathbf{l}_a \mathbf{u}_p \mathbf{q}_a^{-1}$, and the columns of
 $\mathbf{c}$ and the rows of $\mathbf{b}$ are permuted: $\mathbf{c}\mapsto\mathbf{c}\mathbf{q}_a$
-and $\mathbf{b}\mapsto\mathbf{p}_a\mathbf{b}$. In this case, the equations generalize as follows.
+and $\mathbf{b}\mapsto\mathbf{p}_a\mathbf{b}$.
+In this case, the equations generalize as follows.
 
 * $\mathbf{l}_c$ is the solution to the right-multiplication matrix equation
   $\mathbf{l}_c \mathbf{u}_a = \mathbf{c} \mathbf{q}_a$.
@@ -611,8 +667,10 @@ $$
 
 We can see that $\mathbf{l}_c$ and $\mathbf{u}_b$ are affected by the in-block LU decomposition of
 the pivot block $\left(\mathbf{l}_a,\mathbf{u}_a\right)$, as well as the data in the respective
-blocks ($\mathbf{c}$ and $\mathbf{b}$) in the original matrix. Beyond these two sources, no other
-factors affect $\mathbf{l}_c$ and $\mathbf{u}_b$. The generalization to largr block sizes and
+blocks ($\mathbf{c}$ and $\mathbf{b}$) in the original matrix.
+Beyond these two sources, no other
+factors affect $\mathbf{l}_c$ and $\mathbf{u}_b$.
+The generalization to largr block sizes and
 block-matrix sizes follows.
 
 #### Block-sparse indexing
@@ -658,11 +716,14 @@ $$
 
 Because of the sparse structure and the fact that all $\mathbf{M}_{i,j}$ have the same shape, it is
 much more efficient to store the blocks $\mathbf{M}_{i,j}$ in a vector $\mathbf{M}_{\tilde{k}}$
-where $\tilde{k}$ is a reordered index from $(i,j) \mapsto \tilde{k}$. This mapping, in turn, is
+where $\tilde{k}$ is a reordered index from $(i,j) \mapsto \tilde{k}$.
+This mapping, in turn, is
 stored as an index pointer, i.e., a vector of vectors of indices, with the outer index given by the
 row-index $i$, and the inner vector containing the values of $j$ for which $\mathbf{M}_{i,j}$ may be
-non-zero. All topologically relevant matrix elements, as well as [fill-ins](#pivot-operations), are
-included in this mapping. The following illustrates this mapping.
+non-zero.
+All topologically relevant matrix elements, as well as [fill-ins](#pivot-operations), are
+included in this mapping.
+The following illustrates this mapping.
 
 $$
 \begin{align*}
@@ -686,14 +747,19 @@ $$
 $$
 
 In the first equation, the upper row contains the present block entries and the bottom row their
-column indices per row to obtain a flattened representation of the matrix. In the last equivalence,
+column indices per row to obtain a flattened representation of the matrix.
+In the last equivalence,
 the column indices, in turn, are also flattened into a separate flattened representation of the
-column indices and the start indices of each row, i.e., the index pointer (`indptr`). Note that the
-size of `indptr` is 1 greater than the amount of rows. This enables describing the amount of
+column indices and the start indices of each row, i.e., the index pointer (`indptr`).
+Note that the
+size of `indptr` is 1 greater than the amount of rows.
+This enables describing the amount of
 elements in a given row $i$ as the difference between the respective element and the next, i.e.,
 $\text{indptr}[i + 1] - \text{indptr}[i]$.
 
-Looping over the rows and columns becomes trivial. Let $\text{indptr}$ be the start. The double loop
+Looping over the rows and columns becomes trivial.
+Let $\text{indptr}$ be the start.
+The double loop
 becomes:
 
 1. Loop all rows: $i=0..(N-1)$:
@@ -707,15 +773,20 @@ becomes:
 ### Block-sparse LU solving
 
 An equation $\mathbf{M} \boldsymbol{x} = \boldsymbol{b}$ can be solved using
-[LU factorization](#block-sparse-lu-factorization) by forward and backward substitutions. Since the
+[LU factorization](#block-sparse-lu-factorization) by forward and backward substitutions.
+Since the
 blocks of the matrix are already ordered in a way that minimizes the amount of
 [fill-ins](#pivot-operations), it is recommended not to permute across blocks, as that would defeat
-the whole purpose of doing the reordering. Permutations are therefore restricted to intra-block
-operations. The first step of the block-sparse LU solving therefore permutes the rows within each
-block: $\boldsymbol{b}^{\prime} = \mathbf{P}\boldsymbol{b}$. After that, the forward substitution
+the whole purpose of doing the reordering.
+Permutations are therefore restricted to intra-block
+operations.
+The first step of the block-sparse LU solving therefore permutes the rows within each
+block: $\boldsymbol{b}^{\prime} = \mathbf{P}\boldsymbol{b}$.
+After that, the forward substitution
 step essentially amounts to solving the matrix equation
 $\mathbf{L}\boldsymbol{y} = \boldsymbol{b}^{\prime}$, followed by the backwards substitution by
-solving $\mathbf{U}\boldsymbol{z} = \mathbf{y}$. The final result is then obtained by applying the
+solving $\mathbf{U}\boldsymbol{z} = \mathbf{y}$.
+The final result is then obtained by applying the
 column permutation within each block: $\boldsymbol{x} = \mathbf{Q}\boldsymbol{z}$.
 
 #### Forward substitution
@@ -770,29 +841,39 @@ Apply the column permutation as follows.
 
 ```{note}
 If [pivot perturbation](#pivot-perturbation) was used to obtain the LU decomposition, the solution
-obtained here is an approximation to the exact solution. The accuracy can be improved using
+obtained here is an approximation to the exact solution.
+The accuracy can be improved using
 [iterative refinement](#iterative-refinement-of-lu-solver-solutions).
 ```
 
 ### Pivot perturbation
 
-The LU solver implemented in the power grid model features pivot perturbation. We refer readers to
+The LU solver implemented in the power grid model features pivot perturbation.
+We refer readers to
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
 and
 [Schenk06](https://etna.math.kent.edu/volumes/2001-2010/vol23/abstract.php?vol=23&pages=158-179)
-for more details. Here, we briefly present the method used in the power grid model LU solver.
+for more details.
+Here, we briefly present the method used in the power grid model LU solver.
 
 Solving matrix equations with forward and backward substitution requires the selection of a pivot
-element. If the magnitude of a pivot element is too small compared to that of the other elements
+element.
+If the magnitude of a pivot element is too small compared to that of the other elements
 in the matrix, numerical instabilities may be encountered and the pivot element therefore cannot be
-used as is. Another pivot element could potentially be selected by permutation with other matrix
+used as is.
+Another pivot element could potentially be selected by permutation with other matrix
 elements across blocks, but this is not desirable, as described in the section on
-[pivot operations](#pivot-operations). In such cases, the matrix is ill-conditioned.
+[pivot operations](#pivot-operations).
+In such cases, the matrix is ill-conditioned.
 
-Instead, a small perturbation can be added to the pivot element. This renders the matrix equation
-solvable without selecting a different pivot element. The cost of such operation is the introduction
-of numerical errors that are potentially propagating. Iterative refinement can be used to mitigate
-the numerical errors. This method is also used by
+Instead, a small perturbation can be added to the pivot element.
+This renders the matrix equation
+solvable without selecting a different pivot element.
+The cost of such operation is the introduction
+of numerical errors that are potentially propagating.
+Iterative refinement can be used to mitigate
+the numerical errors.
+This method is also used by
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
 and
 [Schenk06](https://etna.math.kent.edu/volumes/2001-2010/vol23/abstract.php?vol=23&pages=158-179),
@@ -816,7 +897,8 @@ matrix.
    3. $\text{pivot_element} \gets \epsilon * \text{phase_shift}$.
 
 $\text{phase_shift}$ ensures that the sign (if $\mathbf{M}$ is a real matrix) or complex phase (if
-$\mathbf{M}$ is a complex matrix) of the pivot element is preserved. The positive real axis is used
+$\mathbf{M}$ is a complex matrix) of the pivot element is preserved.
+The positive real axis is used
 as a fallback when the pivot element is identically zero.
 
 ### Iterative refinement of LU solver solutions
@@ -826,20 +908,26 @@ in [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-
 
 [LU solving](#block-sparse-lu-solving) with an [LU decomposition](#block-sparse-lu-factorization)
 obtained using [pivot perturbation](#pivot-perturbation) yields only approximate results, because
-the LU decomposition itself is only approximate. Because of that, an iterative refinement process
+the LU decomposition itself is only approximate.
+Because of that, an iterative refinement process
 is required to improve the solution to the matrix equation
 $\mathbf{M} \cdot \boldsymbol{x} = \boldsymbol{b}$.
 
-The iterative refinement process works as follows. In step $i$, given an approximation
+The iterative refinement process works as follows.
+In step $i$, given an approximation
 $\boldsymbol{x}_i$ for $\boldsymbol{x}$, the difference between the current best and the exact
-solution is defined as $\boldsymbol{\Delta x} := \boldsymbol{x} - \boldsymbol{x}_i$. Substituting
+solution is defined as $\boldsymbol{\Delta x} := \boldsymbol{x} - \boldsymbol{x}_i$.
+Substituting
 in the original equation yields
 $\mathbf{M} \cdot (\boldsymbol{x}_i + \boldsymbol{\Delta x}) = \boldsymbol{b}$, so that
 $\mathbf{M} \cdot \boldsymbol{\Delta x} = \boldsymbol{b} - \mathbf{M} \cdot \boldsymbol{x}_i =: \boldsymbol{r}$.
-The residual $\boldsymbol{r}$ can be calculated. An estimation for the left-hand side can be
+The residual $\boldsymbol{r}$ can be calculated.
+An estimation for the left-hand side can be
 obtained by using the pivot-perturbed matrix $\tilde{\mathbf{M}}$ instead of the original matrix
-$\mathbf{M}$. Convergence is reached when $\boldsymbol{r} \to \boldsymbol{0}$, which implies
-$\left\|\boldsymbol{\Delta x}\right\| \to 0$. Solving for $\boldsymbol{\Delta x}$ and substituting
+$\mathbf{M}$.
+Convergence is reached when $\boldsymbol{r} \to \boldsymbol{0}$, which implies
+$\left\|\boldsymbol{\Delta x}\right\| \to 0$.
+Solving for $\boldsymbol{\Delta x}$ and substituting
 back into $\boldsymbol{x}_{i+1} = \boldsymbol{x}_i + \boldsymbol{\Delta x}$ provides the next best
 approximation $\boldsymbol{x}_{i+1}$ for $\boldsymbol{x}$.
 
@@ -847,7 +935,8 @@ A measure for the quality of the approximation is given by the $\text{backward_e
 [backward error formula](#backward-error-calculation)).
 
 Since the matrix $\mathbf{M}$ remains static during this process, the LU decomposition is valid
-throughout the process. The accuracy of the result can therefore be iteratively refined efficiently.
+throughout the process.
+The accuracy of the result can therefore be iteratively refined efficiently.
 
 Given the original matrix equation $\mathbf{M} \cdot \boldsymbol{x} = \boldsymbol{b}$ to solve, the
 pivot perturbated matrix $\tilde{\mathbf{M}}$ with a pre-calculated LU decomposition, and the
@@ -882,17 +971,21 @@ As a result, we effectively always do:
 2. At least one refinement step.
 
 When the maximum allowed amount of iterations is exceeded, a sparse matrix error instead of an
-iteration diverge error is raised. The reason is, that it is specifically the iterative refinement
+iteration diverge error is raised.
+The reason is, that it is specifically the iterative refinement
 of the matrix equation solution that cannot be solved in the set amount of iterations - not the set
-of power system equations. This will only happen when the matrix equation requires iterative
+of power system equations.
+This will only happen when the matrix equation requires iterative
 refinement in the first place, which happens only when pivot perturbation is needed, namely in the
-case of an ill-conditioned matrix equation. A matrix equation that is both ill-conditioned and not
+case of an ill-conditioned matrix equation.
+A matrix equation that is both ill-conditioned and not
 iteratively refinable is underdetermined and cannot be solved.
 
 #### Backward error calculation
 
 The [iterative refinement algorithm](#iterative-refinement-of-lu-solver-solutions) uses a backward
-error as a convergence criterion. We use the following backward error calculation, inspired by
+error as a convergence criterion.
+We use the following backward error calculation, inspired by
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761),
 with a few modifications described [below](#improved-backward-error-calculation).
 
@@ -932,7 +1025,8 @@ They are summarized below.
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
 contains an early-out criterion for the
 [iterative refinement](#iterative-refinement-of-lu-solver-solutions) that checks for diminishing
-backward error in consecutive iterations. It amounts to (in reverse order):
+backward error in consecutive iterations.
+It amounts to (in reverse order):
 
 1. If $\text{backward_error} \gt \frac{1}{2}\text{last_backward_error}$, then:
    1. Stop iterative refinement.
@@ -941,10 +1035,14 @@ backward error in consecutive iterations. It amounts to (in reverse order):
 
 In power systems, however, the fact that the matrix may contain elements
 [spanning several orders of magnitude](#element-size-properties-of-power-system-equations) may cause
-slow convergence far away from the optimum. The diminishing criterion would cause the algorithm to
-terminate before the actual solution is found. Multiple refinement iterations may still yield better
-results. The power grid model therefore does not terminate early when encountering diminishing
-backward errors. Instead, a maximum amount of iterations is used in combination with the error
+slow convergence far away from the optimum.
+The diminishing criterion would cause the algorithm to
+terminate before the actual solution is found.
+Multiple refinement iterations may still yield better
+results.
+The power grid model therefore does not terminate early when encountering diminishing
+backward errors.
+Instead, a maximum amount of iterations is used in combination with the error
 tolerance.
 
 #### Improved backward error calculation
@@ -952,8 +1050,10 @@ tolerance.
 In power system equations, the matrix $\mathbf{M}$ in equation
 $\mathbf{M} \boldsymbol{x} = \boldsymbol{b}$ can contain very discrepant entries: some may be very
 large while others are zero or very small (see also the
-[documentation on calculations](../user_manual/calculations.md)). The same may be true for the
-right-hand side of the equation $\boldsymbol{b}$, as well as its solution $\boldsymbol{x}$. In fact,
+[documentation on calculations](../user_manual/calculations.md)).
+The same may be true for the
+right-hand side of the equation $\boldsymbol{b}$, as well as its solution $\boldsymbol{x}$.
+In fact,
 there may be certain rows $i$ for which both $\left|\boldsymbol{b}\left[i\right]\right|$ and
 $\sum_j \left|\mathbf{M}\left[i,j\right]\right| \left|\boldsymbol{x}\left[j\right]\right|$ are small
 and, therefore, their sum is prone to rounding errors, which may be several orders larger than
@@ -978,7 +1078,8 @@ $\left|\boldsymbol{x}\right|_i := \left|\boldsymbol{x}_i\right|$, as
 defined in [Arioli89](https://epubs.siam.org/doi/10.1137/0610013).
 
 Due to the aforementioned, this is prone to rounding errors, and a single row with rounding errors
-may cause the entire iterative refinement to fail. The power grid model therefore uses a modified
+may cause the entire iterative refinement to fail.
+The power grid model therefore uses a modified
 version, in which the denominator is capped to a minimum value, determined by the maximum across all
 denominators:
 
@@ -996,20 +1097,26 @@ D_{\text{max}} &= \max_i\left\{\left(\left|\mathbf{M}\right|\cdot\left|\boldsymb
 \end{align*}
 $$
 
-$\epsilon$ may be chosen. $\epsilon = 0$ means no cut-off, while $\epsilon = 1$ means that only the
-absolute values of the residuals are relevant - not the relative values. The former is prone to
-rounding errors. The latter may hide issues in rows with small coefficients by supressing them
-in the backward error. This would favor rows with larger absolute, but smaller relative residuals.
+$\epsilon$ may be chosen.
+$\epsilon = 0$ means no cut-off, while $\epsilon = 1$ means that only the
+absolute values of the residuals are relevant - not the relative values.
+The former is prone to
+rounding errors.
+The latter may hide issues in rows with small coefficients by supressing them
+in the backward error.
+This would favor rows with larger absolute, but smaller relative residuals.
 This can be the case, even if that row's residual is relatively large compared to the other entries.
 In conclusion, $\epsilon$ should be chosen small, but large enough to suppress numerical
-instabilities. A choice for $\epsilon$ that is experimentally verified to be reasonable is mentioned
+instabilities.
+A choice for $\epsilon$ that is experimentally verified to be reasonable is mentioned
 [above](#backward-error-calculation).
 
 #### Block-wise off-diagonal infinite matrix norm
 
 For the [pivot perturbation algorithm](#pivot-perturbation-algorithm), a matrix norm is used to
 determine the relative size of the current pivot element compared to the rest of the matrix as a
-measure for the degree of ill-conditioning. The norm is a variant of the $L_{\infty}$ norm of a
+measure for the degree of ill-conditioning.
+The norm is a variant of the $L_{\infty}$ norm of a
 matrix, which we call the block-wise off-diagonal infinite matrix norm
 ($L_{\infty ,\text{bwod}}$).
 
@@ -1018,8 +1125,10 @@ intra-block, block-sparse for the full topological structure of the grid), the n
 those same levels, so the calculation of the norm is _block-wise_.
 
 In addition, the diagonal blocks may have much larger elements than the off-diagonal ones, while the
-relevant information is contained mostly in the off-diagonal blocks. As a result, the block-diagonal
-blocks would undesirably dominate the norm. The power grid model therefore restricts the calculation
+relevant information is contained mostly in the off-diagonal blocks.
+As a result, the block-diagonal
+blocks would undesirably dominate the norm.
+The power grid model therefore restricts the calculation
 of the norm to _off-diagonal_ blocks.
 
 In short, the $L_{\infty ,\text{bwod}}$-norm it is the $L_{\infty}$ norm of the block-sparse matrix
@@ -1032,7 +1141,8 @@ The algorithm is as follows:
 
 Let $\mathbf{M}\equiv \mathbf{M}\left[0:N, 0:N\right]$ be the $N\times N$-matrix with a block-sparse
 structure and $\mathbf{M}\left[i,j\right]$ its block element at (0-based) indices $(i,j)$, where
-$i,j = 0..(N-1)$. In turn, let
+$i,j = 0..(N-1)$.
+In turn, let
 $\mathbf{M}\left[i,j\right] \equiv \mathbf{M}_{i,j}\left[0:N_{i,j},0:N_{i,j}\right]$ be the dense
 block with dimensions $N_i\times N_j$.
 

--- a/docs/algorithms/lu-solver.md
+++ b/docs/algorithms/lu-solver.md
@@ -16,9 +16,8 @@ This section documents the need for a custom sparse LU solver and its implementa
 
 ## Background
 
-The choice for the matrix equation solver type heavily leans on the need for
-[performance](#performance-considerations), the
-[topological structure](#topological-structure) of the grid, and the
+The choice for the matrix equation solver type heavily leans on the need for [performance](#performance-considerations),
+the [topological structure](#topological-structure) of the grid, and the
 [properties of the equations](#power-system-equations-properties).
 They are documented here.
 
@@ -28,123 +27,93 @@ There is a large variety of applications of the power grid model that requires h
 This imposes some limitations on the algorithms that can be used.
 
 * Highly accurate and fast calculations are needed for very large grids.
-  This means that direct
-  methods are strongly preferred, and approximate methods can only be used when there is no other
+  This means that direct methods are strongly preferred, and approximate methods can only be used when there is no other
   alternative, and only if they can be iteratively refined with a fast convergence rate.
 * In applications like time series, repetitive calculations are required.
-  In those cases, separating
-  the decomposition (also known as factorization) step of a matrix and the solving step can bring
-  major performance benefits, as the decomposition remains the same across the entire set of
-  calculations.
+  In those cases, separating the decomposition (also known as factorization) step of a matrix and the solving step can
+  bring major performance benefits, as the decomposition remains the same across the entire set of calculations.
 
 ### Topological structure
 
 Distribution grids consist of substations that distribute power in a region.
-This can be represented
-in a topological way as graphs containing vertices and edges.
-As a consequence of the locality of
-Kirchoff's laws, power system equations also take on the same topological structure in block-matrix
-equation form.
+This can be represented in a topological way as graphs containing vertices and edges.
+As a consequence of the locality of Kirchoff's laws, power system equations also take on the same topological structure
+in block-matrix equation form.
 
 #### Sparsity
 
-It is common that a substation is fed by a single upstream substation, i.e., most grids are operated
-in a tree-like structure.
-Meshed grid operations are relatively rare and are generally restricted
-to small sub-sections of the grid, although exceptions exist.
-All this gives rise to extremely
-sparse topologies and, as a result, extremely
+It is common that a substation is fed by a single upstream substation, i.e., most grids are operated in a tree-like
+structure.
+Meshed grid operations are relatively rare and are generally restricted to small sub-sections of the grid, although
+exceptions exist.
+All this gives rise to extremely sparse topologies and, as a result, extremely
 [sparse matrix equations](https://en.wikipedia.org/wiki/Sparse_matrix) with a
 [block structure](https://en.wikipedia.org/wiki/Block_matrix).
 
-Sparse matrix equations can be solved efficiently: they can be solved in linear time complexity, as
-opposed to the cubic complexity of naive
-[Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination).
-As a result, a sparse
-matrix solver is key to the performance of the power grid model.
-QR decomposition therefore is not a
-good candidate.
+Sparse matrix equations can be solved efficiently: they can be solved in linear time complexity, as opposed to the cubic
+complexity of naive [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination).
+As a result, a sparse matrix solver is key to the performance of the power grid model.
+QR decomposition therefore is not a good candidate.
 
 #### Pivot operations
 
-In matrix solvers, it is very common practice to use the top-left diagonal element as the pivot
-point of all consequitive operations.
-This allows in-place operations and enhances computational
-performance.
+In matrix solvers, it is very common practice to use the top-left diagonal element as the pivot point of all
+consequitive operations.
+This allows in-place operations and enhances computational performance.
 This, however, does not guarantee numerical stability.
-Instead, a different pivot
-element (often the matrix element with the largest norm) may be selected and moved to the top-left
-diagonal element by permuting the rows and columns of the matrix.
-This so-called _pivoting_ enhances
-the numerical stability of consequtive operations.
+Instead, a different pivot element (often the matrix element with the largest norm) may be selected and moved to the
+top-left diagonal element by permuting the rows and columns of the matrix.
+This so-called _pivoting_ enhances the numerical stability of consequtive operations.
 
 Pivoting of blocks in sparse matrices is expensive, both time-wise and memory-wise.
-During the
-process of [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination), the pivoted
-sparse block structure of the matrix equations contains newly-introduced, potentially non-zero
-elements, called _fill-ins_.
-To this end, a pre-fixed permutation can be chosen to avoid block
-pivoting at a later stage, at the cost of some numerical stability.
+During the process of [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination), the pivoted sparse
+block structure of the matrix equations contains newly-introduced, potentially non-zero elements, called _fill-ins_.
+To this end, a pre-fixed permutation can be chosen to avoid block pivoting at a later stage, at the cost of some
+numerical stability.
 
-The [topological structure](#topological-structure) of the grid does not change during the
-solving phase.
+The [topological structure](#topological-structure) of the grid does not change during the solving phase.
 The permutation can be obtained from just topology alone.
-This is typically done with
-the [minimum degree algorithm](https://en.wikipedia.org/wiki/Minimum_degree_algorithm), which seeks
-to minimize the amount of fill-ins.
-Note that matrix blocks that contribute topologically to the
-matrix equation can still contain zeros.
-It is possible that such zeros result in
-[ill-conditioned pivot elements](#pivot-perturbation).
-Handling of such ill-conditioned cases is
-discussed in the [section on pivot perturbation](#pivot-perturbation).
+This is typically done with the [minimum degree algorithm](https://en.wikipedia.org/wiki/Minimum_degree_algorithm),
+which seeks to minimize the amount of fill-ins.
+Note that matrix blocks that contribute topologically to the matrix equation can still contain zeros.
+It is possible that such zeros result in [ill-conditioned pivot elements](#pivot-perturbation).
+Handling of such ill-conditioned cases is discussed in the [section on pivot perturbation](#pivot-perturbation).
 
 ### Power system equations properties
 
 #### Matrix properties of power system equations
 
-The matrices involved in
-[power flow equations](../user_manual/calculations.md#power-flow-algorithms) are not Hermitian,
+The matrices involved in [power flow equations](../user_manual/calculations.md#power-flow-algorithms) are not Hermitian,
 nor positive (semi-)definite.
 As a result, methods that depend on that property cannot be used.
 
-The matrices involved in
-[state estimation equations](../user_manual/calculations.md#state-estimation-algorithms),
+The matrices involved in [state estimation equations](../user_manual/calculations.md#state-estimation-algorithms),
 instead, are, in fact, intrinsically both positive definite and Hermitian.
-However, for
-[performance reasons](#performance-considerations), the matrix equation is augmented to achieve
-a consistent structure across the entire topology using Lagrange multipliers.
-This augmented
-structure causes the matrix to no longer be positive definite (but still Hermitian).
+However, for [performance reasons](#performance-considerations), the matrix equation is augmented to achieve a
+consistent structure across the entire topology using Lagrange multipliers.
+This augmented structure causes the matrix to no longer be positive definite (but still Hermitian).
 
-It is in principle possible to use different solvers for power flow equations and state estimation
-equations.
-The power grid model, however, opts for one single implementation that can handle both
-power flow equations and state estimation equations.
-This reduces the overall complexity of the code
-base.
+It is in principle possible to use different solvers for power flow equations and state estimation equations.
+The power grid model, however, opts for one single implementation that can handle both power flow equations and state
+estimation equations.
+This reduces the overall complexity of the code base.
 
 #### Element size properties of power system equations
 
 Power system equations may contain elements of several orders of magnitude.
-However, many matrix
-solvers are inherently unstable under such extreme conditions, as a reslt of non-linearly propagated
-numerical errors under such ill-conditioned matrices.
-It is therefore essential that the solvers
-function under extreme conditions by limiting numerical errors and checking for stability.
+However, many matrix solvers are inherently unstable under such extreme conditions, as a reslt of non-linearly
+propagated numerical errors under such ill-conditioned matrices.
+It is therefore essential that the solvers function under extreme conditions by limiting numerical errors and checking
+for stability.
 
 ### Block-sparsity considerations
 
-The power flow and state estimation equations involve block-sparse matrices containing typically
-dense blocks.
-The dimensionality of such blocks varies between different calculation types, methods
-and symmetries.
+The power flow and state estimation equations involve block-sparse matrices containing typically dense blocks.
+The dimensionality of such blocks varies between different calculation types, methods and symmetries.
 The blocks are typically arranged in extremely sparse fashion.
-The sparse structure
-can be pre-calculated, but the dense blocks need to be inverted separately.
-To make matters worse,
-the dense blocks may differ heavily in structure and contents between different nodes, and are often
-not solvable without pivoting.
+The sparse structure can be pre-calculated, but the dense blocks need to be inverted separately.
+To make matters worse, the dense blocks may differ heavily in structure and contents between different nodes, and are
+often not solvable without pivoting.
 
 ### Custom sparse LU solver
 
@@ -152,15 +121,14 @@ The choice for a custom LU solver implementation comes from a number of consider
 
 * [LU decomposition](https://en.wikipedia.org/wiki/LU_decomposition) is the best choice, because
   [QR decomposition](https://en.wikipedia.org/wiki/QR_decomposition) and
-  [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) cannot solve the
-  power system equations efficiently as a consequence of the
-  [power system equations' properties](#power-system-equations-properties),
-  as the QR decomposition is not as efficient when dealing with sparse matrices, while the latter
-  requires Hermitian and/or semi-definite (in generalized form).
-* Alternative LU solver implementations are optimized for a variety of use cases that are less
-  sparse than the ones encountered in power systems.
-* The power grid model requires a faster and more dedicated block-sparse matrix equation solver than
-  what alternative LU solver implementations provide.
+  [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) cannot solve the power system equations
+  efficiently as a consequence of the [power system equations' properties](#power-system-equations-properties), as the
+  QR decomposition is not as efficient when dealing with sparse matrices, while the latter requires Hermitian and/or
+  semi-definite (in generalized form).
+* Alternative LU solver implementations are optimized for a variety of use cases that are less sparse than the ones
+  encountered in power systems.
+* The power grid model requires a faster and more dedicated block-sparse matrix equation solver than what alternative LU
+  solver implementations provide.
 
 ## Implementation
 
@@ -176,13 +144,12 @@ The LU solver implemented in the power grid model consists of 3 components:
 The power grid model uses a modified version of the
 [`LUFullPiv` defined in Eigen](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/LU/FullPivLU.h)
 (credits go to the original author).
-The modification adds opt-in support for
-[pivot perturbation](#pivot-perturbation).
+The modification adds opt-in support for [pivot perturbation](#pivot-perturbation).
 
 #### Dense LU factorization process
 
-The [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) process is identical
-and iterating over all pivot elements $p$.
+The [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) process is identical and iterating over
+all pivot elements $p$.
 Let the full matrix be as follows.
 
 $$
@@ -194,8 +161,7 @@ m_{N-1,0} && m_{N-1,1} && \cdots && m_{N-1,N-1}
 \end{bmatrix}
 $$
 
-While processing current pivot element $p$, the partially processed matrix has the following
-arrangement.
+While processing current pivot element $p$, the partially processed matrix has the following arrangement.
 
 $$
 \mathbf{M}_{\underline{p}}\equiv\begin{bmatrix}
@@ -211,18 +177,15 @@ $$
 $$
 
 Here, $\underline{p}$ denotes the fact that it is partially processed.
-Furthermore,
-$\mathbf{M}_{\underline{p}}$ is the partially processed matrix up to pivot $p$;
-$\mathbf{U}_{\underline{p}}$ and $\mathbf{L}_{\underline{p}}$ are the upper and lower part of the
-matrix up to pivot $p$;
+Furthermore, $\mathbf{M}_{\underline{p}}$ is the partially processed matrix up to pivot $p$;
+$\mathbf{U}_{\underline{p}}$ and $\mathbf{L}_{\underline{p}}$ are the upper and lower part of the matrix up to pivot
+$p$;
 $\mathbf{M}_p\equiv\begin{bmatrix} m_p && \boldsymbol{r}_p^T \\ \boldsymbol{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
-is the remaining $\left(N-p\right)\times\left(N-p\right)$ part of the matrix that is yet to be
-LU factorized.
-In addition, $m_p$ is the pivot element value, $\boldsymbol{q}$ and
-$\boldsymbol{r}_p^T$ are the associated column and row vectors containing the rest of the pivot
-column and row; and $\hat{\mathbf{M}}_p$ is the remaining bottom-right block of the matrix.
-Plugging
-all definitions into the full matrix yields the following.
+is the remaining $\left(N-p\right)\times\left(N-p\right)$ part of the matrix that is yet to be LU factorized.
+In addition, $m_p$ is the pivot element value, $\boldsymbol{q}$ and $\boldsymbol{r}_p^T$ are the associated column and
+row vectors containing the rest of the pivot column and row; and $\hat{\mathbf{M}}_p$ is the remaining bottom-right
+block of the matrix.
+Plugging all definitions into the full matrix yields the following.
 
 $$
 \begin{bmatrix}
@@ -238,9 +201,8 @@ $$
     && && && \boldsymbol{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}
 $$
 
-In this equation, $\boldsymbol{l}_k$ and $\boldsymbol{u}_k$ are column and row vectors,
-respectively; $m_k$, $\boldsymbol{l}_k$ and $\boldsymbol{u}_k$ ($k < p$) denote sections of the
-matrix that have already been processed.
+In this equation, $\boldsymbol{l}_k$ and $\boldsymbol{u}_k$ are column and row vectors, respectively; $m_k$,
+$\boldsymbol{l}_k$ and $\boldsymbol{u}_k$ ($k < p$) denote sections of the matrix that have already been processed.
 
 [Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) using
 [LU decomposition](https://en.wikipedia.org/wiki/LU_decomposition) constructs the matrices
@@ -253,10 +215,9 @@ $$
 \end{align*}
 $$
 
-where $\mathbf{1}$ is the matrix with ones on the diagonal and zeros off-diagonal, and
-$\mathbf{M}_{p+1}$ is the start of the next iteration.
-$\mathbf{L}_p$, $\mathbf{U}_p$,
-$\mathbf{M}_{p+1}$ and $\mathbf{M}_{p}$ are related as follows.
+where $\mathbf{1}$ is the matrix with ones on the diagonal and zeros off-diagonal, and $\mathbf{M}_{p+1}$ is the start
+of the next iteration.
+$\mathbf{L}_p$, $\mathbf{U}_p$, $\mathbf{M}_{p+1}$ and $\mathbf{M}_{p}$ are related as follows.
 
 $$
 \mathbf{M}_p \equiv
@@ -286,10 +247,9 @@ $$
 \end{bmatrix}\mathbf{U}_{p-1}
 $$
 
-Here, $\mathbf{L}_{p-1}$ and $\mathbf{U}_{p-1}$ have dimensions
-$\left(N-p+1\right)\times \left(N-p+1\right)$, $\mathbf{L}_p$ and $\mathbf{U}_p$ have dimensions
-$\left(N-p\right) \times \left(N-p\right)$, and $\mathbf{M}_{p+1}$ has dimensions
-$\left(N-p-1\right) \times \left(N-p-1\right)$.
+Here, $\mathbf{L}_{p-1}$ and $\mathbf{U}_{p-1}$ have dimensions $\left(N-p+1\right)\times \left(N-p+1\right)$,
+$\mathbf{L}_p$ and $\mathbf{U}_p$ have dimensions $\left(N-p\right) \times \left(N-p\right)$, and $\mathbf{M}_{p+1}$ has
+dimensions $\left(N-p-1\right) \times \left(N-p-1\right)$.
 
 Iterating this process yields the matrices
 
@@ -320,14 +280,13 @@ m_0 && \left(\boldsymbol{r}_0^T\right)_0 && \cdots && \left(\boldsymbol{r}_0^T\r
 \end{align*}
 $$
 
-in which $\boldsymbol{l}_p$ is the first column of the lower triangle of $\mathbf{L}_p$ and
-$\boldsymbol{u}_p^T$ is the first row of the upper triangle of $\mathbf{U}_p$.
+in which $\boldsymbol{l}_p$ is the first column of the lower triangle of $\mathbf{L}_p$ and $\boldsymbol{u}_p^T$ is the
+first row of the upper triangle of $\mathbf{U}_p$.
 
 The process described in the above assumes no pivot permutations were necessary.
-If permutations
-are required, they are kept track of in separate row-permution and column-permutation matrices
-$\mathbf{P}$ and $\mathbf{Q}$, such that $\mathbf{P}\mathbf{M}\mathbf{Q} = \mathbf{L}\mathbf{U}$,
-which can be rewritten as
+If permutations are required, they are kept track of in separate row-permution and column-permutation matrices
+$\mathbf{P}$ and $\mathbf{Q}$, such that $\mathbf{P}\mathbf{M}\mathbf{Q} = \mathbf{L}\mathbf{U}$, which can be rewritten
+as
 
 $$
 \mathbf{M} = \mathbf{P}^{-1}\mathbf{L}\mathbf{U}\mathbf{Q}^{-1}
@@ -337,23 +296,21 @@ $$
 
 The power grid model uses an in-place LU decomposition approach.
 Permutations are separately stored.
-Below is the algorithm of LU decomposition with pivot perturbation
-([see below](#pivot-perturbation)) used in the power grid model.
+Below is the algorithm of LU decomposition with pivot perturbation ([see below](#pivot-perturbation)) used in the power
+grid model.
 
-Let $\mathbf{M}$ be the $N\times N$-matrix and
-$\mathbf{M}\left[i,j\right]$ its element at (0-based) indices $(i,j)$, where $i,j = 0..(N-1)$.
-For
-readbility, we use $:$ to denote a range slicing operation to along a dimension of matrix
-$\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
+Let $\mathbf{M}$ be the $N\times N$-matrix and $\mathbf{M}\left[i,j\right]$ its element at (0-based) indices $(i,j)$,
+where $i,j = 0..(N-1)$.
+For readbility, we use $:$ to denote a range slicing operation to along a dimension of matrix $\mathbf{M}$, e.g.
+$\mathbf{M}\left[0:3, j\right]$.
 
 1. Initialize the permutations $\mathbf{P}$ and $\mathbf{Q}$ to the identity permutation.
 2. Initialize fill-in elements to $0$.
 3. Loop over all rows: $p = 0..(N-1)$:
-   1. Set the remaining matrix: $\mathbf{M}_p \gets \mathbf{M}\left[p:N,p:N\right]$ with size
-      $N_p\times N_p$, where $N_p := N - p$.
+   1. Set the remaining matrix: $\mathbf{M}_p \gets \mathbf{M}\left[p:N,p:N\right]$ with size $N_p\times N_p$, where
+      $N_p := N - p$.
    2. Find largest element $\mathbf{M}_p\left[i_p,j_p\right]$ in $\mathbf{M}_p$ by magnitude.
-      This
-      is the pivot element.
+      This is the pivot element.
    3. If the magnitude of the pivot element is too small:
       1. If pivot perturbation is enabled, then:
          1. Apply [pivot perturbation](#pivot-perturbation).
@@ -364,8 +321,8 @@ $\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
          1. Proceed.
    4. Else:
       1. Proceed.
-   5. Swap the first and pivot row and column of $\mathbf{M}_p$, so that the pivot element is in the
-      top-left corner of the remaining matrix:
+   5. Swap the first and pivot row and column of $\mathbf{M}_p$, so that the pivot element is in the top-left corner of
+      the remaining matrix:
       1. $\mathbf{M}_p\left[0,0:N_p\right] \leftrightarrow \mathbf{M}\left[i_p,0:N_p\right]$
       2. $\mathbf{M}_p\left[0:N_p,0\right] \leftrightarrow \mathbf{M}\left[0:N_p,j_p\right]$
    6. Apply Gaussian elimination for the current pivot element:
@@ -376,55 +333,48 @@ $\mathbf{M}$, e.g. $\mathbf{M}\left[0:3, j\right]$.
       2. In $\mathbf{Q}$: swap $p \leftrightarrow p + j_p$
    8. Continue with the next $p$ to factorize the the bottom-right block.
 
-$\mathbf{L}$ is now the matrix containing the lower triangle of $\mathbf{M}$, ones on the diagonal
-and zeros in the upper triangle.
-Similarly, $\mathbf{U}$ is the matrix containing the upper triangle
-of $\mathbf{M}$ including the diagonal elements and zeros in the lower triangle.
+$\mathbf{L}$ is now the matrix containing the lower triangle of $\mathbf{M}$, ones on the diagonal and zeros in the
+upper triangle.
+Similarly, $\mathbf{U}$ is the matrix containing the upper triangle of $\mathbf{M}$ including the diagonal elements and
+zeros in the lower triangle.
 
 ```{note}
-In the (equivalent) actual implementation, we break from the loop and throw afterwards, instead of
-raising the `SparseMatrixError` immediately.
+In the (equivalent) actual implementation, we break from the loop and throw afterwards, instead of raising the
+`SparseMatrixError` immediately.
 ```
 
 ```{note}
-Permutations are only allowed within each dense block, for the reasons described
-[earlier](#pivot-operations).
+Permutations are only allowed within each dense block, for the reasons described [earlier](#pivot-operations).
 ```
 
 ### Block-sparse LU factorization
 
-The LU factorization process for block-sparse matrices is similar to that for
-[dense matrices](#dense-lu-factorization).
+The LU factorization process for block-sparse matrices is similar to that for [dense matrices](#dense-lu-factorization).
 Only in this case, $m_p$ refers to a block element.
 $\boldsymbol{q}_p$, $\boldsymbol{r}_p^T$ and $\hat{\mathbf{M}}_p$ consist of block elements as well.
-Notice that the block-wise inverse $m_p^{-1}$ can be calculated using its LU decomposition, which
-can be obtained from the [dense LU factorization process](#dense-lu-factorization-process).
+Notice that the block-wise inverse $m_p^{-1}$ can be calculated using its LU decomposition, which can be obtained from
+the [dense LU factorization process](#dense-lu-factorization-process).
 
 #### Block-sparse LU factorization process
 
 The block-sparse LU factorization process differs slightly from the
 [dense counterpart](#dense-lu-factorization-process).
-Below, we first
-[describe the naive approach](#naive-block-sparse-lu-factorization-process), followed by the
-rationale and proof of the alternative approach.
+Below, we first [describe the naive approach](#naive-block-sparse-lu-factorization-process), followed by the rationale
+and proof of the alternative approach.
 
 ##### Naive block-sparse LU factorization process
 
 A naïve approach towards block-sparse LU factorization is done as follows.
-The
-[dense LU factorization process](#dense-lu-factorization-process) is followed but on blocks instead
-of single elements.
+The [dense LU factorization process](#dense-lu-factorization-process) is followed but on blocks instead of single
+elements.
 Let
-$\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
-be the block-sparse sub-matrix yet to be decomposed.
-$\mathbf{m}_p$ is a dense block that can be
-[LU factorized](#dense-lu-factorization-process):
-$\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$, where
-the lower-case helps avoiding confusion with the block-sparse matrix components.
-The matrices
-constructed with [LU decomposition](https://en.wikipedia.org/wiki/LU_decomposition) for
-[Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) are constructed
-accordingly.
+$\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$ be
+the block-sparse sub-matrix yet to be decomposed.
+$\mathbf{m}_p$ is a dense block that can be [LU factorized](#dense-lu-factorization-process):
+$\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$, where the lower-case helps avoiding
+confusion with the block-sparse matrix components.
+The matrices constructed with [LU decomposition](https://en.wikipedia.org/wiki/LU_decomposition) for
+[Gaussian elimination](https://en.wikipedia.org/wiki/Gaussian_elimination) are constructed accordingly.
 
 $$
 \begin{align*}
@@ -434,11 +384,10 @@ $$
 \end{align*}
 $$
 
-Here, $\overrightarrow{\mathbf{m}_p^{-1}\mathbf{q}_p}$ is symbolic notation for the block-vector of
-solutions to the equation $\mathbf{m}_p x_{p;k} = \mathbf{q}_{p;k}$, where $k = 0..(p-1)$.
-Similarly, $\widehat{\mathbf{m}_p^{-1}\mathbf{q}_p \mathbf{r}_p^T}$ is symbolic notation for the
-block-matrix of solutions to the equation
-$\mathbf{m}_p x_{p;k,l} = \mathbf{q}_{p;k} \mathbf{r}_{p;l}^T$, where $k,l = 0..(p-1)$.
+Here, $\overrightarrow{\mathbf{m}_p^{-1}\mathbf{q}_p}$ is symbolic notation for the block-vector of solutions to the
+equation $\mathbf{m}_p x_{p;k} = \mathbf{q}_{p;k}$, where $k = 0..(p-1)$.
+Similarly, $\widehat{\mathbf{m}_p^{-1}\mathbf{q}_p \mathbf{r}_p^T}$ is symbolic notation for the block-matrix of
+solutions to the equation $\mathbf{m}_p x_{p;k,l} = \mathbf{q}_{p;k} \mathbf{r}_{p;l}^T$, where $k,l = 0..(p-1)$.
 That is:
 
 $$
@@ -456,35 +405,29 @@ $$
 \end{align*}
 $$
 
-Iteratively applying above factorization process yields $\mathbf{L}$ and $\mathbf{U}$, as well as
-$\mathbf{P}$ and $\mathbf{Q}$.
+Iteratively applying above factorization process yields $\mathbf{L}$ and $\mathbf{U}$, as well as $\mathbf{P}$ and
+$\mathbf{Q}$.
 
-Unfortunately, the process of obtaining $\mathbf{m}_p^{-1} \boldsymbol{x}_p$ can be numerically
-unstable, even if it is split into multiple solving steps.
+Unfortunately, the process of obtaining $\mathbf{m}_p^{-1} \boldsymbol{x}_p$ can be numerically unstable, even if it is
+split into multiple solving steps.
 Instead, the process below is used.
 
 ##### Partially solved block-sparse LU factorization process
 
-A more numerically stable approach compared to the
-[naïve approach](#naive-block-sparse-lu-factorization-process) is equivalent to single-element
-pivot.
-Instead of applying the full pivot decomposition in the $L$-matrix and delaying the solve
-process until the final solving phase, we only apply a partial pivoting step to both $L$ matrix and
-the $U$ matrix.
+A more numerically stable approach compared to the [naïve approach](#naive-block-sparse-lu-factorization-process) is
+equivalent to single-element pivot.
+Instead of applying the full pivot decomposition in the $L$-matrix and delaying the solve process until the final
+solving phase, we only apply a partial pivoting step to both $L$ matrix and the $U$ matrix.
 This is equivalent to single-element pivoting without block-pivoting.
-In the
-following sections, we provide the
-[rationale](#rationale-of-the-block-sparse-lu-factorization-process) and
+In the following sections, we provide the [rationale](#rationale-of-the-block-sparse-lu-factorization-process) and
 [proof](#proof-of-block-sparse-lu-factorization-process).
 
 Following the same conventions as [above](#naive-block-sparse-lu-factorization-process), let
-$\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$
-be the block-sparse matrix to decompose.
-$\mathbf{m}_p$ is a dense block that can be
-[LU factorized](#dense-lu-factorization-process):
+$\mathbf{M}_p\equiv\begin{bmatrix}\mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{q}_p && \hat{\mathbf{M}}_p\end{bmatrix}$ be
+the block-sparse matrix to decompose.
+$\mathbf{m}_p$ is a dense block that can be [LU factorized](#dense-lu-factorization-process):
 $\mathbf{m}_p = \mathbf{p}_p^{-1} \mathbf{l}_p \mathbf{u}_p \mathbf{q}_p^{-1}$.
-Partial Gaussian
-elimination constructs the following matrices.
+Partial Gaussian elimination constructs the following matrices.
 
 $$
 \begin{align*}
@@ -494,8 +437,8 @@ $$
 \end{align*}
 $$
 
-Note that the first column of $\mathbf{L}_p$ can be obtained by applying a right-solve procedure,
-instead of the regular left-solve procedure, as is the case for $\mathbf{U}_p$.
+Note that the first column of $\mathbf{L}_p$ can be obtained by applying a right-solve procedure, instead of the regular
+left-solve procedure, as is the case for $\mathbf{U}_p$.
 
 ##### Rationale of the block-sparse LU factorization process
 
@@ -570,39 +513,35 @@ $$
 \end{align*}
 $$
 
-Interestingly, the matrices $\mathbf{l}_c$, $\mathbf{u}_b$ and $\mathbf{l}_d\mathbf{u}_d$ can be
-obtained without doing full pivoting on the sub-block level:
+Interestingly, the matrices $\mathbf{l}_c$, $\mathbf{u}_b$ and $\mathbf{l}_d\mathbf{u}_d$ can be obtained without doing
+full pivoting on the sub-block level:
 
-* $\mathbf{l}_c$ is the solution to the right-multiplication matrix equation
-  $\mathbf{l}_c \mathbf{u}_a = \mathbf{c}$
-* $\mathbf{u}_b$ is the solution to the left-multiplication matrix equation
-  $\mathbf{l}_a \mathbf{u}_b = \mathbf{b}$.
-* $\mathbf{l}_d\mathbf{u}_d$ denotes the start matrix of the decomposition of the next iteration and
-  is equal to $\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$.
+* $\mathbf{l}_c$ is the solution to the right-multiplication matrix equation $\mathbf{l}_c \mathbf{u}_a = \mathbf{c}$
+* $\mathbf{u}_b$ is the solution to the left-multiplication matrix equation $\mathbf{l}_a \mathbf{u}_b = \mathbf{b}$.
+* $\mathbf{l}_d\mathbf{u}_d$ denotes the start matrix of the decomposition of the next iteration and is equal to
+  $\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$.
 
-This process generalizes to block-invertible matrices of any size: $\mathbf{c}$ and $\mathbf{b}$
-become a column- and row-vector of block-matrices for which the individual block-elements of the
-vectorized decompositions $\mathbf{l}_c$ and $\mathbf{u}_b$ can be obtained by solving the
-equations above.
+This process generalizes to block-invertible matrices of any size: $\mathbf{c}$ and $\mathbf{b}$ become a column- and
+row-vector of block-matrices for which the individual block-elements of the vectorized decompositions $\mathbf{l}_c$ and
+$\mathbf{u}_b$ can be obtained by solving the equations above.
 
 If, during the LU decomposition of the pivot block, a row- and column-permutation was used,
-$\mathbf{a} = \mathbf{p}_a^{-1} \mathbf{l}_a \mathbf{u}_p \mathbf{q}_a^{-1}$, and the columns of
-$\mathbf{c}$ and the rows of $\mathbf{b}$ are permuted: $\mathbf{c}\mapsto\mathbf{c}\mathbf{q}_a$
-and $\mathbf{b}\mapsto\mathbf{p}_a\mathbf{b}$.
+$\mathbf{a} = \mathbf{p}_a^{-1} \mathbf{l}_a \mathbf{u}_p \mathbf{q}_a^{-1}$, and the columns of $\mathbf{c}$ and the
+rows of $\mathbf{b}$ are permuted: $\mathbf{c}\mapsto\mathbf{c}\mathbf{q}_a$ and
+$\mathbf{b}\mapsto\mathbf{p}_a\mathbf{b}$.
 In this case, the equations generalize as follows.
 
 * $\mathbf{l}_c$ is the solution to the right-multiplication matrix equation
   $\mathbf{l}_c \mathbf{u}_a = \mathbf{c} \mathbf{q}_a$.
 * $\mathbf{u}_b$ is the solution to the left-multiplication matrix equation
   $\mathbf{l}_a \mathbf{u}_b = \mathbf{p}_a \mathbf{b}$.
-* $\mathbf{l}_d\mathbf{u}_d$ denotes the start matrix of the decomposition of the next iteration and
-  is equal to $\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$.
+* $\mathbf{l}_d\mathbf{u}_d$ denotes the start matrix of the decomposition of the next iteration and is equal to
+  $\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$.
 
 ##### Proof of block-sparse LU factorization process
 
-The following proves the equations $\mathbf{l}_c \mathbf{u}_a = \mathbf{c}$,
-$\mathbf{l}_a \mathbf{u}_b = \mathbf{b}$ and
-$\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$ mentioned in the
+The following proves the equations $\mathbf{l}_c \mathbf{u}_a = \mathbf{c}$, $\mathbf{l}_a \mathbf{u}_b = \mathbf{b}$
+and $\mathbf{l}_d\mathbf{u}_d = \mathbf{d} - \mathbf{l}_c \mathbf{u}_b$ mentioned in the
 [previous section](#rationale-of-the-block-sparse-lu-factorization-process).
 
 $$
@@ -665,23 +604,19 @@ $$
 \end{align*}
 $$
 
-We can see that $\mathbf{l}_c$ and $\mathbf{u}_b$ are affected by the in-block LU decomposition of
-the pivot block $\left(\mathbf{l}_a,\mathbf{u}_a\right)$, as well as the data in the respective
-blocks ($\mathbf{c}$ and $\mathbf{b}$) in the original matrix.
-Beyond these two sources, no other
-factors affect $\mathbf{l}_c$ and $\mathbf{u}_b$.
-The generalization to largr block sizes and
-block-matrix sizes follows.
+We can see that $\mathbf{l}_c$ and $\mathbf{u}_b$ are affected by the in-block LU decomposition of the pivot block
+$\left(\mathbf{l}_a,\mathbf{u}_a\right)$, as well as the data in the respective blocks ($\mathbf{c}$ and $\mathbf{b}$)
+in the original matrix.
+Beyond these two sources, no other factors affect $\mathbf{l}_c$ and $\mathbf{u}_b$.
+The generalization to largr block sizes and block-matrix sizes follows.
 
 #### Block-sparse indexing
 
 The structure of the block-sparse matrices is as follows.
 
-* The $N\times N$ block matrix $\mathbf{M}$ is interpreted as the block-matrix, with
-  $\mathbf{M}\left[i,j\right]$ its block element at (0-based) indices $(i,j)$, where
-  $i,j = 0..(N-1)$.
-* In turn, let $\mathbf{M}\left[i,j\right]\equiv\mathbf{M}_{i,j}$ be the dense block with dimensions
-  $N_i\times N_j$.
+* The $N\times N$ block matrix $\mathbf{M}$ is interpreted as the block-matrix, with $\mathbf{M}\left[i,j\right]$ its
+  block element at (0-based) indices $(i,j)$, where $i,j = 0..(N-1)$.
+* In turn, let $\mathbf{M}\left[i,j\right]\equiv\mathbf{M}_{i,j}$ be the dense block with dimensions $N_i\times N_j$.
 
 This can be graphically represented as
 
@@ -714,15 +649,12 @@ $$
 \end{align*}
 $$
 
-Because of the sparse structure and the fact that all $\mathbf{M}_{i,j}$ have the same shape, it is
-much more efficient to store the blocks $\mathbf{M}_{i,j}$ in a vector $\mathbf{M}_{\tilde{k}}$
-where $\tilde{k}$ is a reordered index from $(i,j) \mapsto \tilde{k}$.
-This mapping, in turn, is
-stored as an index pointer, i.e., a vector of vectors of indices, with the outer index given by the
-row-index $i$, and the inner vector containing the values of $j$ for which $\mathbf{M}_{i,j}$ may be
-non-zero.
-All topologically relevant matrix elements, as well as [fill-ins](#pivot-operations), are
-included in this mapping.
+Because of the sparse structure and the fact that all $\mathbf{M}_{i,j}$ have the same shape, it is much more efficient
+to store the blocks $\mathbf{M}_{i,j}$ in a vector $\mathbf{M}_{\tilde{k}}$ where $\tilde{k}$ is a reordered index from
+$(i,j) \mapsto \tilde{k}$.
+This mapping, in turn, is stored as an index pointer, i.e., a vector of vectors of indices, with the outer index given
+by the row-index $i$, and the inner vector containing the values of $j$ for which $\mathbf{M}_{i,j}$ may be non-zero.
+All topologically relevant matrix elements, as well as [fill-ins](#pivot-operations), are included in this mapping.
 The following illustrates this mapping.
 
 $$
@@ -746,21 +678,17 @@ $$
 \end{align*}
 $$
 
-In the first equation, the upper row contains the present block entries and the bottom row their
-column indices per row to obtain a flattened representation of the matrix.
-In the last equivalence,
-the column indices, in turn, are also flattened into a separate flattened representation of the
+In the first equation, the upper row contains the present block entries and the bottom row their column indices per row
+to obtain a flattened representation of the matrix.
+In the last equivalence, the column indices, in turn, are also flattened into a separate flattened representation of the
 column indices and the start indices of each row, i.e., the index pointer (`indptr`).
-Note that the
-size of `indptr` is 1 greater than the amount of rows.
-This enables describing the amount of
-elements in a given row $i$ as the difference between the respective element and the next, i.e.,
-$\text{indptr}[i + 1] - \text{indptr}[i]$.
+Note that the size of `indptr` is 1 greater than the amount of rows.
+This enables describing the amount of elements in a given row $i$ as the difference between the respective element and
+the next, i.e., $\text{indptr}[i + 1] - \text{indptr}[i]$.
 
 Looping over the rows and columns becomes trivial.
 Let $\text{indptr}$ be the start.
-The double loop
-becomes:
+The double loop becomes:
 
 1. Loop all rows: $i=0..(N-1)$:
    1. The column indices for this row start at $\text{indptr}\left[i\right]$.
@@ -774,20 +702,16 @@ becomes:
 
 An equation $\mathbf{M} \boldsymbol{x} = \boldsymbol{b}$ can be solved using
 [LU factorization](#block-sparse-lu-factorization) by forward and backward substitutions.
-Since the
-blocks of the matrix are already ordered in a way that minimizes the amount of
-[fill-ins](#pivot-operations), it is recommended not to permute across blocks, as that would defeat
-the whole purpose of doing the reordering.
-Permutations are therefore restricted to intra-block
-operations.
-The first step of the block-sparse LU solving therefore permutes the rows within each
-block: $\boldsymbol{b}^{\prime} = \mathbf{P}\boldsymbol{b}$.
-After that, the forward substitution
-step essentially amounts to solving the matrix equation
-$\mathbf{L}\boldsymbol{y} = \boldsymbol{b}^{\prime}$, followed by the backwards substitution by
-solving $\mathbf{U}\boldsymbol{z} = \mathbf{y}$.
-The final result is then obtained by applying the
-column permutation within each block: $\boldsymbol{x} = \mathbf{Q}\boldsymbol{z}$.
+Since the blocks of the matrix are already ordered in a way that minimizes the amount of [fill-ins](#pivot-operations),
+it is recommended not to permute across blocks, as that would defeat the whole purpose of doing the reordering.
+Permutations are therefore restricted to intra-block operations.
+The first step of the block-sparse LU solving therefore permutes the rows within each block:
+$\boldsymbol{b}^{\prime} = \mathbf{P}\boldsymbol{b}$.
+After that, the forward substitution step essentially amounts to solving the matrix equation
+$\mathbf{L}\boldsymbol{y} = \boldsymbol{b}^{\prime}$, followed by the backwards substitution by solving
+$\mathbf{U}\boldsymbol{z} = \mathbf{y}$.
+The final result is then obtained by applying the column permutation within each block:
+$\boldsymbol{x} = \mathbf{Q}\boldsymbol{z}$.
 
 #### Forward substitution
 
@@ -840,10 +764,9 @@ Apply the column permutation as follows.
       1. Proceed.
 
 ```{note}
-If [pivot perturbation](#pivot-perturbation) was used to obtain the LU decomposition, the solution
-obtained here is an approximation to the exact solution.
-The accuracy can be improved using
-[iterative refinement](#iterative-refinement-of-lu-solver-solutions).
+If [pivot perturbation](#pivot-perturbation) was used to obtain the LU decomposition, the solution obtained here is an
+approximation to the exact solution.
+The accuracy can be improved using [iterative refinement](#iterative-refinement-of-lu-solver-solutions).
 ```
 
 ### Pivot perturbation
@@ -856,23 +779,17 @@ and
 for more details.
 Here, we briefly present the method used in the power grid model LU solver.
 
-Solving matrix equations with forward and backward substitution requires the selection of a pivot
-element.
-If the magnitude of a pivot element is too small compared to that of the other elements
-in the matrix, numerical instabilities may be encountered and the pivot element therefore cannot be
-used as is.
-Another pivot element could potentially be selected by permutation with other matrix
-elements across blocks, but this is not desirable, as described in the section on
-[pivot operations](#pivot-operations).
+Solving matrix equations with forward and backward substitution requires the selection of a pivot element.
+If the magnitude of a pivot element is too small compared to that of the other elements in the matrix, numerical
+instabilities may be encountered and the pivot element therefore cannot be used as is.
+Another pivot element could potentially be selected by permutation with other matrix elements across blocks, but this is
+not desirable, as described in the section on [pivot operations](#pivot-operations).
 In such cases, the matrix is ill-conditioned.
 
 Instead, a small perturbation can be added to the pivot element.
-This renders the matrix equation
-solvable without selecting a different pivot element.
-The cost of such operation is the introduction
-of numerical errors that are potentially propagating.
-Iterative refinement can be used to mitigate
-the numerical errors.
+This renders the matrix equation solvable without selecting a different pivot element.
+The cost of such operation is the introduction of numerical errors that are potentially propagating.
+Iterative refinement can be used to mitigate the numerical errors.
 This method is also used by
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
 and
@@ -883,8 +800,7 @@ as well as the well-known
 #### Pivot perturbation algorithm
 
 Let $\mathbf{M}$ be the matrix, $\left\|\mathbf{M}\right\|_{\infty ,\text{bwod}}$ the
-[block-wise off-diagonal infinite norm](#block-wise-off-diagonal-infinite-matrix-norm) of the
-matrix.
+[block-wise off-diagonal infinite norm](#block-wise-off-diagonal-infinite-matrix-norm) of the matrix.
 
 1. $\epsilon \gets \text{perturbation_threshold} * \left\|\mathbf{M}\right\|_{\text{bwod}}$.
 2. If $|\text{pivot_element}| \lt \epsilon$, then:
@@ -896,51 +812,45 @@ matrix.
       2. Proceed.
    3. $\text{pivot_element} \gets \epsilon * \text{phase_shift}$.
 
-$\text{phase_shift}$ ensures that the sign (if $\mathbf{M}$ is a real matrix) or complex phase (if
-$\mathbf{M}$ is a complex matrix) of the pivot element is preserved.
-The positive real axis is used
-as a fallback when the pivot element is identically zero.
+$\text{phase_shift}$ ensures that the sign (if $\mathbf{M}$ is a real matrix) or complex phase (if $\mathbf{M}$ is a
+complex matrix) of the pivot element is preserved.
+The positive real axis is used as a fallback when the pivot element is identically zero.
 
 ### Iterative refinement of LU solver solutions
 
-The following refinement algorithm draws substantial inspiration from the GESP algorithm described
-in [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761).
+The following refinement algorithm draws substantial inspiration from the GESP algorithm described in
+[Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761).
 
-[LU solving](#block-sparse-lu-solving) with an [LU decomposition](#block-sparse-lu-factorization)
-obtained using [pivot perturbation](#pivot-perturbation) yields only approximate results, because
-the LU decomposition itself is only approximate.
-Because of that, an iterative refinement process
-is required to improve the solution to the matrix equation
+[LU solving](#block-sparse-lu-solving) with an [LU decomposition](#block-sparse-lu-factorization) obtained using
+[pivot perturbation](#pivot-perturbation) yields only approximate results, because the LU decomposition itself is only
+approximate.
+Because of that, an iterative refinement process is required to improve the solution to the matrix equation
 $\mathbf{M} \cdot \boldsymbol{x} = \boldsymbol{b}$.
 
 The iterative refinement process works as follows.
-In step $i$, given an approximation
-$\boldsymbol{x}_i$ for $\boldsymbol{x}$, the difference between the current best and the exact
-solution is defined as $\boldsymbol{\Delta x} := \boldsymbol{x} - \boldsymbol{x}_i$.
-Substituting
-in the original equation yields
+In step $i$, given an approximation $\boldsymbol{x}_i$ for $\boldsymbol{x}$, the difference between the current best and
+the exact solution is defined as $\boldsymbol{\Delta x} := \boldsymbol{x} - \boldsymbol{x}_i$.
+Substituting in the original equation yields
 $\mathbf{M} \cdot (\boldsymbol{x}_i + \boldsymbol{\Delta x}) = \boldsymbol{b}$, so that
 $\mathbf{M} \cdot \boldsymbol{\Delta x} = \boldsymbol{b} - \mathbf{M} \cdot \boldsymbol{x}_i =: \boldsymbol{r}$.
 The residual $\boldsymbol{r}$ can be calculated.
-An estimation for the left-hand side can be
-obtained by using the pivot-perturbed matrix $\tilde{\mathbf{M}}$ instead of the original matrix
-$\mathbf{M}$.
+An estimation for the left-hand side can be obtained by using the pivot-perturbed matrix $\tilde{\mathbf{M}}$ instead of
+the original matrix $\mathbf{M}$.
 Convergence is reached when $\boldsymbol{r} \to \boldsymbol{0}$, which implies
 $\left\|\boldsymbol{\Delta x}\right\| \to 0$.
-Solving for $\boldsymbol{\Delta x}$ and substituting
-back into $\boldsymbol{x}_{i+1} = \boldsymbol{x}_i + \boldsymbol{\Delta x}$ provides the next best
-approximation $\boldsymbol{x}_{i+1}$ for $\boldsymbol{x}$.
+Solving for $\boldsymbol{\Delta x}$ and substituting back into
+$\boldsymbol{x}_{i+1} = \boldsymbol{x}_i + \boldsymbol{\Delta x}$ provides the next best approximation
+$\boldsymbol{x}_{i+1}$ for $\boldsymbol{x}$.
 
 A measure for the quality of the approximation is given by the $\text{backward_error}$ (see also
 [backward error formula](#backward-error-calculation)).
 
-Since the matrix $\mathbf{M}$ remains static during this process, the LU decomposition is valid
-throughout the process.
+Since the matrix $\mathbf{M}$ remains static during this process, the LU decomposition is valid throughout the process.
 The accuracy of the result can therefore be iteratively refined efficiently.
 
-Given the original matrix equation $\mathbf{M} \cdot \boldsymbol{x} = \boldsymbol{b}$ to solve, the
-pivot perturbated matrix $\tilde{\mathbf{M}}$ with a pre-calculated LU decomposition, and the
-convergence threshold $\epsilon$, the algorithm is as follows:
+Given the original matrix equation $\mathbf{M} \cdot \boldsymbol{x} = \boldsymbol{b}$ to solve, the pivot perturbated
+matrix $\tilde{\mathbf{M}}$ with a pre-calculated LU decomposition, and the convergence threshold $\epsilon$, the
+algorithm is as follows:
 
 1. Initialize:
    1. Set the initial estimate: $\boldsymbol{x}_{\text{est}} = \boldsymbol{0}$.
@@ -952,13 +862,11 @@ convergence threshold $\epsilon$, the algorithm is as follows:
       1. If $\text{backward_error} \leq \epsilon$, then:
          1. Convergence reached: stop the refinement process.
       2. Else, if the number of iterations > maximum allowed amount of iterations, then:
-         1. Convergence not reached; iterative refinement not possible: raise a sparse matrix
-            error.
+         1. Convergence not reached; iterative refinement not possible: raise a sparse matrix error.
       3. Else:
          1. Increase the number of iterations.
          2. Proceed.
-   2. Solve $\tilde{\mathbf{M}} \cdot \boldsymbol{\Delta x} = \boldsymbol{r}$ for
-      $\boldsymbol{\Delta x}$.
+   2. Solve $\tilde{\mathbf{M}} \cdot \boldsymbol{\Delta x} = \boldsymbol{r}$ for $\boldsymbol{\Delta x}$.
    3. Calculate the backward error with the original $\boldsymbol{x}$ and $\boldsymbol{r}$ using the
       [backward error formula](#improved-backward-error-calculation).
    4. Set the next estimation of
@@ -970,21 +878,18 @@ As a result, we effectively always do:
 1. A solving step; and
 2. At least one refinement step.
 
-When the maximum allowed amount of iterations is exceeded, a sparse matrix error instead of an
-iteration diverge error is raised.
-The reason is, that it is specifically the iterative refinement
-of the matrix equation solution that cannot be solved in the set amount of iterations - not the set
-of power system equations.
-This will only happen when the matrix equation requires iterative
-refinement in the first place, which happens only when pivot perturbation is needed, namely in the
-case of an ill-conditioned matrix equation.
-A matrix equation that is both ill-conditioned and not
-iteratively refinable is underdetermined and cannot be solved.
+When the maximum allowed amount of iterations is exceeded, a sparse matrix error instead of an iteration diverge error
+is raised.
+The reason is, that it is specifically the iterative refinement of the matrix equation solution that cannot be solved in
+the set amount of iterations - not the set of power system equations.
+This will only happen when the matrix equation requires iterative refinement in the first place, which happens only when
+pivot perturbation is needed, namely in the case of an ill-conditioned matrix equation.
+A matrix equation that is both ill-conditioned and not iteratively refinable is underdetermined and cannot be solved.
 
 #### Backward error calculation
 
-The [iterative refinement algorithm](#iterative-refinement-of-lu-solver-solutions) uses a backward
-error as a convergence criterion.
+The [iterative refinement algorithm](#iterative-refinement-of-lu-solver-solutions) uses a backward error as a
+convergence criterion.
 We use the following backward error calculation, inspired by
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761),
 with a few modifications described [below](#improved-backward-error-calculation).
@@ -1004,12 +909,11 @@ D_{\text{max}} &= \max_i\left\{\left(\left|\mathbf{M}\right|\cdot\left|\boldsymb
 $$
 
 $\epsilon \in \left[0, 1\right]$ is a value that introduces a
-[cut-off value to improve stability](#improved-backward-error-calculation) of the algorithm and
-should ideally be small.
+[cut-off value to improve stability](#improved-backward-error-calculation) of the algorithm and should ideally be small.
 
 ```{note}
-$\epsilon = 10^{-4}$ was experimentally determined to be a reasonably good value on a number of
-real-world medium voltage grids.
+$\epsilon = 10^{-4}$ was experimentally determined to be a reasonably good value on a number of real-world medium
+voltage grids.
 ```
 
 ### Differences with literature
@@ -1023,9 +927,8 @@ They are summarized below.
 #### No diminishing backward error
 
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
-contains an early-out criterion for the
-[iterative refinement](#iterative-refinement-of-lu-solver-solutions) that checks for diminishing
-backward error in consecutive iterations.
+contains an early-out criterion for the [iterative refinement](#iterative-refinement-of-lu-solver-solutions) that checks
+for diminishing backward error in consecutive iterations.
 It amounts to (in reverse order):
 
 1. If $\text{backward_error} \gt \frac{1}{2}\text{last_backward_error}$, then:
@@ -1034,30 +937,22 @@ It amounts to (in reverse order):
    1. Go to next refinement iteration.
 
 In power systems, however, the fact that the matrix may contain elements
-[spanning several orders of magnitude](#element-size-properties-of-power-system-equations) may cause
-slow convergence far away from the optimum.
-The diminishing criterion would cause the algorithm to
-terminate before the actual solution is found.
-Multiple refinement iterations may still yield better
-results.
-The power grid model therefore does not terminate early when encountering diminishing
-backward errors.
-Instead, a maximum amount of iterations is used in combination with the error
-tolerance.
+[spanning several orders of magnitude](#element-size-properties-of-power-system-equations) may cause slow convergence
+far away from the optimum.
+The diminishing criterion would cause the algorithm to terminate before the actual solution is found.
+Multiple refinement iterations may still yield better results.
+The power grid model therefore does not terminate early when encountering diminishing backward errors.
+Instead, a maximum amount of iterations is used in combination with the error tolerance.
 
 #### Improved backward error calculation
 
-In power system equations, the matrix $\mathbf{M}$ in equation
-$\mathbf{M} \boldsymbol{x} = \boldsymbol{b}$ can contain very discrepant entries: some may be very
-large while others are zero or very small (see also the
+In power system equations, the matrix $\mathbf{M}$ in equation $\mathbf{M} \boldsymbol{x} = \boldsymbol{b}$ can contain
+very discrepant entries: some may be very large while others are zero or very small (see also the
 [documentation on calculations](../user_manual/calculations.md)).
-The same may be true for the
-right-hand side of the equation $\boldsymbol{b}$, as well as its solution $\boldsymbol{x}$.
-In fact,
-there may be certain rows $i$ for which both $\left|\boldsymbol{b}\left[i\right]\right|$ and
-$\sum_j \left|\mathbf{M}\left[i,j\right]\right| \left|\boldsymbol{x}\left[j\right]\right|$ are small
-and, therefore, their sum is prone to rounding errors, which may be several orders larger than
-machine precision.
+The same may be true for the right-hand side of the equation $\boldsymbol{b}$, as well as its solution $\boldsymbol{x}$.
+In fact, there may be certain rows $i$ for which both $\left|\boldsymbol{b}\left[i\right]\right|$ and
+$\sum_j \left|\mathbf{M}\left[i,j\right]\right| \left|\boldsymbol{x}\left[j\right]\right|$ are small and, therefore,
+their sum is prone to rounding errors, which may be several orders larger than machine precision.
 
 [Li99](https://www.semanticscholar.org/paper/A-Scalable-Sparse-Direct-Solver-Using-Static-Li-Demmel/7ea1c3360826ad3996f387eeb6d70815e1eb3761)
 uses the following backward error in the
@@ -1071,17 +966,16 @@ $$
 \end{align*}
 $$
 
-In this equation, the symbolic notation $\left|\mathbf{M}\right|$ and $\left|\boldsymbol{x}\right|$
-are the matrix and vector with absolute values of the elements of $\mathbf{M}$ and $\boldsymbol{x}$
-as elements, i.e., $\left|\mathbf{M}\right|_{i,j} := \left|\mathbf{M}_{i,j}\right|$ and
-$\left|\boldsymbol{x}\right|_i := \left|\boldsymbol{x}_i\right|$, as
-defined in [Arioli89](https://epubs.siam.org/doi/10.1137/0610013).
+In this equation, the symbolic notation $\left|\mathbf{M}\right|$ and $\left|\boldsymbol{x}\right|$ are the matrix and
+vector with absolute values of the elements of $\mathbf{M}$ and $\boldsymbol{x}$ as elements, i.e.,
+$\left|\mathbf{M}\right|_{i,j} := \left|\mathbf{M}_{i,j}\right|$ and
+$\left|\boldsymbol{x}\right|_i := \left|\boldsymbol{x}_i\right|$, as defined in
+[Arioli89](https://epubs.siam.org/doi/10.1137/0610013).
 
-Due to the aforementioned, this is prone to rounding errors, and a single row with rounding errors
-may cause the entire iterative refinement to fail.
-The power grid model therefore uses a modified
-version, in which the denominator is capped to a minimum value, determined by the maximum across all
-denominators:
+Due to the aforementioned, this is prone to rounding errors, and a single row with rounding errors may cause the entire
+iterative refinement to fail.
+The power grid model therefore uses a modified version, in which the denominator is capped to a minimum value,
+determined by the maximum across all denominators:
 
 $$
 \begin{align*}
@@ -1098,53 +992,43 @@ D_{\text{max}} &= \max_i\left\{\left(\left|\mathbf{M}\right|\cdot\left|\boldsymb
 $$
 
 $\epsilon$ may be chosen.
-$\epsilon = 0$ means no cut-off, while $\epsilon = 1$ means that only the
-absolute values of the residuals are relevant - not the relative values.
-The former is prone to
-rounding errors.
-The latter may hide issues in rows with small coefficients by supressing them
-in the backward error.
+$\epsilon = 0$ means no cut-off, while $\epsilon = 1$ means that only the absolute values of the residuals are
+relevant - not the relative values.
+The former is prone to rounding errors.
+The latter may hide issues in rows with small coefficients by supressing them in the backward error.
 This would favor rows with larger absolute, but smaller relative residuals.
 This can be the case, even if that row's residual is relatively large compared to the other entries.
-In conclusion, $\epsilon$ should be chosen small, but large enough to suppress numerical
-instabilities.
+In conclusion, $\epsilon$ should be chosen small, but large enough to suppress numerical instabilities.
 A choice for $\epsilon$ that is experimentally verified to be reasonable is mentioned
 [above](#backward-error-calculation).
 
 #### Block-wise off-diagonal infinite matrix norm
 
-For the [pivot perturbation algorithm](#pivot-perturbation-algorithm), a matrix norm is used to
-determine the relative size of the current pivot element compared to the rest of the matrix as a
-measure for the degree of ill-conditioning.
-The norm is a variant of the $L_{\infty}$ norm of a
-matrix, which we call the block-wise off-diagonal infinite matrix norm
-($L_{\infty ,\text{bwod}}$).
+For the [pivot perturbation algorithm](#pivot-perturbation-algorithm), a matrix norm is used to determine the relative
+size of the current pivot element compared to the rest of the matrix as a measure for the degree of ill-conditioning.
+The norm is a variant of the $L_{\infty}$ norm of a matrix, which we call the block-wise off-diagonal infinite matrix
+norm ($L_{\infty ,\text{bwod}}$).
 
-Since the power grid model solves the matrix equations using a multi-scale matrix solver (dense
-intra-block, block-sparse for the full topological structure of the grid), the norm is also taken on
-those same levels, so the calculation of the norm is _block-wise_.
+Since the power grid model solves the matrix equations using a multi-scale matrix solver (dense intra-block,
+block-sparse for the full topological structure of the grid), the norm is also taken on those same levels, so the
+calculation of the norm is _block-wise_.
 
-In addition, the diagonal blocks may have much larger elements than the off-diagonal ones, while the
-relevant information is contained mostly in the off-diagonal blocks.
-As a result, the block-diagonal
-blocks would undesirably dominate the norm.
-The power grid model therefore restricts the calculation
-of the norm to _off-diagonal_ blocks.
+In addition, the diagonal blocks may have much larger elements than the off-diagonal ones, while the relevant
+information is contained mostly in the off-diagonal blocks.
+As a result, the block-diagonal blocks would undesirably dominate the norm.
+The power grid model therefore restricts the calculation of the norm to _off-diagonal_ blocks.
 
-In short, the $L_{\infty ,\text{bwod}}$-norm it is the $L_{\infty}$ norm of the block-sparse matrix
-with the $L_{\infty}$ norm of the individual blocks as elements, where the diagonal blocks are
-skipped.
+In short, the $L_{\infty ,\text{bwod}}$-norm it is the $L_{\infty}$ norm of the block-sparse matrix with the
+$L_{\infty}$ norm of the individual blocks as elements, where the diagonal blocks are skipped.
 
 ##### Block-wise off-diagonal infinite matrix norm algorithm
 
 The algorithm is as follows:
 
-Let $\mathbf{M}\equiv \mathbf{M}\left[0:N, 0:N\right]$ be the $N\times N$-matrix with a block-sparse
-structure and $\mathbf{M}\left[i,j\right]$ its block element at (0-based) indices $(i,j)$, where
-$i,j = 0..(N-1)$.
-In turn, let
-$\mathbf{M}\left[i,j\right] \equiv \mathbf{M}_{i,j}\left[0:N_{i,j},0:N_{i,j}\right]$ be the dense
-block with dimensions $N_i\times N_j$.
+Let $\mathbf{M}\equiv \mathbf{M}\left[0:N, 0:N\right]$ be the $N\times N$-matrix with a block-sparse structure and
+$\mathbf{M}\left[i,j\right]$ its block element at (0-based) indices $(i,j)$, where $i,j = 0..(N-1)$.
+In turn, let $\mathbf{M}\left[i,j\right] \equiv \mathbf{M}_{i,j}\left[0:N_{i,j},0:N_{i,j}\right]$ be the dense block
+with dimensions $N_i\times N_j$.
 
 1. $\text{norm} \gets 0$.
 2. Loop over all block-rows: $i = 0..(N-1)$:
@@ -1170,8 +1054,8 @@ block with dimensions $N_i\times N_j$.
 
 ##### Illustration of the block-wise off-diagonal infinite matrix norm calculation
 
-This section aims to illustrate how the $L_{\infty ,\text{bwod}}$-norm differs from a regular
-$L_{\infty}$-norm using the following examples.
+This section aims to illustrate how the $L_{\infty ,\text{bwod}}$-norm differs from a regular $L_{\infty}$-norm using
+the following examples.
 
 The first example shows how the taking the block-wise norm affects the calculation of the norm.
 

--- a/docs/algorithms/lu-solver.md
+++ b/docs/algorithms/lu-solver.md
@@ -327,7 +327,7 @@ $\mathbf{M}\left[0:3, j\right]$.
       2. $\mathbf{M}_p\left[0:N_p,0\right] \leftrightarrow \mathbf{M}\left[0:N_p,j_p\right]$
    6. Apply Gaussian elimination for the current pivot element:
       1. $\mathbf{M}_p\left[0,0:N_p\right] \gets \frac{1}{\mathbf{M}_p[0,0]}\mathbf{M}_p\left[0,0:N_p\right]$
-      2. $\mathbf{M}_p\left[1:N_p,0:N_p\right] \gets \mathbf{M}_p\left[1:N_p,0:N_p\right] - \mathbf{M}_p\left[1:N_p,0\right] \otimes \mathbf{M}_p\left[0,0:N_p\right]$
+      2. $\mathbf{M}_p\left[1:N_p,0:N_p\right] \gets \mathbf{M}_p\left[1:N_p,0:N_p\right] - \mathbf{M}_p\left[1:N_p,0\right] \otimes \mathbf{M}_p\left[0,0:N_p\right]$  <!-- markdownlint-disable-line MD013 -->
    7. Accumulate the permutation matrices:
       1. In $\mathbf{P}$: swap $p \leftrightarrow p + i_p$
       2. In $\mathbf{Q}$: swap $p \leftrightarrow p + j_p$
@@ -378,8 +378,14 @@ The matrices constructed with [LU decomposition](https://en.wikipedia.org/wiki/L
 
 $$
 \begin{align*}
-\mathbf{L}_p &= \begin{bmatrix} \mathbf{1} && \mathbf{0}^T \\ \overrightarrow{\mathbf{m}_p^{-1}\mathbf{q}_p} && \mathbf{1}_p\end{bmatrix} \\
-\mathbf{U}_p &= \begin{bmatrix} \mathbf{m}_p && \mathbf{r}_p^T \\ \mathbf{0} && \mathbf{1}_p \end{bmatrix} \\
+\mathbf{L}_p &= \begin{bmatrix}
+    \mathbf{1} && \mathbf{0}^T \\
+    \overrightarrow{\mathbf{m}_p^{-1}\mathbf{q}_p} && \mathbf{1}_p
+\end{bmatrix} \\
+\mathbf{U}_p &= \begin{bmatrix}
+    \mathbf{m}_p && \mathbf{r}_p^T \\
+    \mathbf{0} && \mathbf{1}_p
+\end{bmatrix} \\
 \mathbf{M}_{p+1} &= \hat{\mathbf{M}}_p - \widehat{\mathbf{m}_p^{-1}\mathbf{q}_p \mathbf{r}_p^T}
 \end{align*}
 $$
@@ -431,9 +437,16 @@ Partial Gaussian elimination constructs the following matrices.
 
 $$
 \begin{align*}
-\mathbf{L}_p &= \begin{bmatrix} \mathbf{l}_p && \mathbf{0}^T \\ \overrightarrow{\mathbf{q}_p\mathbf{q}_p\mathbf{u}_p^{-1}} && \mathbf{1}_p\end{bmatrix} \\
-\mathbf{U}_p &= \begin{bmatrix} \mathbf{u}_p && \overrightarrow{\mathbf{l}_p\mathbf{p}_p\mathbf{r}_p}^T \\ \mathbf{0} && \mathbf{1}_p \end{bmatrix} \\
-\mathbf{M}_{p+1} &= \hat{\mathbf{M}}_p - \widehat{\mathbf{q}_p\mathbf{q}_p\mathbf{u}_p^{-1}\mathbf{l}_p^{-1}\mathbf{p}_p\mathbf{r}_p^T}
+\mathbf{L}_p &= \begin{bmatrix}
+    \mathbf{l}_p && \mathbf{0}^T \\
+    \overrightarrow{\mathbf{q}_p\mathbf{q}_p\mathbf{u}_p^{-1}} && \mathbf{1}_p
+\end{bmatrix} \\
+\mathbf{U}_p &= \begin{bmatrix}
+    \mathbf{u}_p && \overrightarrow{\mathbf{l}_p\mathbf{p}_p\mathbf{r}_p}^T \\
+    \mathbf{0} && \mathbf{1}_p
+\end{bmatrix} \\
+\mathbf{M}_{p+1} &=
+    \hat{\mathbf{M}}_p - \widehat{\mathbf{q}_p\mathbf{q}_p\mathbf{u}_p^{-1}\mathbf{l}_p^{-1}\mathbf{p}_p\mathbf{r}_p^T}
 \end{align*}
 $$
 
@@ -460,9 +473,18 @@ c_{21} && c_{22} && d_{21} && d_{22}
 & \mapsto
 \begin{bmatrix}
 a_{11} && a_{12} && b_{11} && b_{12} \\
-\frac{a_{21}}{a_{11}} && a_{22} - a_{12} \frac{a_{21}}{a_{11}} && b_{21} - b_{11}\frac{a_{21}}{a_{11}} && b_{22} - b_{12}\frac{a_{21}}{a_{11}} \\
-\frac{c_{11}}{a_{11}} && c_{12} - a_{12} \frac{c_{11}}{a_{11}} && d_{11} - b_{11}\frac{c_{11}}{a_{11}} && d_{12} - b_{12}\frac{c_{11}}{a_{11}} \\
-\frac{c_{21}}{a_{11}} && c_{22} - a_{12} \frac{c_{21}}{a_{11}} && d_{21} - b_{11}\frac{c_{21}}{a_{11}} && d_{22} - b_{12}\frac{c_{21}}{a_{11}}
+\frac{a_{21}}{a_{11}} &&
+    a_{22} - a_{12} \frac{a_{21}}{a_{11}} &&
+    b_{21} - b_{11}\frac{a_{21}}{a_{11}} &&
+    b_{22} - b_{12}\frac{a_{21}}{a_{11}} \\
+\frac{c_{11}}{a_{11}} &&
+    c_{12} - a_{12} \frac{c_{11}}{a_{11}} &&
+    d_{11} - b_{11}\frac{c_{11}}{a_{11}} &&
+    d_{12} - b_{12}\frac{c_{11}}{a_{11}} \\
+\frac{c_{21}}{a_{11}} &&
+    c_{22} - a_{12} \frac{c_{21}}{a_{11}} &&
+    d_{21} - b_{11}\frac{c_{21}}{a_{11}} &&
+    d_{22} - b_{12}\frac{c_{21}}{a_{11}}
 \end{bmatrix} \\
 & \mapsto
 \begin{bmatrix}
@@ -473,12 +495,20 @@ a_{11} && a_{12} && b_{11} && b_{12} \\
     b_{22} - b_{12}\frac{a_{21}}{a_{11}} \\
 \frac{c_{11}}{a_{11}} &&
     \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-    d_{11} - b_{11}\frac{c_{11}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-    d_{12} - b_{12}\frac{c_{11}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}  \\
+    d_{11} - b_{11}\frac{c_{11}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+    d_{12} - b_{12}\frac{c_{11}}{a_{11}}
+        - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}  \\
 \frac{c_{21}}{a_{11}} &&
     \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-    d_{21} - b_{11}\frac{c_{21}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-    d_{22} - b_{12}\frac{c_{21}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
+    d_{21} - b_{11}\frac{c_{21}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+    d_{22} - b_{12}\frac{c_{21}}{a_{11}}
+        - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
 \end{bmatrix}
 \end{align*}
 $$
@@ -505,10 +535,18 @@ $$
     b_{21} - b_{11}\frac{a_{21}}{a_{11}} && b_{22} - b_{12}\frac{a_{21}}{a_{11}}
 \end{bmatrix} \\
 \mathbf{l}_d\mathbf{u}_d &= \begin{bmatrix}
-    d_{11} - b_{11}\frac{c_{11}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-        d_{12} - b_{12}\frac{c_{11}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}  \\
-    d_{21} - b_{11}\frac{c_{21}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-        d_{22} - b_{12}\frac{c_{21}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
+    d_{11} - b_{11}\frac{c_{11}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+    d_{12} - b_{12}\frac{c_{11}}{a_{11}}
+        - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}  \\
+    d_{21} - b_{11}\frac{c_{21}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+     d_{22} - b_{12}\frac{c_{21}}{a_{11}}
+         - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+             \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
 \end{bmatrix}
 \end{align*}
 $$
@@ -556,8 +594,14 @@ $$
     0 && a_{22} - a_{12} \frac{a_{21}}{a_{11}}
 \end{bmatrix} \\
 &= \begin{bmatrix}
-    a_{11} \frac{c_{11}}{a_{11}} && a_{12} \frac{c_{11}}{a_{11}} + \left(a_{22} - a_{12} \frac{a_{21}}{a_{11}}\right)\frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} \\
-    a_{11} \frac{c_{21}}{a_{11}} && a_{12} \frac{c_{21}}{a_{11}} + \left(a_{22} - a_{12} \frac{a_{21}}{a_{11}}\right)\frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
+    a_{11} \frac{c_{11}}{a_{11}} &&
+    a_{12} \frac{c_{11}}{a_{11}}
+        + \left(a_{22} - a_{12} \frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} \\
+    a_{11} \frac{c_{21}}{a_{11}} &&
+    a_{12} \frac{c_{21}}{a_{11}}
+        + \left(a_{22} - a_{12} \frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
 \end{bmatrix} \\
 &= \begin{bmatrix}
     c_{11} && c_{11} + \left(c_{12} - c_{11}\right) \\
@@ -577,8 +621,10 @@ $$
     b_{21} - b_{11}\frac{a_{21}}{a_{11}} && b_{22} - b_{12}\frac{a_{21}}{a_{11}}
 \end{bmatrix} \\
 &= \begin{bmatrix}
-    b_{11}                                                               && b_{12} \\
-    b_{11} \frac{a_{21}}{a_{11}} + b_{21} - b_{11} \frac{a_{21}}{a_{11}} && b_{12} \frac{a_{21}}{a_{11}} + b_{22} - b_{12}\frac{a_{21}}{a_{11}}
+    b_{11} &&
+    b_{12} \\
+    b_{11} \frac{a_{21}}{a_{11}} + b_{21} - b_{11} \frac{a_{21}}{a_{11}} &&
+    b_{12} \frac{a_{21}}{a_{11}} + b_{22} - b_{12}\frac{a_{21}}{a_{11}}
 \end{bmatrix} \\
 &= \begin{bmatrix}
     b_{11} && b_{12} \\
@@ -595,10 +641,18 @@ $$
     b_{21} - b_{11}\frac{a_{21}}{a_{11}} && b_{22} - b_{12}\frac{a_{21}}{a_{11}}
 \end{bmatrix} \\
 &= \begin{bmatrix}
-    d_{11} - b_{11}\frac{c_{11}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-        d_{12} - b_{12}\frac{c_{11}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} \\
-    d{21} - b_{11}\frac{c_{21}}{a_{11}} - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
-        d_{22} - b_{12}\frac{c_{21}}{a_{11}} - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right) \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
+    d_{11} - b_{11}\frac{c_{11}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+    d_{12} - b_{12}\frac{c_{11}}{a_{11}}
+        - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{12} - a_{12} \frac{c_{11}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} \\
+    d{21} - b_{11}\frac{c_{21}}{a_{11}}
+        - \left(b_{21} - b_{11}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}} &&
+    d_{22} - b_{12}\frac{c_{21}}{a_{11}}
+        - \left(b_{22} - b_{12}\frac{a_{21}}{a_{11}}\right)
+            \frac{c_{22} - a_{12} \frac{c_{21}}{a_{11}}}{a_{22} - a_{12} \frac{a_{21}}{a_{11}}}
 \end{bmatrix} \\
 &= \mathbf{l}_d\mathbf{u}_d
 \end{align*}
@@ -666,14 +720,33 @@ $$
 \mathbf{M}_{3,0} &&         && \mathbf{M}_{3,2} && \mathbf{M}_{3,3}
 \end{bmatrix} &\equiv
 \begin{bmatrix}
-\mathbf{M}_{0,0} && \mathbf{M}_{0,3} && \mathbf{M}_{1,1} && \mathbf{M}_{1,2} && \mathbf{M}_{2,1} && \mathbf{M}_{2,2} && \mathbf{M}_{2,3} && \mathbf{M}_{3,0} && \mathbf{M}_{3,2} && \mathbf{M}_{3,3} \\
-[[0 && 3] && [1 && 2] && [1 && 2 && 3] && [0 && 2 && 3]] \\
+    \mathbf{M}_{0,0} &&
+        \mathbf{M}_{0,3} &&
+        \mathbf{M}_{1,1} &&
+        \mathbf{M}_{1,2} &&
+        \mathbf{M}_{2,1} &&
+        \mathbf{M}_{2,2} &&
+        \mathbf{M}_{2,3} &&
+        \mathbf{M}_{3,0} &&
+        \mathbf{M}_{3,2} &&
+        \mathbf{M}_{3,3} \\
+    [[0 && 3] && [1 && 2] && [1 && 2 && 3] && [0 && 2 && 3]] \\
 \end{bmatrix} \\
 &\equiv
 \begin{bmatrix}
-\mathbf{M}_{0,0} && \mathbf{M}_{0,3} && \mathbf{M}_{1,1} && \mathbf{M}_{1,2} && \mathbf{M}_{2,1} && \mathbf{M}_{2,2} && \mathbf{M}_{2,3} && \mathbf{M}_{3,0} && \mathbf{M}_{3,2} && \mathbf{M}_{3,3} && \\
-[0 && 3 && 1 && 2 && 1 && 2 && 3 && 0 && 2 && 3] && \\
-[0 && && 2 && && 4 && && && 7 && && && && 10]
+    \mathbf{M}_{0,0} &&
+        \mathbf{M}_{0,3} &&
+        \mathbf{M}_{1,1} &&
+        \mathbf{M}_{1,2} &&
+        \mathbf{M}_{2,1} &&
+        \mathbf{M}_{2,2} &&
+        \mathbf{M}_{2,3} &&
+        \mathbf{M}_{3,0} &&
+        \mathbf{M}_{3,2} &&
+        \mathbf{M}_{3,3} &&
+        \\
+    [0 && 3 && 1 && 2 && 1 && 2 && 3 && 0 && 2 && 3] && \\
+    [0 && && 2 && && 4 && && && 7 && && && && 10]
 \end{bmatrix}
 \end{align*}
 $$
@@ -729,7 +802,7 @@ The equation $\mathbf{L}\boldsymbol{y} = \mathbf{P}\boldsymbol{b}$ is solved as 
 
 1. Loop over all block-rows: $i=0..(N-1)$:
    1. Loop over all lower-triangle off-diagonal columns (beware of sparsity): $j=0..(i-1)$:
-      1. $\boldsymbol{b}\left[i\right] \gets \boldsymbol{b}\left[i\right] - \mathbf{L}\left[i,j\right] \cdot \boldsymbol{b}\left[j\right]$.
+      1. $\boldsymbol{b}\left[i\right] \gets \boldsymbol{b}\left[i\right] - \mathbf{L}\left[i,j\right] \cdot \boldsymbol{b}\left[j\right]$.  <!-- markdownlint-disable-line MD013 -->
       2. Continue with next block-column.
    2. If the matrix is a block matrix:
       1. Follow the same steps within the block.
@@ -743,7 +816,7 @@ The equation $Uz = y$ is solved as follows.
 
 1. Loop over all block-rows in reverse order: $i=(N-1)..0$:
    1. Loop over all upper-triangle off-diagonal columns (beware of sparsity): $j=(i+1)..0$:
-      1. $\boldsymbol{b}\left[i\right] \gets \boldsymbol{b}\left[i\right] - \mathbf{U}\left[i,j\right] \cdot \boldsymbol{b}\left[j\right]$.
+      1. $\boldsymbol{b}\left[i\right] \gets \boldsymbol{b}\left[i\right] - \mathbf{U}\left[i,j\right] \cdot \boldsymbol{b}\left[j\right]$.  <!-- markdownlint-disable-line MD013 -->
       2. Continue with next block-column.
    2. Handle the diagonal element:
       1. If the matrix is a block matrix:
@@ -896,14 +969,16 @@ with a few modifications described [below](#improved-backward-error-calculation)
 
 $$
 \begin{align*}
-D_{\text{max}} &= \max_i\left\{\left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i\right\} \\
+D_{\text{max}} &= \max_i\left\{
+    \left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i
+\right\} \\
 \text{backward_error} &= \max_i \left\{
-   \frac{\left|\boldsymbol{r}\right|_i}{
-      \max\left\{
-         \left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i,
-         \epsilon_{\text{backward_error}} D_{\text{max}}
-      \right\}
-   }
+    \frac{\left|\boldsymbol{r}\right|_i}{
+        \max\left\{
+            \left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i,
+            \epsilon_{\text{backward_error}} D_{\text{max}}
+        \right\}
+    }
 \right\}
 \end{align*}
 $$
@@ -960,9 +1035,22 @@ uses the following backward error in the
 
 $$
 \begin{align*}
-\text{backward_error}_{\text{Li}} &= \max_i \frac{\left|\boldsymbol{r}_i\right|}{\sum_j \left|\mathbf{M}_{i,j}\right| \left|\boldsymbol{x}_j\right| + \left|\boldsymbol{b}_i\right|} \\
-&= \max_i \frac{\left|\boldsymbol{b}_i - \sum_j \mathbf{M}_{i,j} \boldsymbol{x}_j\right|}{\sum_j \left|\mathbf{M}_{i,j}\right| \left|\boldsymbol{x}_j\right| + \left|\boldsymbol{b}_i\right|} \\
-&= \max_i \frac{\left|\boldsymbol{r}_i\right|}{\left(\left|\mathbf{M}\right| \cdot \left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i}
+\text{backward_error}_{\text{Li}}
+   &= \max_i \frac{
+         \left|\boldsymbol{r}_i\right|
+      }{
+         \sum_j \left|\mathbf{M}_{i,j}\right| \left|\boldsymbol{x}_j\right| + \left|\boldsymbol{b}_i\right|
+      } \\
+   &= \max_i \frac{
+         \left|\boldsymbol{b}_i - \sum_j \mathbf{M}_{i,j} \boldsymbol{x}_j\right|
+      }{
+         \sum_j \left|\mathbf{M}_{i,j}\right| \left|\boldsymbol{x}_j\right| + \left|\boldsymbol{b}_i\right|
+      } \\
+   &= \max_i \frac{
+         \left|\boldsymbol{r}_i\right|
+      }{
+         \left(\left|\mathbf{M}\right| \cdot \left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i
+      }
 \end{align*}
 $$
 
@@ -979,7 +1067,9 @@ determined by the maximum across all denominators:
 
 $$
 \begin{align*}
-D_{\text{max}} &= \max_i\left\{\left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i\right\} \\
+D_{\text{max}} &= \max_i\left\{
+   \left(\left|\mathbf{M}\right|\cdot\left|\boldsymbol{x}\right| + \left|\boldsymbol{b}\right|\right)_i
+\right\} \\
 \text{backward_error} &= \max_i \left\{
    \frac{\left|\boldsymbol{r}\right|_i}{
       \max\left\{
@@ -1099,6 +1189,7 @@ $$
 
 * The regular $L_{\infty}$-norm is $\max\left\{1+3, 3, 5, \frac{1}{2}, 1, 1\right\} = 5$.
 * The block-wise off-diagonal infinity $L_{\infty ,\text{bwod}}$-norm is
+  <!-- markdownlint-disable-next-line MD013 -->
   $\max\left\{\max\left\{1, 3\right\}+\max\left\{3, 0\right\},\max\left\{5, 0\right\} + \max\left\{0, \frac{1}{2}\right\}, 1\right\} = \max\left\{3+3, 5+\frac{1}{2}, 1, 1\right\} = 6$.
 
 The two norms clearly differ and even the elements that contribute most to the norm are different.
@@ -1126,6 +1217,7 @@ $$
 
 * The regular $L_{\infty}$-norm is $\max\left\{20+20+2+2,30+3,100,3+1\right\} = \max\left\{44,33,100,4\right\} = 100$.
 * The block-wise infinity norm with diagonals would be
+  <!-- markdownlint-disable-next-line MD013 -->
   $\max\left\{\max\left\{20+20, 30\right\}+\max\left\{2+2, 3\right\},\max\left\{0,3\right\} + \max\left\{100, 1\right\}\right\} = \max\left\{40+4, 3+100\right\} = \max\left\{44, 103\right\} = 103$.
 * The $L_{\infty ,\text{bwod}}$-norm is
   $\max\left\{\max\left\{2+2, 3\right\},\max\left\{0,3\right\}\right\} = \max\left\{4, 3\right\} = 4$.

--- a/docs/api_reference/python-api-reference.md
+++ b/docs/api_reference/python-api-reference.md
@@ -10,7 +10,8 @@ This is the Python API reference for the `power-grid-model` library.
 Due to the nature of how Python module works, we cannnot hide the implementation detail completely from the user.
 As a general rule, any Python modules/functions/classes which are not documented in this API documentation,
 are internal implementations.
-**The user should not use any of them. We do not guarantee the stability or even the existence of those modules.**
+**The user should not use any of them.**
+**We do not guarantee the stability or even the existence of those modules.**
 
 ```{eval-rst}
 .. py:module:: power_grid_model

--- a/docs/contribution/folder-structure.md
+++ b/docs/contribution/folder-structure.md
@@ -8,18 +8,24 @@ SPDX-License-Identifier: MPL-2.0
 
 The repository folder structure is as follows. The `docs` and `scripts` folders are self-explanatory.
 
-- The C++ calculation core is inside {{ "[power_grid_model_c/power_grid_model/include/power_grid_model]({}/power_grid_model_c/power_grid_model/include/power_grid_model)".format(gh_link_head_tree) }}.
-- The C API is inside {{ "[power_grid_model_c/power_grid_model_c]({}/power_grid_model_c/power_grid_model_c)".format(gh_link_head_tree) }}.
-- The C program example to use the C API is inside {{ "[power_grid_model_c_example]({}/power_grid_model_c_example)".format(gh_link_head_tree) }}.
+- The C++ calculation core is inside
+  {{ "[power_grid_model_c/power_grid_model/include/power_grid_model]({}/power_grid_model_c/power_grid_model/include/power_grid_model)".format(gh_link_head_tree) }}.
+- The C API is inside
+  {{ "[power_grid_model_c/power_grid_model_c]({}/power_grid_model_c/power_grid_model_c)".format(gh_link_head_tree) }}.
+- The C program example to use the C API is inside
+  {{ "[power_grid_model_c_example]({}/power_grid_model_c_example)".format(gh_link_head_tree) }}.
 - The python interface code is in {{ "[src/power_grid_model]({}/src/power_grid_model)".format(gh_link_head_tree) }}
-- The code for validation of input data is in {{ "[validation]({}/src/power_grid_model/validation)".format(gh_link_head_tree) }} folder.
+- The code for validation of input data is in
+  {{ "[validation]({}/src/power_grid_model/validation)".format(gh_link_head_tree) }} folder.
 - The {{ "[tests]({}/tests)".format(gh_link_head_tree) }} folder is divided in the following way:
   - `cpp_unit_tests` contains the tests for the C++ calculation core.
   - `cpp_integration_tests` contains more extensive tests for the C++ calculation core.
   - `cpp_validation_tests` contains the validation test cases for the C++ calculation core.
   - `c_api_tests` contains the tests for communication with the C API.
   - `benchmark_cpp` contains a benchmark test case generator in C++.
-  - `package_tests` contains an integration test CMake project that tests whether the C API package is correctly installed.
+  - `package_tests` contains an integration test CMake project that tests whether the C API package is correctly
+    installed.
   - `unit` folder contains tests for the python code.
-  - `data` contains validation test cases designed for every component and algorithm. Some sample network types are also included.
-  The validation is either against popular power system analysis software or hand calculation.
+  - `data` contains validation test cases designed for every component and algorithm.
+    Some sample network types are also included.
+    The validation is either against popular power system analysis software or hand calculation.

--- a/docs/contribution/folder-structure.md
+++ b/docs/contribution/folder-structure.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MPL-2.0
 The repository folder structure is as follows. The `docs` and `scripts` folders are self-explanatory.
 
 - The C++ calculation core is inside
-  {{ "[power_grid_model_c/power_grid_model/include/power_grid_model]({}/power_grid_model_c/power_grid_model/include/power_grid_model)".format(gh_link_head_tree) }}.
+  {{ "[power_grid_model_c/power_grid_model/include/power_grid_model]({}/power_grid_model_c/power_grid_model/include/power_grid_model)".format(gh_link_head_tree) }}.  <!-- markdownlint-disable-line MD013 -->
 - The C API is inside
   {{ "[power_grid_model_c/power_grid_model_c]({}/power_grid_model_c/power_grid_model_c)".format(gh_link_head_tree) }}.
 - The C program example to use the C API is inside

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,12 +21,15 @@ Currently, it supports both symmetric and asymmetric calculations for the follow
 * State Estimation
 * Short Circuit
 
-For conversions from various data format to the power-grid-model, refer to the [power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io) repository.
-For an extended python interface to the the power-grid-model, refer to the [power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds) repository.
+For conversions from various data format to the power-grid-model, refer to the
+[power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io) repository.
+For an extended python interface to the the power-grid-model, refer to the
+[power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds) repository.
 
 ```{note}
 Do you wish to be updated on the latest news and releases?
-Subscribe to the Power Grid Model mailing list by sending an (empty) email to: [powergridmodel+subscribe@lists.lfenergy.org](powergridmodel+subscribe@lists.lfenergy.org)
+Subscribe to the Power Grid Model mailing list by sending an (empty) email to:
+[powergridmodel+subscribe@lists.lfenergy.org](powergridmodel+subscribe@lists.lfenergy.org)
 ```
 
 ## Install from PyPI
@@ -51,7 +54,8 @@ To install the library from source, refer to the [Build Guide](advanced_document
 
 ## Citations
 
-If you are using Power Grid Model in your research work, please consider citing our library using the references in [Citation](release_and_support/CITATION.md).
+If you are using Power Grid Model in your research work, please consider citing our library using the references in
+[Citation](release_and_support/CITATION.md).
 
 ## Contents
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,8 @@ For conversions from various data format to the power-grid-model, refer to the [
 For an extended python interface to the the power-grid-model, refer to the [power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds) repository.
 
 ```{note}
-Do you wish to be updated on the latest news and releases? Subscribe to the Power Grid Model mailing list by sending an (empty) email to: powergridmodel+subscribe@lists.lfenergy.org
+Do you wish to be updated on the latest news and releases?
+Subscribe to the Power Grid Model mailing list by sending an (empty) email to: [powergridmodel+subscribe@lists.lfenergy.org](powergridmodel+subscribe@lists.lfenergy.org)
 ```
 
 ## Install from PyPI
@@ -50,7 +51,7 @@ To install the library from source, refer to the [Build Guide](advanced_document
 
 ## Citations
 
-If you are using Power Grid Model in your research work, please consider citing our library using the references in [Citation](release_and_support/CITATION.md)
+If you are using Power Grid Model in your research work, please consider citing our library using the references in [Citation](release_and_support/CITATION.md).
 
 ## Contents
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,8 @@ In this quick start a simple 10kV network as below is calculated.
 A line connects two nodes.
 One node has a source.
 The other node has a symmetric load.
-The full code for this section is provided in {{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
+The full code for this section is provided in
+{{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
 
 ```txt
 node_1 ---line_3--- node_2
@@ -18,11 +19,11 @@ node_1 ---line_3--- node_2
 source_5            sym_load_4
 ```
 
-The library uses a graph data model to represent the physical components and their attributes,
-see [Graph Data Model](user_manual/data-model).
+The library uses a graph data model to represent the physical components and their attributes, see
+[Graph Data Model](user_manual/data-model).
 
-Before we start working on the network, we need first import the main model class
-as well as some helper functions for enumerations and meta data.
+Before we start working on the network, we need first import the main model class as well as some helper functions for
+enumerations and meta data.
 
 ```python
 from power_grid_model import LoadGenType
@@ -42,12 +43,12 @@ self_test()
 ## Input Data
 
 The library uses dictionaries of
-[numpy structured arrays](https://numpy.org/doc/stable/user/basics.rec.html)
-as the main (input and output) data exchange format between Python interface and C++ core.
+[numpy structured arrays](https://numpy.org/doc/stable/user/basics.rec.html) as the main (input and output) data
+exchange format between Python interface and C++ core.
 Detailed design of data interface can be found in [Native Data Interface](advanced_documentation/native-data-interface).
 
-The helper function {py:class}`power_grid_model.initialize_array` can be used to
-easily generate an array of the correct format.
+The helper function {py:class}`power_grid_model.initialize_array` can be used to easily generate an array of the correct
+format.
 
 ```python
 # node
@@ -56,8 +57,7 @@ node['id'] = [1, 2]
 node['u_rated'] = [10.5e3, 10.5e3]
 ```
 
-The code above generates a node input array with two nodes,
-and assigns the attributes of the nodes to the array.
+The code above generates a node input array with two nodes, and assigns the attributes of the nodes to the array.
 Similarly, we can create input arrays for line, load, and generation.
 A dictionary of such arrays is used for `input_data` and `update_data`.
 
@@ -97,7 +97,8 @@ input_data = {
 }
 ```
 
-Another example of how to create components can be found in [Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
+Another example of how to create components can be found in
+[Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
 
 ```{note}
 The keys of the dictonary of arrays are unique and should match with the respective `type name` of the component.
@@ -114,8 +115,8 @@ model = PowerGridModel(input_data, system_frequency=50.0)
 
 ## Power Flow Calculation
 
-To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`
-or {py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
+To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow` or
+{py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
 Refer [Calculations](user_manual/calculations) for more details on the many optional arguments.
 
 ```python
@@ -149,12 +150,15 @@ Node Result
 
 ## Validation
 
-To validate the `input_data` and `update_data` for valid values, use {py:class}`power_grid_model.validation.validate_input_data` and {py:class}`power_grid_model.validation.validate_batch_data`.
-Refer to [Data Validator](user_manual/data-validator) for more details
+To validate the `input_data` and `update_data` for valid values, use
+{py:class}`power_grid_model.validation.validate_input_data` and
+{py:class}`power_grid_model.validation.validate_batch_data`.
+Refer to [Data Validator](user_manual/data-validator) for more details.
 
 ## Batch Data
 
 You can calculate a (large) number of scenarios using one command and even in parallel threading.
 This is what makes Power Grid Model a powerful calculation engine.
 You need to create a batch update dataset and put it in the `update_data` argument of `calculate_power_flow`.
-Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute batch calculations.
+Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute
+batch calculations.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,11 @@ SPDX-License-Identifier: MPL-2.0
 # Quick Start
 
 In this quick start a simple 10kV network as below is calculated.
-A line connects two nodes. One node has a source. The other node has a symmetric load.
-The full code for this section is provided in {{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
+A line connects two nodes.
+One node has a source.
+The other node has a symmetric load.
+The full code for this section is provided in
+{{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
 
 ```txt
 node_1 ---line_3--- node_2
@@ -16,11 +19,11 @@ node_1 ---line_3--- node_2
 source_5            sym_load_4
 ```
 
-The library uses a graph data model to represent the physical components and their attributes,
-see [Graph Data Model](user_manual/data-model).
+The library uses a graph data model to represent the physical components and their attributes, see
+[Graph Data Model](user_manual/data-model).
 
-Before we start working on the network, we need first import the main model class
-as well as some helper functions for enumerations and meta data.
+Before we start working on the network, we need first import the main model class as well as some helper functions for
+enumerations and meta data.
 
 ```python
 from power_grid_model import LoadGenType
@@ -29,8 +32,8 @@ from power_grid_model import initialize_array
 from power_grid_model.utils import self_test
 ```
 
-A basic self_test function is provided to check if the installation was successful
-and there are no build errors, segmentation violations, undefined symbols, etc.
+A basic self_test function is provided to check if the installation was successful and there are no build errors,
+segmentation violations, undefined symbols, etc.
 The function should be imported and called by a user by running following commands:
 
 ```python
@@ -44,8 +47,8 @@ The library uses dictionaries of
 as the main (input and output) data exchange format between Python interface and C++ core.
 Detailed design of data interface can be found in [Native Data Interface](advanced_documentation/native-data-interface).
 
-The helper function {py:class}`power_grid_model.initialize_array` can be used to
-easily generate an array of the correct format.
+The helper function {py:class}`power_grid_model.initialize_array` can be used to easily generate an array of the correct
+format.
 
 ```python
 # node
@@ -54,8 +57,7 @@ node['id'] = [1, 2]
 node['u_rated'] = [10.5e3, 10.5e3]
 ```
 
-The code above generates a node input array with two nodes,
-and assigns the attributes of the nodes to the array.
+The code above generates a node input array with two nodes, and assigns the attributes of the nodes to the array.
 Similarly, we can create input arrays for line, load, and generation.
 A dictionary of such arrays is used for `input_data` and `update_data`.
 
@@ -95,16 +97,18 @@ input_data = {
 }
 ```
 
-Another example of how to create components can be found in [Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
+Another example of how to create components can be found in
+[Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
 
 ```{note}
-The keys of the dictonary of arrays are unique and should match with the respective `type name` of the component. 
+The keys of the dictonary of arrays are unique and should match with the respective `type name` of the component.
+
 See, e.g., that type name of {hoverxref}`user_manual/components:node` is `node`.
 ```
 
 ## Instantiate Model
 
-We can instantiate the model by calling the constructor of {py:class}`power_grid_model.PowerGridModel`
+We can instantiate the model by calling the constructor of {py:class}`power_grid_model.PowerGridModel`:
 
 ```python
 model = PowerGridModel(input_data, system_frequency=50.0)
@@ -112,8 +116,8 @@ model = PowerGridModel(input_data, system_frequency=50.0)
 
 ## Power Flow Calculation
 
-To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`
-or {py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
+To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow` or
+{py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
 Refer [Calculations](user_manual/calculations) for more details on the many optional arguments.
 
 ```python
@@ -147,11 +151,15 @@ Node Result
 
 ## Validation
 
-To validate the `input_data` and `update_data` for valid values, use {py:class}`power_grid_model.validation.validate_input_data` and {py:class}`power_grid_model.validation.validate_batch_data`. Refer to [Data Validator](user_manual/data-validator) for more details
+To validate the `input_data` and `update_data` for valid values, use
+{py:class}`power_grid_model.validation.validate_input_data` and
+{py:class}`power_grid_model.validation.validate_batch_data`.
+Refer to [Data Validator](user_manual/data-validator) for more details.
 
 ## Batch Data
 
 You can calculate a (large) number of scenarios using one command and even in parallel threading.
 This is what makes Power Grid Model a powerful calculation engine.
 You need to create a batch update dataset and put it in the `update_data` argument of `calculate_power_flow`.
-Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute batch calculations.
+Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute
+batch calculations.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,8 +10,7 @@ In this quick start a simple 10kV network as below is calculated.
 A line connects two nodes.
 One node has a source.
 The other node has a symmetric load.
-The full code for this section is provided in
-{{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
+The full code for this section is provided in {{ "[quick_example.py]({}/scripts/quick_example.py)".format(gh_link_head_blob) }}.
 
 ```txt
 node_1 ---line_3--- node_2
@@ -19,11 +18,11 @@ node_1 ---line_3--- node_2
 source_5            sym_load_4
 ```
 
-The library uses a graph data model to represent the physical components and their attributes, see
-[Graph Data Model](user_manual/data-model).
+The library uses a graph data model to represent the physical components and their attributes,
+see [Graph Data Model](user_manual/data-model).
 
-Before we start working on the network, we need first import the main model class as well as some helper functions for
-enumerations and meta data.
+Before we start working on the network, we need first import the main model class
+as well as some helper functions for enumerations and meta data.
 
 ```python
 from power_grid_model import LoadGenType
@@ -32,8 +31,8 @@ from power_grid_model import initialize_array
 from power_grid_model.utils import self_test
 ```
 
-A basic self_test function is provided to check if the installation was successful and there are no build errors,
-segmentation violations, undefined symbols, etc.
+A basic self_test function is provided to check if the installation was successful
+and there are no build errors, segmentation violations, undefined symbols, etc.
 The function should be imported and called by a user by running following commands:
 
 ```python
@@ -47,8 +46,8 @@ The library uses dictionaries of
 as the main (input and output) data exchange format between Python interface and C++ core.
 Detailed design of data interface can be found in [Native Data Interface](advanced_documentation/native-data-interface).
 
-The helper function {py:class}`power_grid_model.initialize_array` can be used to easily generate an array of the correct
-format.
+The helper function {py:class}`power_grid_model.initialize_array` can be used to
+easily generate an array of the correct format.
 
 ```python
 # node
@@ -57,7 +56,8 @@ node['id'] = [1, 2]
 node['u_rated'] = [10.5e3, 10.5e3]
 ```
 
-The code above generates a node input array with two nodes, and assigns the attributes of the nodes to the array.
+The code above generates a node input array with two nodes,
+and assigns the attributes of the nodes to the array.
 Similarly, we can create input arrays for line, load, and generation.
 A dictionary of such arrays is used for `input_data` and `update_data`.
 
@@ -97,12 +97,10 @@ input_data = {
 }
 ```
 
-Another example of how to create components can be found in
-[Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
+Another example of how to create components can be found in [Input data](examples/Power%20Flow%20Example.ipynb#input-dataset).
 
 ```{note}
 The keys of the dictonary of arrays are unique and should match with the respective `type name` of the component.
-
 See, e.g., that type name of {hoverxref}`user_manual/components:node` is `node`.
 ```
 
@@ -116,8 +114,8 @@ model = PowerGridModel(input_data, system_frequency=50.0)
 
 ## Power Flow Calculation
 
-To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow` or
-{py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
+To run calculations, use the object methods {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`
+or {py:class}`power_grid_model.PowerGridModel.calculate_state_estimation` functions.
 Refer [Calculations](user_manual/calculations) for more details on the many optional arguments.
 
 ```python
@@ -151,15 +149,12 @@ Node Result
 
 ## Validation
 
-To validate the `input_data` and `update_data` for valid values, use
-{py:class}`power_grid_model.validation.validate_input_data` and
-{py:class}`power_grid_model.validation.validate_batch_data`.
-Refer to [Data Validator](user_manual/data-validator) for more details.
+To validate the `input_data` and `update_data` for valid values, use {py:class}`power_grid_model.validation.validate_input_data` and {py:class}`power_grid_model.validation.validate_batch_data`.
+Refer to [Data Validator](user_manual/data-validator) for more details
 
 ## Batch Data
 
 You can calculate a (large) number of scenarios using one command and even in parallel threading.
 This is what makes Power Grid Model a powerful calculation engine.
 You need to create a batch update dataset and put it in the `update_data` argument of `calculate_power_flow`.
-Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute
-batch calculations.
+Please refer to [Power Flow Example](examples/Power%20Flow%20Example.ipynb) for a detailed tutorial about how to execute batch calculations.

--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -11,19 +11,26 @@ SPDX-License-Identifier: MPL-2.0
 With power-grid-model it is possible to perform three different types of calculations:
 
 - [Power flow](#power-flow-algorithms): a "what-if" scenario calculation.
-This calculation can be performed by using the {py:class}`calculate_power_flow <power_grid_model.PowerGridModel.calculate_power_flow>` method.
-An example of usage of the power-flow calculation function is given in [Power flow Example](../examples/Power%20Flow%20Example.ipynb)
-- [State estimation](#state-estimation-algorithms): a statistical method that calculates the most probabilistic state of the grid, given sensor values with an uncertainty.
-This calculation can be performed by using the {py:class}`calculate_state_estimation <power_grid_model.PowerGridModel.calculate_state_estimation>` method.
-An example of usage of the power-flow calculation function is given in [State Estimation Example](../examples/State%20Estimation%20Example.ipynb)
+  This calculation can be performed by using the
+  {py:class}`calculate_power_flow <power_grid_model.PowerGridModel.calculate_power_flow>` method.
+  An example of usage of the power-flow calculation function is given in
+  [Power flow Example](../examples/Power%20Flow%20Example.ipynb)
+- [State estimation](#state-estimation-algorithms): a statistical method that calculates the most probabilistic state of
+  the grid, given sensor values with an uncertainty.
+  This calculation can be performed by using the
+  {py:class}`calculate_state_estimation <power_grid_model.PowerGridModel.calculate_state_estimation>` method.
+  An example of usage of the power-flow calculation function is given in
+  [State Estimation Example](../examples/State%20Estimation%20Example.ipynb)
 - [Short circuit](#short-circuit-calculation-algorithms): a "what-if" scenario calculation with short circuit entries.
-This calculation can be performed by using the {py:class}`calculate_short_circuit <power_grid_model.PowerGridModel.calculate_short_circuit>` method.
+  This calculation can be performed by using the
+  {py:class}`calculate_short_circuit <power_grid_model.PowerGridModel.calculate_short_circuit>` method.
 
 ### Calculation types explained
 
 #### Power flow
 
-Power flow is a "what-if" based grid calculation that will calculate the node voltages and the power flow through the branches, based on assumed load/generation profiles.
+Power flow is a "what-if" based grid calculation that will calculate the node voltages and the power flow through the
+branches, based on assumed load/generation profiles.
 Some typical use-cases are network planning and contingency analysis.
 
 Input:
@@ -42,16 +49,18 @@ See [Power flow algorithms](#power-flow-algorithms) for detailed documentation o
 
 For most power flow calculations, the grid is fixed as the user dictates.
 However, in practice, the grid often contains regulators for certain components.
-When including those regulators in the calculations, the grid may be optimized according to the power flow results and the behaviour of the regulators.
+When including those regulators in the calculations, the grid may be optimized according to the power flow results and
+the behaviour of the regulators.
 
-See [Regulated power flow calculations](#regulated-power-flow-calculations) for detailed documentation on regulated power flow calculations.
+See [Regulated power flow calculations](#regulated-power-flow-calculations) for detailed documentation on regulated
+power flow calculations.
 
 #### State estimation
 
 State estimation is a statistical calculation method that determines the most probable state of the grid, based on
 network data and measurements.
-Here, measurements can be power flow or voltage values with certain kind of uncertainty, which were
-either measured, estimated or forecasted.
+Here, measurements can be power flow or voltage values with certain kind of uncertainty, which were either measured,
+estimated or forecasted.
 
 Input:
 
@@ -65,14 +74,13 @@ Output:
 - Deviation between measurement values and estimated state
 
 In order to perform a state estimation, the system should be observable.
-If the system is not observable,
-the calculation will raise either a `NotObservableError` or a `SparseMatrixError`.
-In short, meeting the requirement of observability indicates that the system is either an overdetermined
-system (when the number of independent measurements is larger than the number of unknowns) or an exactly
-determined system (the number of independent measurements equals the number of unknowns).
+If the system is not observable, the calculation will raise either a `NotObservableError` or a `SparseMatrixError`.
+In short, meeting the requirement of observability indicates that the system is either an overdetermined system (when
+the number of independent measurements is larger than the number of unknowns) or an exactly determined system (the
+number of independent measurements equals the number of unknowns).
 For each node, there are two unknowns, `u` and `u_angle`.
-Due to the relative nature of `u_angle`
-(relevant only in systems with at least two nodes), in total the following conditions should be met:
+Due to the relative nature of `u_angle` (relevant only in systems with at least two nodes), in total the following
+conditions should be met:
 
 $$
     \begin{eqnarray}
@@ -98,8 +106,7 @@ The number of measurements can be found by taking the sum of the following:
 
 ```{note}
 Having enough measurements does not necessarily mean that the system is observable.
-The location of the measurements is
-also of importance, i.e., the measurements should be topologically independent.
+The location of the measurements is also of importance, i.e., the measurements should be topologically independent.
 Additionally, there should be at least one voltage measurement.
 ```
 
@@ -109,24 +116,32 @@ See also the [current sensor component documentation](./components.md#global-ang
 ```
 
 ```{note}
-It is not possible to mix [power sensors](./components.md#generic-current-sensor) with [current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
-It is also not possible to mix [current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with [current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is not possible to mix [power sensors](./components.md#generic-current-sensor) with
+[current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is also not possible to mix
+[current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with
+[current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the
+same component.
 However, such mixing of sensor types is allowed as long as they are on different terminals.
 ```
 
 ```{warning}
-The [iterative linear](#iterative-linear-state-estimation) and [Newton-Raphson](#newton-raphson-state-estimation) state estimation algorithms will assume angles to be zero by default (see the details about voltage sensors).
+The [iterative linear](#iterative-linear-state-estimation) and [Newton-Raphson](#newton-raphson-state-estimation) state
+estimation algorithms will assume angles to be zero by default (see the details about voltage sensors).
 In observable systems this helps better outputting correct results.
-On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be prevented.
+On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be
+prevented.
 ```
 
 ```{warning}
-At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation).
+At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the
+calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation).
 ```
 
 ##### Necessary observability condition
 
-Based on the requirements of observability mentioned above, users need to satisfy at least the following conditions for state estimation calculation in `power-grid-model`.
+Based on the requirements of observability mentioned above, users need to satisfy at least the following conditions for
+state estimation calculation in `power-grid-model`.
 
 - `n_voltage_sensor >= 1`
 - If no voltage phasor sensors are available, then both the following conditions shall be satisfied:
@@ -146,7 +161,8 @@ Either of them counts as one.
 ##### Sufficient observability condition
 
 The condition check above only checks the necessary condition for observability.
-When the measurements are not independent enough, the system may still be unobservable even if the necessary condition is met.
+When the measurements are not independent enough, the system may still be unobservable even if the necessary condition
+is met.
 It is rather complicated to do a full sufficient and necessary observability check in generic cases.
 However, `power-grid-model` performs the sufficient condition check when the following conditions are met:
 
@@ -160,13 +176,15 @@ If the system is not observable, the calculation will raise a `NotObservableErro
 
 Short circuit calculation is carried out to analyze the worst case scenario when a fault has occurred.
 The currents flowing through branches and node voltages are calculated.
-Some typical use-cases are selection or design of components like conductors or breakers and power system protection, e.g. relay co-ordination.
+Some typical use-cases are selection or design of components like conductors or breakers and power system protection,
+e.g. relay co-ordination.
 
 Input:
 
 - Network data: topology + component attributes
 - Fault type and impedance.
-- In the API call: choose between `minimum` and `maximum` voltage scaling to calculate the minimum or maximum short circuit currents (according to IEC 60909).
+- In the API call: choose between `minimum` and `maximum` voltage scaling to calculate the minimum or maximum short
+- circuit currents (according to IEC 60909).
 
 Output:
 
@@ -187,16 +205,19 @@ These quantities are in complex form.
 Hence, they can be constructed by PGM output attributes in the following way:
 
 - For  $\underline{U}$ of nodes, `u` is the magnitude and `u_angle` is the angle.
-Also the line to neutral voltage can be converted into line to line voltage by $ U_{LN} = U_{LL} / \sqrt{3}$.
-Check [Node Steady State Output](components.md#steady-state-output) to find out which quantity is relevant in your calculation.
+  Also the line to neutral voltage can be converted into line to line voltage by $ U_{LN} = U_{LL} / \sqrt{3}$.
+  Check [Node Steady State Output](components.md#steady-state-output) to find out which quantity is relevant in your
+  calculation.
 
 - For  $\underline{I}$ of branches, `i_side` is the magnitude.
-Its angle can be found from `p_side` and `q_side` by: $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
-The `side` here can be `from`, `to` for {hoverxreftooltip}`user_manual/components:Branch`es, `1`, `2`, `3` for {hoverxreftooltip}`user_manual/components:Branch3`s.
+  Its angle can be found from `p_side` and `q_side` by: $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
+  The `side` here can be `from`, `to` for {hoverxreftooltip}`user_manual/components:Branch`es, `1`, `2`, `3` for
+  {hoverxreftooltip}`user_manual/components:Branch3`s.
 
 ### Power flow algorithms
 
-Two types of power flow algorithms are implemented in power-grid-model; iterative algorithms (Newton-Raphson / Iterative current) and linear algorithms (Linear / Linear current).
+Two types of power flow algorithms are implemented in power-grid-model; iterative algorithms (Newton-Raphson / Iterative
+current) and linear algorithms (Linear / Linear current).
 Iterative methods are more accurate and should thus be selected when an accurate solution is required.
 Linear approximation methods are many times faster than the iterative methods, but are generally less accurate.
 They can be used where approximate solutions are acceptable.
@@ -219,7 +240,8 @@ By default, the [Newton-Raphson](#newton-raphson-power-flow) method is used.
 ```
 
 ```{note}
-When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the fastest without loss of accuracy.
+When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the
+fastest without loss of accuracy.
 Therefore power-grid-model will use this method regardless of the input provided by the user in this case.
 ```
 
@@ -232,8 +254,7 @@ $$
 $$
 
 Where $I_N$ is the $N$ vector of source currents injected into each bus and $U_N$ is the $N$ vector of bus voltages.
-The complex power
-delivered to bus $k$ is:
+The complex power delivered to bus $k$ is:
 
 $$
     \begin{eqnarray}
@@ -241,22 +262,22 @@ $$
     \end{eqnarray}
 $$
 
-Power flow equations are based on solving the nodal equations above to obtain the voltage magnitude and voltage angle at each node
-and then obtaining the real and reactive power flow through the branches.
+Power flow equations are based on solving the nodal equations above to obtain the voltage magnitude and voltage angle at
+each node and then obtaining the real and reactive power flow through the branches.
 The following bus types can be present in the system:
 
-- Slack bus: the reference bus with known voltage and angle; in power-grid-model referred to as the [source](./components.md#source).
+- Slack bus: the reference bus with known voltage and angle; in power-grid-model referred to as the
+  [source](./components.md#source).
 - Load bus: a bus with known $P$ and $Q$.
 - Voltage controlled bus: a bus with known $P$ and $U$.
-Note: this bus is not supported by power-grid-model yet.
+  Note: this bus is not supported by power-grid-model yet.
 
 #### Newton-Raphson power flow
 
 Algorithm call: {py:class}`CalculationMethod.newton_raphson <power_grid_model.enum.CalculationMethod.newton_raphson>`
 
 This is the traditional method for power flow calculations.
-This method uses a Taylor series, ignoring the higher order
-terms, to solve the nonlinear set of equations iteratively:
+This method uses a Taylor series, ignoring the higher order terms, to solve the nonlinear set of equations iteratively:
 
 $$
     \begin{eqnarray}
@@ -341,12 +362,15 @@ For each iteration the following steps are executed:
 
 #### Iterative current power flow
 
-Algorithm call: {py:class}`CalculationMethod.iterative_current <power_grid_model.enum.CalculationMethod.iterative_current>`
+Algorithm call:
+{py:class}`CalculationMethod.iterative_current <power_grid_model.enum.CalculationMethod.iterative_current>`
 
 This algorithm is a Jacobi-like method for powerflow analysis.
-It has a linear convergence rate as opposed to the quadratic convergence rate in the [Newton-Raphson](#newton-raphson-power-flow) method.
+It has a linear convergence rate as opposed to the quadratic convergence rate in the
+[Newton-Raphson](#newton-raphson-power-flow) method.
 This means that more iterations is needed to achieve similar convergence.
-Additionally, [Newton-Raphson](#newton-raphson-power-flow) will be more robust converging in case of greater meshed configurations.
+Additionally, [Newton-Raphson](#newton-raphson-power-flow) will be more robust converging in case of greater meshed
+configurations.
 Nevertheless, the iterative current algorithm will be faster most of the time.
 
 The algorithm is as follows:
@@ -367,17 +391,22 @@ The iterative current algorithm only needs to calculate injected currents before
 This is more straightforward than calculating the Jacobian, which was done in the Newton-Raphson algorithm.
 
 Factorizing the matrix of linear equation is the most computationally heavy task.
-The $Y_{bus}$ matrix here does not change across iterations which means it only needs to be factorized once to solve the linear equations in all iterations.
+The $Y_{bus}$ matrix here does not change across iterations which means it only needs to be factorized once to solve the
+linear equations in all iterations.
 The $Y_{bus}$ matrix also remains unchanged in certain batch calculations like timeseries calculations.
 
 #### Linear power flow
 
 Algorithm call: {py:class}`CalculationMethod.linear <power_grid_model.enum.CalculationMethod.linear>`
 
-This is an approximation method where we assume that all loads and generations are of constant impedance type regardless of their actual {py:class}`LoadGenType <power_grid_model.enum.LoadGenType>`.
-By doing so, we obtain huge performance benefits as the computation required is equivalent to a single iteration of the iterative methods.
-It will be more accurate when most of the load/generation types are of constant impedance or the actual node voltages are close to 1 p.u.
-When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the fastest without loss of accuracy.
+This is an approximation method where we assume that all loads and generations are of constant impedance type regardless
+of their actual {py:class}`LoadGenType <power_grid_model.enum.LoadGenType>`.
+By doing so, we obtain huge performance benefits as the computation required is equivalent to a single iteration of the
+iterative methods.
+It will be more accurate when most of the load/generation types are of constant impedance or the actual node voltages
+are close to 1 p.u.
+When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the
+fastest without loss of accuracy.
 Therefore power-grid-model will use this method regardless of the input provided by the user in this case.
 
 The algorithm is as follows:
@@ -396,13 +425,15 @@ Algorithm call: {py:class}`CalculationMethod.linear_current <power_grid_model.en
 
 This approximation method will give better results when most of the load/generation types resemble constant current.
 Similar to [iterative current](#iterative-current-power-flow), batch calculations like timeseries will also be faster.
-Same reason applies here: the $Y_{bus}$ matrix does not change across batches and as a result the same factorization could be used.
+Same reason applies here: the $Y_{bus}$ matrix does not change across batches and as a result the same factorization 
+ould be used.
 
 In practical grids most loads and generations correspond to the constant power type.
 Linear current would give a better approximation than [Linear](#linear-power-flow) in such case.
 This is because we approximate the load as current instead of impedance.
 There is a correlation in voltage error of approximation with respect to the actual voltage for all approximations.
-They are most accurate when the actual voltages are close to 1 p.u. and the error increases as we deviate from this level.
+They are most accurate when the actual voltages are close to 1 p.u. and the error increases as we deviate from this
+level.
 When we approximate the load as impedance at 1 p.u., the voltage error has quadratic relation to the actual voltage.
 When it is approximated as a current at 1 p.u., the voltage error is only linearly dependent in comparison.
 
@@ -424,8 +455,8 @@ $$
 
 Where $\underline{U}_i$ is the complex voltage phasor of the i-th bus.
 
-The goal of WLS state estimation is to evaluate the state variable with the highest likelihood given (pseudo) measurement input,
-by solving:
+The goal of WLS state estimation is to evaluate the state variable with the highest likelihood given (pseudo)
+measurement input, by solving:
 
 $$
    \begin{eqnarray}

--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -210,7 +210,8 @@ Hence, they can be constructed by PGM output attributes in the following way:
   calculation.
 
 - For  $\underline{I}$ of branches, `i_side` is the magnitude.
-  Its angle can be found from `p_side` and `q_side` by: $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
+  Its angle can be found from `p_side` and `q_side` by:
+  $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
   The `side` here can be `from`, `to` for {hoverxreftooltip}`user_manual/components:Branch`es, `1`, `2`, `3` for
   {hoverxreftooltip}`user_manual/components:Branch3`s.
 
@@ -350,7 +351,8 @@ $$
 $$
 
 $J$ is the [Jacobian](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant), a matrix with all partial
-derivatives of $\dfrac{\partial P}{\partial \delta}$, $\dfrac{\partial P}{\partial U}$, $\dfrac{\partial Q}{\partial \delta}$
+derivatives of
+$\dfrac{\partial P}{\partial \delta}$, $\dfrac{\partial P}{\partial U}$, $\dfrac{\partial Q}{\partial \delta}$
 and $\dfrac{\partial Q}{\partial U}$.
 
 For each iteration the following steps are executed:
@@ -380,12 +382,15 @@ The algorithm is as follows:
 3. Calculate injected currents: $I_N^i$ for $i^{th}$ iteration.
    The injected currents are calculated as per ZIP model of loads and generation using $U_N$.
    $
-       \begin{eqnarray}
-           I_N = \overline{S_{Z}} \cdot U_{N} + \overline{(\frac{S_{I}}{U_{N}})} \cdot |U_{N}| + \overline{(\frac{S_{P}}{U_N})}
-       \end{eqnarray}
+     \begin{eqnarray}
+       I_N = \overline{S_{Z}} \cdot U_{N}
+             + \overline{(\frac{S_{I}}{U_{N}})} \cdot |U_{N}|
+             + \overline{(\frac{S_{P}}{U_N})}
+     \end{eqnarray}
    $
 4. Solve linear equation: $YU_N^i = I_N^i$
-5. Check convergence: If maximum voltage deviation from the previous iteration is greater than the tolerance setting (ie. $u^{(i-1)}_\sigma > u_\epsilon$), then go back to step 3.
+5. Check convergence: If maximum voltage deviation from the previous iteration is greater than the tolerance setting
+   (ie. $u^{(i-1)}_\sigma > u_\epsilon$), then go back to step 3.
 
 The iterative current algorithm only needs to calculate injected currents before solving linear equations.
 This is more straightforward than calculating the Jacobian, which was done in the Newton-Raphson algorithm.
@@ -425,7 +430,7 @@ Algorithm call: {py:class}`CalculationMethod.linear_current <power_grid_model.en
 
 This approximation method will give better results when most of the load/generation types resemble constant current.
 Similar to [iterative current](#iterative-current-power-flow), batch calculations like timeseries will also be faster.
-Same reason applies here: the $Y_{bus}$ matrix does not change across batches and as a result the same factorization 
+Same reason applies here: the $Y_{bus}$ matrix does not change across batches and as a result the same factorization
 ould be used.
 
 In practical grids most loads and generations correspond to the constant power type.
@@ -459,9 +464,9 @@ The goal of WLS state estimation is to evaluate the state variable with the high
 measurement input, by solving:
 
 $$
-   \begin{eqnarray}
-            \min r(\underline{U}) = \dfrac{1}{2} (f(\underline{U}) - \underline{z})^H W (f(\underline{U}) - \underline{z})
-   \end{eqnarray}
+  \begin{eqnarray}
+    \min r(\underline{U}) = \dfrac{1}{2} (f(\underline{U}) - \underline{z})^H W (f(\underline{U}) - \underline{z})
+  \end{eqnarray}
 $$
 
 Where:
@@ -498,9 +503,9 @@ $$
     \end{eqnarray}
 $$
 
-Where $\underline{x}_i$ is the real value of the i-th measured quantity in complex form, $\underline{z}_i$ is the i-th measured value in complex form,
-$\sigma_i$ is the normalized standard deviation of the measurement error of the i-th measurement, $\Sigma$ is the normalized covariance matrix
-and $W$ is the weighting factor matrix.
+Where $\underline{x}_i$ is the real value of the i-th measured quantity in complex form, $\underline{z}_i$ is the i-th
+measured value in complex form, $\sigma_i$ is the normalized standard deviation of the measurement error of the i-th
+measurement, $\Sigma$ is the normalized covariance matrix and $W$ is the weighting factor matrix.
 
 At the moment, the following state estimation algorithms are implemented.
 
@@ -516,8 +521,7 @@ By default, the [iterative linear](#iterative-linear-state-estimation) method is
 #### State estimation measurement aggregation
 
 There can be multiple sensors measuring the same physical quantity.
-For example, there can be multiple
-voltage sensors on the same bus.
+For example, there can be multiple voltage sensors on the same bus.
 The measurement data can be merged into one virtual measurement using a Kalman filter:
 
 $$
@@ -540,38 +544,49 @@ $$
     \end{eqnarray}
 $$
 
-Where $S_k$ and $\sigma_{P,k}$ and $\sigma_{Q,k}$ are the measured value and the standard deviation of the individual appliances.
+Where $S_k$ and $\sigma_{P,k}$ and $\sigma_{Q,k}$ are the measured value and the standard deviation of the individual
+appliances.
 
 ```{note}
-It is not possible to mix [power sensors](./components.md#generic-current-sensor) with [current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
-It is also not possible to mix [current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with [current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is not possible to mix [power sensors](./components.md#generic-current-sensor) with
+[current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is also not possible to mix
+[current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with
+[current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the
+same component.
 However, such mixing of sensor types is allowed as long as they are on different terminals.
 ```
 
 #### State estimate sensor transformations
 
 Sometimes, measurements need to be transformed between coordinate spaces.
-For example, current measurements are in polar coordinates (magnitude and angle), but it is beneficial to transform them to separate real and imaginary components per phase, with each their own variances.
+For example, current measurements are in polar coordinates (magnitude and angle), but it is beneficial to transform them
+to separate real and imaginary components per phase, with each their own variances.
 Variances of the results of such transformations are estimated using the common linearization approximation.
-E.g., for a real random variable $X$, the random variable $Y = F\left(X\right)$, with $F$ sufficiently well-behaved, exists.
+E.g., for a real random variable $X$, the random variable $Y = F\left(X\right)$, with $F$ sufficiently well-behaved,
+exists.
 The variances of $Y$ can then be estimated from the variance of $X$ using
 $\text{Var}\left(Y\right) \approx \text{Var}\left(X\right) \left\|\frac{\delta f}{\delta X}\right\|^2$
 
 This approach generalizes to extension fields and to more dimensions.
 Both generalizations are required for current sensors.
-The current phasor is described by a complex random variable, which can be decomposed into a real and an imaginary component, or into a magnitude and a phasor.
+The current phasor is described by a complex random variable, which can be decomposed into a real and an imaginary
+component, or into a magnitude and a phasor.
 Asymmetric sensors and asymmetric calculations, on the other hand, require multidimensional approaches.
 The generalization is done as follows.
 
 Let $A$ and $B$ be fields (or rings) that may be multidimensional and that may be extension fields.
 Let $\boldsymbol{X}$ be a random variable with codomain $A$ with components $X_i$.
-Let $\boldsymbol{Y} = \boldsymbol{F}\left(\boldsymbol{X}\right)$ be a random variable with codomain $B$, with $\boldsymbol{F}$ sufficiently well-behaved,
+Let $\boldsymbol{Y} = \boldsymbol{F}\left(\boldsymbol{X}\right)$ be a random variable with codomain $B$, with
+$\boldsymbol{F}$ sufficiently well-behaved,
 so that its components $Y_j = F_j\left(\boldsymbol{X}\right)$ are well-behaved.
-Then the variances $\text{Var}\left(Y_i\right)$ of the components of $\boldsymbol{Y}$ can be estimated
-in terms of the variances $\text{Var}\left(X_j\right)$ of the components of $\boldsymbol{X}$ using the following function.
+Then the variances $\text{Var}\left(Y_i\right)$ of the components of $\boldsymbol{Y}$ can be estimated in terms of the
+variances $\text{Var}\left(X_j\right)$ of the components of $\boldsymbol{X}$ using the following function.
 
 $$
-\text{Var}\left(Y_j\right) = \text{Var}\left(F_j\left(\boldsymbol{X}\right)\right) \approx \sum_i \text{Var}\left(X_i\right) \left\|\frac{\delta F_j}{\delta x_i}\left(\boldsymbol{X}\right)\right\|^2
+\text{Var}\left(Y_j\right)
+    = \text{Var}\left(F_j\left(\boldsymbol{X}\right)\right)
+    \approx \sum_i \text{Var}\left(X_i\right) \left\|\frac{\delta F_j}{\delta x_i}\left(\boldsymbol{X}\right)\right\|^2
 $$
 
 The following illustrates how this works for `sym_current_sensor`s in symmetric calculations.
@@ -581,25 +596,27 @@ $$
    \begin{eqnarray}
         & \mathrm{Re}\left\{I\right\} = I \cos\theta \\
         & \mathrm{Im}\left\{I\right\} = I \sin\theta \\
-        & \text{Var}\left(\mathrm{Re}\left\{I\right\}\right) = \sigma_i^2 \cos^2\theta + I^2 \sigma_{\theta}^2\sin^2\theta \\
-        & \text{Var}\left(\mathrm{Im}\left\{I\right\}\right) = \sigma_i^2 \sin^2\theta + I^2 \sigma_{\theta}^2\cos^2\theta
+        & \text{Var}\left(\mathrm{Re}\left\{I\right\}\right) =
+            \sigma_i^2 \cos^2\theta + I^2 \sigma_{\theta}^2\sin^2\theta \\
+        & \text{Var}\left(\mathrm{Im}\left\{I\right\}\right) =
+            \sigma_i^2 \sin^2\theta + I^2 \sigma_{\theta}^2\cos^2\theta
    \end{eqnarray}
 $$
 
 #### Iterative linear state estimation
 
-Algorithm call: {py:class}`CalculationMethod.iterative_linear <power_grid_model.enum.CalculationMethod.iterative_linear>`
+Algorithm call:
+{py:class}`CalculationMethod.iterative_linear <power_grid_model.enum.CalculationMethod.iterative_linear>`
 
 Linear WLS requires all measurements to be linear and only handles voltage phasor measurements including a phase angle,
 as well as complex current phasor measurements.
-This is only possible when all measurements are phasor unit measurements,
-which is not realistic in distribution grids.
+This is only possible when all measurements are phasor unit measurements, which is not realistic in distribution grids.
 Therefore, traditional measurements are linearized prior to running the algorithm.
 
-- Bus voltage: Given that the phase shift in the distribution grid is very small,
-  it is assumed that the angle shift is zero plus the intrinsic phase shift of transformers.
-  For a certain bus `i`, the voltage
-  magnitude measured at that bus is translated into a voltage phasor, where $\theta_i$ is the intrinsic transformer phase shift:
+- Bus voltage: Given that the phase shift in the distribution grid is very small, it is assumed that the angle shift is
+  zero plus the intrinsic phase shift of transformers.
+  For a certain bus `i`, the voltage magnitude measured at that bus is translated into a voltage phasor, where
+  $\theta_i$ is the intrinsic transformer phase shift:
 
 $$
     \begin{eqnarray}
@@ -607,13 +624,12 @@ $$
     \end{eqnarray}
 $$
 
-- Branch current with global angle: The global angle current measurement captures
-the phase offset relative to the same predetermined reference phase against which the voltage angle is measured.
-It is not
-sufficient to use the default zero-phase reference offset, because the reference point is not uniquely determined when there
-are no voltage angle measurements, resulting in ambiguities.
-As a result, using any global angle current sensor in the grid
-requires at least one voltage phasor measurement (with angle).
+- Branch current with global angle: The global angle current measurement captures the phase offset relative to the same
+  predetermined reference phase against which the voltage angle is measured.
+  It is not sufficient to use the default zero-phase reference offset, because the reference point is not uniquely
+  determined when there are no voltage angle measurements, resulting in ambiguities.
+  As a result, using any global angle current sensor in the grid requires at least one voltage phasor measurement (with
+  angle).
 
 $$
     \begin{eqnarray}
@@ -621,17 +637,15 @@ $$
     \end{eqnarray}
 $$
 
-- Branch current with local angle: Sometimes, (accurate) voltage measurements are not available for a branch,
-which means no power measurement is possible.
-While it is not straightforward to use magnitude-only measurements of currents in
-calculations, current phasor measurements can in fact be used in cases where it is possible to obtain a reasonably accurate
-measurement of the current amplitude and the relative phase angle to the voltage.
-In this way, we still have enough information
-for the state estimation.
-The resulting local current phasor $\underline{I}_{\text{local}}$ can be translated to the global
-current phasor (see above) for iterative linear state estimation.
-Given the measured (linearized) voltage phasor,
-the current phasor is calculated as follows:
+- Branch current with local angle: Sometimes, (accurate) voltage measurements are not available for a branch, which
+  means no power measurement is possible.
+  While it is not straightforward to use magnitude-only measurements of currents in calculations, current phasor
+  measurements can in fact be used in cases where it is possible to obtain a reasonably accurate measurement of the
+  current amplitude and the relative phase angle to the voltage.
+  In this way, we still have enough information for the state estimation.
+  The resulting local current phasor $\underline{I}_{\text{local}}$ can be translated to the global current phasor (see
+  above) for iterative linear state estimation.
+  Given the measured (linearized) voltage phasor, the current phasor is calculated as follows:
 
 $$
     \begin{equation}
@@ -640,13 +654,13 @@ $$
     \end{equation}
 $$
 
-where $\underline{U}$ is either measured voltage magnitude at the bus or assumed unity magnitude, with the intrinsic phase shift.
+where $\underline{U}$ is either measured voltage magnitude at the bus or assumed unity magnitude, with the intrinsic
+phase shift.
 $\theta$ is the phase angle of the voltage.
 
 - Branch/shunt power flow: To translate the power flow to a complex current phasor, the voltage at the terminal should
-also be measured, otherwise the nominal voltage with zero angle is used as an estimation.
-Given the measured (linearized) voltage
-phasor, the current phasor is calculated as follows:
+  also be measured, otherwise the nominal voltage with zero angle is used as an estimation.
+  Given the measured (linearized) voltage phasor, the current phasor is calculated as follows:
 
 $$
     \begin{eqnarray}
@@ -654,9 +668,9 @@ $$
     \end{eqnarray}
 $$
 
-- Bus power injection: Similar as above, to translate the power flow to a complex current phasor, if the bus voltage is not measured,
-the nominal voltage with zero angle will be used as an estimation.
-The current phasor is calculated as follows:
+- Bus power injection: Similar as above, to translate the power flow to a complex current phasor, if the bus voltage is
+  not measured, the nominal voltage with zero angle will be used as an estimation.
+  The current phasor is calculated as follows:
 
 $$
     \begin{eqnarray}
@@ -664,47 +678,46 @@ $$
     \end{eqnarray}
 $$
 
-The aggregated apparent power flow is considered as a single measurement, with variance $\sigma_S^2 = \sigma_P^2 + \sigma_Q^2$.
+The aggregated apparent power flow is considered as a single measurement, with variance
+$\sigma_S^2 = \sigma_P^2 + \sigma_Q^2$.
 
-The assumption made in the linearization of measurements introduces a system error to the algorithm, because the phase shifts of
-bus voltages are ignored in the input measurement data.
-This error is corrected by applying an iterative approach to the linear WLS
-algorithm.
+The assumption made in the linearization of measurements introduces a system error to the algorithm, because the phase
+shifts of bus voltages are ignored in the input measurement data.
+This error is corrected by applying an iterative approach to the linear WLS algorithm.
 In each iteration, the resulted voltage phase angle will be applied as the phase shift of the measured voltage phasor
 for the next iteration:
 
 - Initialization: let $\underline{U}^{(k)}$ be the column vector of the estimated voltage phasor in the k-th iteration.
-Let Bus $s$
-be the slack bus, which is connected to the external network (source).
-$\underline{U}^{(0)}$ is initialized as follows:
-  - For bus $i$, if there is no voltage measurement, assign $\underline{U}^{(0)} = e^{j \theta_i}$, where $\theta_i$ is the intrinsic
-  transformer phase shift between Bus $i$ and Bus $s$.
-  - For bus $i$, if there is a voltage measurement, assign $\underline{U}^{(0)} = U_{meas,i}e^{j \theta_i}$, where $U_{meas,i}$ is
-  the measured voltage magnitude.
+  Let Bus $s$ be the slack bus, which is connected to the external network (source).
+  $\underline{U}^{(0)}$ is initialized as follows:
+  - For bus $i$, if there is no voltage measurement, assign $\underline{U}^{(0)} = e^{j \theta_i}$, where $\theta_i$ is
+    the intrinsic transformer phase shift between Bus $i$ and Bus $s$.
+  - For bus $i$, if there is a voltage measurement, assign $\underline{U}^{(0)} = U_{meas,i}e^{j \theta_i}$, where
+    $U_{meas,i}$ is the measured voltage magnitude.
 - In iteration $k$, follow the steps below:
   - Linearize the voltage measurements by using the phase angle of the calculated voltages of iteration $k-1$.
-  - Linearize the complex power flow measurements by using either the linearized voltage measurement if the bus is measured, or
-  the voltage phasor result from iteration $k-1$.
+  - Linearize the complex power flow measurements by using either the linearized voltage measurement if the bus is
+    measured, or the voltage phasor result from iteration $k-1$.
   - Compute the temporary new voltage phasor $\underline{\tilde{U}}^{(k)}$ using the pre-factorized matrix.
-  See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
+    See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
   - Normalize the voltage phasor angle by setting the angle of the slack bus to zero:
-  - If the maximum deviation between $\underline{U}^{(k)}$ and $\underline{U}^{(k-1)}$ is smaller than the error tolerance $\epsilon$,
-  stop the iteration.
-  Otherwise, continue until the maximum number of iterations is reached.
+  - If the maximum deviation between $\underline{U}^{(k)}$ and $\underline{U}^{(k-1)}$ is smaller than the error
+    tolerance $\epsilon$, stop the iteration.
+    Otherwise, continue until the maximum number of iterations is reached.
 
-In the iteration process, the phase angle of voltages at each bus is updated using the last iteration;
-the system error of the phase shift converges to zero.
-Because the matrix is pre-built and
-pre-factorized, the computation cost of each iteration is much smaller than for the [Newton-Raphson](#newton-raphson-state-estimation)
-method, where the Jacobian matrix needs to be constructed and factorized each time.
+In the iteration process, the phase angle of voltages at each bus is updated using the last iteration; the system error
+of the phase shift converges to zero.
+Because the matrix is pre-built and pre-factorized, the computation cost of each iteration is much smaller than for the
+[Newton-Raphson](#newton-raphson-state-estimation) method, where the Jacobian matrix needs to be constructed and
+factorized each time.
 
-Because the matrix depends on the variances of the linearized current measurements, pre-factorization
-requires assuming that the magnitudes of the voltages remain constant throughout the iteration process.
-This assumption is, of course, an approximation, and potentially results an inaccurate relative weighing
-of the power measurements.
-However, the difference between the solution and the actual grid state is
-usually small, because the error introduced by this is typically dominated by the following contributing
-factors (see also [this thread](https://github.com/PowerGridModel/power-grid-model/pull/951#issuecomment-2805154436)).
+Because the matrix depends on the variances of the linearized current measurements, pre-factorization requires assuming
+that the magnitudes of the voltages remain constant throughout the iteration process.
+This assumption is, of course, an approximation, and potentially results an inaccurate relative weighing of the power
+measurements.
+However, the difference between the solution and the actual grid state is usually small, because the error introduced by
+this is typically dominated by the following contributing factors (see also
+[this thread](https://github.com/PowerGridModel/power-grid-model/pull/951#issuecomment-2805154436)).
 
 - voltages in the distribution grid are usually close to 1 p.u..
 - power sensor errors are usually best-effort estimates.
@@ -712,12 +725,14 @@ factors (see also [this thread](https://github.com/PowerGridModel/power-grid-mod
 
 ```{warning}
 In short, the pre-factorization may produce results that may deviate from the actual grid state.
-If higher precision is desired, please consider using [Newton-Raphson state estimation](#newton-raphson-state-estimation) instead.
+If higher precision is desired, please consider using
+[Newton-Raphson state estimation](#newton-raphson-state-estimation) instead.
 ```
 
 ```{warning}
 The algorithm will assume angles to be zero by default (see the details about voltage sensors).
-This produces more correct outputs when the system is observable, but will prevent the calculation from raising an exception, even if it is unobservable, therefore giving faulty results.
+This produces more correct outputs when the system is observable, but will prevent the calculation from raising an
+exception, even if it is unobservable, therefore giving faulty results.
 ```
 
 #### Newton-Raphson state estimation
@@ -726,35 +741,41 @@ Algorithm call: {py:class}`CalculationMethod.newton_raphson <power_grid_model.en
 
 The Newton-Raphson state estimation considers the problem as a system of real, non-linear equations.
 It iteratively solves the first order Taylor expansion of the system.
-It does not make any assumptions on linearization
-It could be more accurate and converge in less iterations than the [iterative linear](#iterative-linear-state-estimation) approach.
-However, the Jacobian matrix needs to be calculated every iteration and cannot be prefactorized, which makes it slower on average.
+It does not make any assumptions on linearization.
+It could be more accurate and converge in less iterations than the
+[iterative linear](#iterative-linear-state-estimation) approach.
+However, the Jacobian matrix needs to be calculated every iteration and cannot be prefactorized, which makes it slower
+on average.
 
 The Newton-Raphson method considers all measurements to be independent real measurements.
 I.e., $\sigma_P$, $\sigma_Q$ and $\sigma_U$ are all independent values.
-The rationale behind to calculation is similar to that of the [Newton-Raphson method for power flow](#newton-raphson-power-flow).
-Consequently, the iteration process differs slightly from that of [iterative linear state estimation](#iterative-linear-state-estimation), as shown below.
+The rationale behind to calculation is similar to that of the
+[Newton-Raphson method for power flow](#newton-raphson-power-flow).
+Consequently, the iteration process differs slightly from that of
+[iterative linear state estimation](#iterative-linear-state-estimation), as shown below.
 
-- Initialization: let $\boldsymbol{U}^{(k)}$ be the column vector of the estimated voltage magnitude and $\boldsymbol{\theta}^{(k)}$ the column vector of the
-estimated voltage angle in k-th iteration.
-Let Bus $s$ be the slack bus which is connected to external network (source).
-We initialize $\boldsymbol{U}^{(0)}$ and $\boldsymbol{\theta}^{(k)}$ as follows:
-  - For Bus $i$, if there is no voltage measurement, assign $U_i^{(0)} = 1$ and $\theta_i^{(0)} = 0$,
-  where $\theta_i$ is the intrinsic transformer phase shift between Bus $i$ and Bus $s$.
+- Initialization: let $\boldsymbol{U}^{(k)}$ be the column vector of the estimated voltage magnitude and
+  $\boldsymbol{\theta}^{(k)}$ the column vector of the estimated voltage angle in k-th iteration.
+  Let Bus $s$ be the slack bus which is connected to external network (source).
+  We initialize $\boldsymbol{U}^{(0)}$ and $\boldsymbol{\theta}^{(k)}$ as follows:
+  - For Bus $i$, if there is no voltage measurement, assign $U_i^{(0)} = 1$ and $\theta_i^{(0)} = 0$, where $\theta_i$
+    is the intrinsic transformer phase shift between Bus $i$ and Bus $s$.
   - For Bus $i$, if there is a voltage measurement, $U_i^{(0)} = U_{\text{mea},i}$ and $\theta_i^{(0)} = \theta_i$,
-  where $U_{\text{mea},i}$ is the measured voltage magnitude.
+    where $U_{\text{mea},i}$ is the measured voltage magnitude.
 - In iteration $k$, follow the steps below:
   - Construct and (LU-)factorize the Jacobian matrix for $\boldsymbol{x}^{(k)}$, using the network parameters.
-  - Compute the temporary new voltage magnitude and angle result, $\widetilde{\boldsymbol{U}}^{(k)}$ and $\widetilde{\boldsymbol{\theta}}^{(k)}$,
-  using the prefactorized matrix.
-  See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
+  - Compute the temporary new voltage magnitude and angle result,
+    $\widetilde{\boldsymbol{U}}^{(k)}$ and $\widetilde{\boldsymbol{\theta}}^{(k)}$, using the prefactorized matrix.
+    See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
   - Normalize the result voltage phasor angle by setting angle of slack bus to zero:
-  $\underline{U}_i^{(k)} = \widetilde{\underline{U}}_i^{(k)} \times |\widetilde{\underline{U}}_s^{(k)}| / \widetilde{\underline{U}}_s^{(k)}$.
-  - If the maximum deviation between $\underline{\boldsymbol{U}}^{(k)}$ and $\underline{\boldsymbol{U}}^{(k-1)}$ is smaller than the tolerance $\epsilon$,
-  stop the iteration, otherwise continue until the maximum number of iterations is reached.
-  Note: we're using the phasor here: $\underline{\boldsymbol{U}} = \boldsymbol{U}e^{j\boldsymbol{\theta}}$.
+    $\underline{U}_i^{(k)} = \widetilde{\underline{U}}_i^{(k)} \times |\widetilde{\underline{U}}_s^{(k)}| / \widetilde{\underline{U}}_s^{(k)}$. <!-- markdownlint-disable-line MD013 -->
+  - If the maximum deviation between $\underline{\boldsymbol{U}}^{(k)}$ and $\underline{\boldsymbol{U}}^{(k-1)}$ is
+    smaller than the tolerance $\epsilon$, stop the iteration, otherwise continue until the maximum number of iterations
+    is reached.
+    Note: we're using the phasor here: $\underline{\boldsymbol{U}} = \boldsymbol{U}e^{j\boldsymbol{\theta}}$.
 
-As for the [iterative linear](#iterative-linear-state-estimation) approach, during iterations, phase angles of voltage at each bus are updated using ones from the previous iteration.
+As for the [iterative linear](#iterative-linear-state-estimation) approach, during iterations, phase angles of voltage
+at each bus are updated using ones from the previous iteration.
 The system error of the phase shift converges to zero.
 
 ```{note}
@@ -770,7 +791,8 @@ On the other hand with unobservable systems, exceptions raised from calculations
 
 ### Short circuit calculation algorithms
 
-In the short circuit calculation, the following equations are solved with border conditions of faults added as constraints.
+In the short circuit calculation, the following equations are solved with border conditions of faults added as
+constraints.
 
 $$ \begin{eqnarray} I_N & = Y_{bus}U_N \end{eqnarray} $$
 
@@ -787,16 +809,20 @@ At the moment, the following short circuit algorithms are implemented.
 
 Algorithm call: {py:class}`CalculationMethod.iec60909 <power_grid_model.enum.CalculationMethod.iec60909>`
 
-The assumptions used for calculations in power-grid-model are aligned to the ones mentioned in [IEC 60909](https://webstore.iec.ch/publication/24100).
+The assumptions used for calculations in power-grid-model are aligned to the ones mentioned in
+[IEC 60909](https://webstore.iec.ch/publication/24100).
 
 - The state of the grid with respect to loads and generations are ignored for the short circuit calculation.
   (Note: Shunt admittances are included in calculation.)
 - The pre-fault voltage is considered in the calculation and is calculated based on the grid parameters and topology.
   (Excl. loads and generation)
 - The calculations are assumed to be time-independent.
-(Voltages are sine throughout with the fault occurring at a zero crossing of the voltage, the complexity of rotating machines and harmonics are neglected, etc.)
-- To account for the different operational conditions, a voltage scaling factor of `c` is applied to the voltage source while running short circuit calculation function.
-  The factor `c` is determined by the nominal voltage of the node that the source is connected to and the API option to calculate the `minimum` or `maximum` short circuit currents.
+  (Voltages are sine throughout with the fault occurring at a zero crossing of the voltage, the complexity of rotating
+  machines and harmonics are neglected, etc.)
+- To account for the different operational conditions, a voltage scaling factor of `c` is applied to the voltage source
+  while running short circuit calculation function.
+  The factor `c` is determined by the nominal voltage of the node that the source is connected to and the API option to
+  calculate the `minimum` or `maximum` short circuit currents.
   The table to derive `c` according to IEC 60909 is shown below.
 
 | Algorithm      | c_max | c_min |
@@ -805,11 +831,13 @@ The assumptions used for calculations in power-grid-model are aligned to the one
 | `U_nom` > 1kV  | 1.10  | 1.00  |
 
 ```{note}
-In the IEC 609090 standard, there is a difference in `c` (for `U_nom` <= 1kV) for systems with a voltage tolerance of 6% and 10%.
+In the IEC 609090 standard, there is a difference in `c` (for `U_nom` <= 1kV) for systems with a voltage tolerance of 6%
+and 10%.
 In power-grid-model we only use the value for a 10% voltage tolerance.
 ```
 
-There are {py:class}`4 types <power_grid_model.enum.FaultType>` of fault situations that can occur in the grid, along with the following possible combinations of the {py:class}`associated phases <power_grid_model.enum.FaultType>`:
+There are {py:class}`4 types <power_grid_model.enum.FaultType>` of fault situations that can occur in the grid, along
+with the following possible combinations of the {py:class}`associated phases <power_grid_model.enum.FaultType>`:
 
 - Three-phase to ground: `abc`
 - Single phase to ground: `a`, `b`, `c`
@@ -830,9 +858,12 @@ Please refer to their respective sections for detailed documentation.
 #### Power flow with automatic tap changing
 
 Some of the most important regulators in the grid affect the tap position of transformers.
-These {hoverxreftooltip}`user_manual/components:Transformer Tap Regulator`s try to regulate a control voltage $U_{\text{control}}$ such that it is within a specified voltage band.
+These {hoverxreftooltip}`user_manual/components:Transformer Tap Regulator`s try to regulate a control voltage
+$U_{\text{control}}$ such that it is within a specified voltage band.
 The $U_{\text{control}}$ may be compensated for the voltage drop during transport.
-Power flow calculations that take the behavior of these regulators into account may be toggled by providing one of the following strategies to the {py:meth}`tap_changing_strategy <power_grid_model.PowerGridModel.calculate_power_flow>` option.
+Power flow calculations that take the behavior of these regulators into account may be toggled by providing one of the
+following strategies to the {py:meth}`tap_changing_strategy <power_grid_model.PowerGridModel.calculate_power_flow>`
+option.
 
 | Algorithm                                                                   | Default  | Speed    | Algorithm call                                                                                              |
 | --------------------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
@@ -845,56 +876,76 @@ Power flow calculations that take the behavior of these regulators into account 
 ##### Control logic for power flow with automatic tap changing
 
 We provide the control logic used for tap changing.
-For simplicity, we demonstrate the case where the regulator control side and the transformer tap side are at different sides.
+For simplicity, we demonstrate the case where the regulator control side and the transformer tap side are at different
+sides.
 
-- Regulated transformers are ranked according to how close they are to {hoverxreftooltip}`sources <user_manual/components:source>` in terms of the amount of regulated transformers inbetween.
+- Regulated transformers are ranked according to how close they are to
+  {hoverxreftooltip}`sources <user_manual/components:source>` in terms of the amount of regulated transformers
+  inbetween.
   In the presence of meshed grids, transformers with conflicting ranks will be ranked the last.
   - Transformers are regulated in order according to their ranks.
-- Initialize all transformers to their starting tap position (see {hoverxreftooltip}`user_manual/calculations:Initialization and exploitation of regulated transformers`)
+- Initialize all transformers to their starting tap position (see
+  {hoverxreftooltip}`user_manual/calculations:Initialization and exploitation of regulated transformers`)
 - Find the optimal state using the following procedure
   - While some transformers can still be further regulated, iterate as follows:
-    - Run a power flow calculation with the current tap positions with the specified [calculation method](#power-flow-algorithms).
-    - Start with the transformers ranked closest to a {hoverxreftooltip}`user_manual/components:source` (because the source provides a relatively stable voltage level and these transformers will have a high impact on the rest of the grid).
+    - Run a power flow calculation with the current tap positions with the specified
+      [calculation method](#power-flow-algorithms).
+    - Start with the transformers ranked closest to a {hoverxreftooltip}`user_manual/components:source` (because the
+      source provides a relatively stable voltage level and these transformers will have a high impact on the rest of
+      the grid).
     - Loop over all ranks:
       - Loop over all transformers within this rank; transformers with the same rank are independently regulated:
         - If the $U_{\text{control}} < U_{\text{set}} - \frac{U_{\text{band}}}{2}$:
           - The ratio between the voltage on the tap side and the voltage on the control side is too high.
           - To decrease this ratio, the tap ratio must be decreased.
-          - Therefore, the tap position of the regulated transformer is decreased if it satisfies the bounds set by `tap_min` and `tap_max`.
+          - Therefore, the tap position of the regulated transformer is decreased if it satisfies the bounds set by
+            `tap_min` and `tap_max`.
         - If, however, the $U_{\text{control}} > U_{\text{set}} + \frac{U_{\text{band}}}{2}$:
           - The ratio between the voltage on the tap side and the voltage on the control side is too low.
           - To increase this ratio, the tap ratio must be increase.
-          - Therefore, the tap position of the regulated transformer is increased if it satisfies the bounds set by `tap_min` and `tap_max`.
+          - Therefore, the tap position of the regulated transformer is increased if it satisfies the bounds set by
+            `tap_min` and `tap_max`.
         - If the tap position of this transformer did not change, the transformer is considered regulated.
       - If not all transformers within this rank are regulated:
         - A better combination of tap positions may have been found.
         - Step out of the loop and go to the next iteration step.
-  - Exploit the neighbourhood of all transformers (see {hoverxreftooltip}`user_manual/calculations:Initialization and exploitation of regulated transformers`)
+  - Exploit the neighbourhood of all transformers (see
+    {hoverxreftooltip}`user_manual/calculations:Initialization and exploitation of regulated transformers`)
     - Re-run the iteration in the above if any of the tap positions changed by the exploitation.
 
-In the case where the control side of the regulator and the tap side of the transformer are at the same side, the control logic of taps will be reverted (see `user_manual/calculations:Initialization and exploitation of regulated transformers`).
-The exploitation of the neighbourhood ensures that the actual optimum is not accidentally missed due to feedback mechanisms in the grid.
+In the case where the control side of the regulator and the tap side of the transformer are at the same side, the
+control logic of taps will be reverted (see
+`user_manual/calculations:Initialization and exploitation of regulated transformers`).
+The exploitation of the neighbourhood ensures that the actual optimum is not accidentally missed due to feedback
+mechanisms in the grid.
 
 ```{note}
 For iterative [power flow calculation methods](#power-flow-algorithms), the initial state may not converge.
 If the iterative process failed to converge, the optimization procedure is executed twice.
-First, the {py:class}`linear <power_grid_model.enum.CalculationMethod.linear>` calculation method is used to find an approximate solution.
-The optimization procedure is then run a second time to find the actual optimum with the user-specified calculation method.
+First, the {py:class}`linear <power_grid_model.enum.CalculationMethod.linear>` calculation method is used to find an
+approximate solution.
+The optimization procedure is then run a second time to find the actual optimum with the user-specified calculation
+method.
 ```
 
 ```{note}
-The control logic assumes that changes in the voltage level at a transformer are dominated by changes in the tap position of the transformer itself, rather than by adjacent transformers.
-This assumption is reflected in the requirements mentioned in {hoverxreftooltip}`user_manual/components:Transformer Tap Regulator`.
+The control logic assumes that changes in the voltage level at a transformer are dominated by changes in the tap
+position of the transformer itself, rather than by adjacent transformers.
+This assumption is reflected in the requirements mentioned in
+{hoverxreftooltip}`user_manual/components:Transformer Tap Regulator`.
 ```
 
 ```{note}
-If the line drop compensation impedance is high, and the control side has generator-like behavior, then this assumption does not hold, and the calculation may diverge.
-Hence, this assumption is reflected in the requirements mentioned in {hoverxreftooltip}`user_manual/components:Line drop compensation`.
+If the line drop compensation impedance is high, and the control side has generator-like behavior, then this assumption
+does not hold, and the calculation may diverge.
+Hence, this assumption is reflected in the requirements mentioned in
+{hoverxreftooltip}`user_manual/components:Line drop compensation`.
 ```
 
 ##### Initialization and exploitation of regulated transformers
 
-Internally, to achieve an optimal regulated tap position, the control algorithm sets initial tap positions and exploits neighborhoods around local optima, depending on the strategy as follows.
+Internally, to achieve an optimal regulated tap position, the control algorithm sets initial tap positions and exploits
+neighborhoods around local optima, depending on the strategy as follows.
 
 | strategy                                                                                                    | initial tap position | exploitation direction | search method | description                                                                           |
 | ----------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------- | ------------- | ------------------------------------------------------------------------------------- |
@@ -910,7 +961,8 @@ Internally, to achieve an optimal regulated tap position, the control algorithm 
 
 ##### Search methods used for tap changing optimization
 
-Given the discrete nature of the finite tap ranges, we use the following search methods to find the next tap position along the exploitation direction.
+Given the discrete nature of the finite tap ranges, we use the following search methods to find the next tap position
+along the exploitation direction.
 
 | Search method | Description                                                                                     |
 | ------------- | ----------------------------------------------------------------------------------------------- |
@@ -921,30 +973,40 @@ Given the discrete nature of the finite tap ranges, we use the following search 
 
 Usually, a single power-flow or state estimation calculation would not be enough to get insights in the grid.
 Any form of multiple calculations can be carried out in power-grid-model using batch calculations.
-Batches are not restricted to any particular type of calculations, like timeseries or contingency analysis or their combination.
-They can be used for determining hosting/loading capacity, determining optimal tap positions, estimating system losses, monte-carlo simulations or any other form of multiple calculations required in a power-flow study.
+Batches are not restricted to any particular type of calculations, like timeseries or contingency analysis or their
+combination.
+They can be used for determining hosting/loading capacity, determining optimal tap positions, estimating system losses,
+monte-carlo simulations or any other form of multiple calculations required in a power-flow study.
 The framework for creating the batches is the same for all types of calculations.
-For every component, the attributes that can be updated in a batch scenario are mentioned in [Components](components.md).
-Examples of batch calculations for timeseries and contingency analysis are given in [Power Flow Example](../examples/Power%20Flow%20Example.ipynb)
+For every component, the attributes that can be updated in a batch scenario are mentioned in
+[Components](components.md).
+Examples of batch calculations for timeseries and contingency analysis are given in
+[Power Flow Example](../examples/Power%20Flow%20Example.ipynb)
 
-The same method as for single calculations, {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`, can be used to calculate a number of scenarios in one go.
+The same method as for single calculations, {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`, can be
+used to calculate a number of scenarios in one go.
 To do this, you need to supply an `update_data` keyword argument.
 This keyword argument contains a dictionary of 2D update arrays (one array per component type).
 
 The performance for different batches vary.
 power-grid-model automatically makes efficient calculations whenever possible.
-See the [Performance Guide](performance-guide.md#topology-caching) for ways to optimally use the performance optimizations.
+See the [Performance Guide](performance-guide.md#topology-caching) for ways to optimally use the performance
+optimizations.
 
 ### Batch data set
 
-The parameters of the individual scenarios within a batch can be done by providing deltas compared to the existing state of the model.
-The values of unchanged attributes and components parameters within a scenario may be implicit (like a delta update) or explicit (similarly to how one would provide a full state).
-In the context of the power-grid-model, these are called **dependent** (implicit) and **independent** (explicit) batch updates, respectively.
+The parameters of the individual scenarios within a batch can be done by providing deltas compared to the existing state
+of the model.
+The values of unchanged attributes and components parameters within a scenario may be implicit (like a delta update) or
+explicit (similarly to how one would provide a full state).
+In the context of the power-grid-model, these are called **dependent** (implicit) and **independent** (explicit) batch
+updates, respectively.
 In both cases, all scenario updates are relative to the state of the model before the call of the calculation.
 See the examples below for usage.
 
 - Dependent batches are useful for a sparse sampling for many different components, e.g. for N-1 checks.
-- Independent batches are useful for a dense sampling of a small subset of components, e.g. time series power flow calculation.
+- Independent batches are useful for a dense sampling of a small subset of components, e.g. time series power flow
+  calculation.
 
 See the [Performance Guide](performance-guide.md#using-independent-batches) for more suggestions.
 
@@ -990,7 +1052,9 @@ independent_update_data = {'line': line_update}
 The batch calculation supports shared memory multi-threading parallel computing.
 The common internal states and variables are shared as much as possible to save memory usage and avoid copy.
 
-You can set the `threading` keyword argument in the `calculate_*` functions (like {py:class}`calculate_power_flow() <power_grid_model.PowerGridModel.calculate_power_flow>`) to enable/disable parallel computing.
+You can set the `threading` keyword argument in the `calculate_*` functions (like
+{py:class}`calculate_power_flow() <power_grid_model.PowerGridModel.calculate_power_flow>`) to enable/disable parallel
+computing.
 
 - `threading=-1`, use sequential computing (default)
 - `threading=0`, use number of threads available from the machine hardware (recommended)

--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -10,9 +10,14 @@ SPDX-License-Identifier: MPL-2.0
 
 With power-grid-model it is possible to perform three different types of calculations:
 
-- [Power flow](#power-flow-algorithms): a "what-if" scenario calculation. This calculation can be performed by using the {py:class}`calculate_power_flow <power_grid_model.PowerGridModel.calculate_power_flow>` method. An example of usage of the power-flow calculation function is given in [Power flow Example](../examples/Power%20Flow%20Example.ipynb)
-- [State estimation](#state-estimation-algorithms): a statistical method that calculates the most probabilistic state of the grid, given sensor values with an uncertainty. This calculation can be performed by using the {py:class}`calculate_state_estimation <power_grid_model.PowerGridModel.calculate_state_estimation>` method. An example of usage of the power-flow calculation function is given in [State Estimation Example](../examples/State%20Estimation%20Example.ipynb)
-- [Short circuit](#short-circuit-calculation-algorithms): a "what-if" scenario calculation with short circuit entries. This calculation can be performed by using the {py:class}`calculate_short_circuit <power_grid_model.PowerGridModel.calculate_short_circuit>` method.
+- [Power flow](#power-flow-algorithms): a "what-if" scenario calculation.
+This calculation can be performed by using the {py:class}`calculate_power_flow <power_grid_model.PowerGridModel.calculate_power_flow>` method.
+An example of usage of the power-flow calculation function is given in [Power flow Example](../examples/Power%20Flow%20Example.ipynb)
+- [State estimation](#state-estimation-algorithms): a statistical method that calculates the most probabilistic state of the grid, given sensor values with an uncertainty.
+This calculation can be performed by using the {py:class}`calculate_state_estimation <power_grid_model.PowerGridModel.calculate_state_estimation>` method.
+An example of usage of the power-flow calculation function is given in [State Estimation Example](../examples/State%20Estimation%20Example.ipynb)
+- [Short circuit](#short-circuit-calculation-algorithms): a "what-if" scenario calculation with short circuit entries.
+This calculation can be performed by using the {py:class}`calculate_short_circuit <power_grid_model.PowerGridModel.calculate_short_circuit>` method.
 
 ### Calculation types explained
 
@@ -35,7 +40,8 @@ See [Power flow algorithms](#power-flow-algorithms) for detailed documentation o
 
 ##### Regulated power flow
 
-For most power flow calculations, the grid is fixed as the user dictates. However, in practice, the grid often contains regulators for certain components.
+For most power flow calculations, the grid is fixed as the user dictates.
+However, in practice, the grid often contains regulators for certain components.
 When including those regulators in the calculations, the grid may be optimized according to the power flow results and the behaviour of the regulators.
 
 See [Regulated power flow calculations](#regulated-power-flow-calculations) for detailed documentation on regulated power flow calculations.
@@ -43,7 +49,8 @@ See [Regulated power flow calculations](#regulated-power-flow-calculations) for 
 #### State estimation
 
 State estimation is a statistical calculation method that determines the most probable state of the grid, based on
-network data and measurements. Here, measurements can be power flow or voltage values with certain kind of uncertainty, which were
+network data and measurements.
+Here, measurements can be power flow or voltage values with certain kind of uncertainty, which were
 either measured, estimated or forecasted.
 
 Input:
@@ -57,12 +64,14 @@ Output:
 - Power flow through branches
 - Deviation between measurement values and estimated state
 
-In order to perform a state estimation, the system should be observable. If the system is not observable,
+In order to perform a state estimation, the system should be observable.
+If the system is not observable,
 the calculation will raise either a `NotObservableError` or a `SparseMatrixError`.
 In short, meeting the requirement of observability indicates that the system is either an overdetermined
 system (when the number of independent measurements is larger than the number of unknowns) or an exactly
 determined system (the number of independent measurements equals the number of unknowns).
-For each node, there are two unknowns, `u` and `u_angle`. Due to the relative nature of `u_angle`
+For each node, there are two unknowns, `u` and `u_angle`.
+Due to the relative nature of `u_angle`
 (relevant only in systems with at least two nodes), in total the following conditions should be met:
 
 $$
@@ -88,12 +97,15 @@ The number of measurements can be found by taking the sum of the following:
 - two times the number of branches with a power sensor and/or a current sensor
 
 ```{note}
-Having enough measurements does not necessarily mean that the system is observable. The location of the measurements is
-also of importance, i.e., the measurements should be topologically independent. Additionally, there should be at least one voltage measurement.
+Having enough measurements does not necessarily mean that the system is observable.
+The location of the measurements is
+also of importance, i.e., the measurements should be topologically independent.
+Additionally, there should be at least one voltage measurement.
 ```
 
 ```{note}
-Global angle current measurements require at least one voltage angle measurement to make sense. See also the [current sensor component documentation](./components.md#global-angle-current-sensors).
+Global angle current measurements require at least one voltage angle measurement to make sense.
+See also the [current sensor component documentation](./components.md#global-angle-current-sensors).
 ```
 
 ```{note}
@@ -104,11 +116,12 @@ However, such mixing of sensor types is allowed as long as they are on different
 
 ```{warning}
 The [iterative linear](#iterative-linear-state-estimation) and [Newton-Raphson](#newton-raphson-state-estimation) state estimation algorithms will assume angles to be zero by default (see the details about voltage sensors).
-In observable systems this helps better outputting correct results. On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be prevented.
+In observable systems this helps better outputting correct results.
+On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be prevented.
 ```
 
 ```{warning}
-At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation). 
+At the time of writing, the component [current sensor](./components.md#generic-current-sensor) is not supported in the calculation of [Newton-Raphson state estimation](#newton-raphson-state-estimation).
 ```
 
 ##### Necessary observability condition
@@ -125,19 +138,23 @@ Based on the requirements of observability mentioned above, users need to satisf
 `n_unique_power_or_current_sensor` can be calculated as sum of following:
 
 - Zero injection or zero power flow constraint if present for all nodes.
-- Complete injections for all nodes: All appliances in a node are measured or a node injection sensor is present. Either of them counts as one.
+- Complete injections for all nodes: All appliances in a node are measured or a node injection sensor is present.
+Either of them counts as one.
 - Any sensor on a `Branch` for all branches: Parallel branches with either side of measurements count as one.
 - All `Branch3` sensors.
 
 ##### Sufficient observability condition
 
-The condition check above only checks the necessary condition for observability. When the measurements are not independent enough, the system may still be unobservable even if the necessary condition is met.
-It is rather complicated to do a full sufficient and necessary observability check in generic cases. However, `power-grid-model` performs the sufficient condition check when the following conditions are met:
+The condition check above only checks the necessary condition for observability.
+When the measurements are not independent enough, the system may still be unobservable even if the necessary condition is met.
+It is rather complicated to do a full sufficient and necessary observability check in generic cases.
+However, `power-grid-model` performs the sufficient condition check when the following conditions are met:
 
 1. The system is a radial network.
 2. The system does not have voltage phasor measurements.
 
-In this case, the validation of the independent measurements is rather straightforward. If the system is not observable, the calculation will raise a `NotObservableError` instead of `SparseMatrixError`.
+In this case, the validation of the independent measurements is rather straightforward.
+If the system is not observable, the calculation will raise a `NotObservableError` instead of `SparseMatrixError`.
 
 #### Short circuit calculations
 
@@ -166,19 +183,27 @@ $$
     \end{eqnarray}
 $$
 
-These quantities are in complex form. Hence, they can be constructed by PGM output attributes in the following way:
+These quantities are in complex form.
+Hence, they can be constructed by PGM output attributes in the following way:
 
-- For  $\underline{U}$ of nodes, `u` is the magnitude and `u_angle` is the angle. Also the line to neutral voltage can be converted into line to line voltage by $ U_{LN} = U_{LL} / \sqrt{3}$. Check [Node Steady State Output](components.md#steady-state-output) to find out which quantity is relevant in your calculation.
+- For  $\underline{U}$ of nodes, `u` is the magnitude and `u_angle` is the angle.
+Also the line to neutral voltage can be converted into line to line voltage by $ U_{LN} = U_{LL} / \sqrt{3}$.
+Check [Node Steady State Output](components.md#steady-state-output) to find out which quantity is relevant in your calculation.
 
-- For  $\underline{I}$ of branches, `i_side` is the magnitude. Its angle can be found from `p_side` and `q_side` by: $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
+- For  $\underline{I}$ of branches, `i_side` is the magnitude.
+Its angle can be found from `p_side` and `q_side` by: $\arctan(\frac{P_{side} + j \cdot Q_{side}}{\underline{U}})^{*}$.
 The `side` here can be `from`, `to` for {hoverxreftooltip}`user_manual/components:Branch`es, `1`, `2`, `3` for {hoverxreftooltip}`user_manual/components:Branch3`s.
 
 ### Power flow algorithms
 
 Two types of power flow algorithms are implemented in power-grid-model; iterative algorithms (Newton-Raphson / Iterative current) and linear algorithms (Linear / Linear current).
-Iterative methods are more accurate and should thus be selected when an accurate solution is required. Linear approximation methods are many times faster than the iterative methods, but are generally less accurate. They can be used where approximate solutions are acceptable.
-Their accuracy is not explicitly calculated and may vary a lot. The user should have an intuition of their applicability based on the input grid configuration.
-The table below can be used to pick the right algorithm. Below the table a more in depth explanation is given for each algorithm.
+Iterative methods are more accurate and should thus be selected when an accurate solution is required.
+Linear approximation methods are many times faster than the iterative methods, but are generally less accurate.
+They can be used where approximate solutions are acceptable.
+Their accuracy is not explicitly calculated and may vary a lot.
+The user should have an intuition of their applicability based on the input grid configuration.
+The table below can be used to pick the right algorithm.
+Below the table a more in depth explanation is given for each algorithm.
 
 At the moment, the following power flow algorithms are implemented.
 
@@ -194,8 +219,8 @@ By default, the [Newton-Raphson](#newton-raphson-power-flow) method is used.
 ```
 
 ```{note}
-When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the fastest without loss of accuracy. 
-Therefore power-grid-model will use this method regardless of the input provided by the user in this case. 
+When all the load/generation types are of constant impedance, the [Linear](#linear-power-flow) method will be the fastest without loss of accuracy.
+Therefore power-grid-model will use this method regardless of the input provided by the user in this case.
 ```
 
 The nodal equations of a power system network can be written as:
@@ -206,7 +231,8 @@ $$
     \end{eqnarray}
 $$
 
-Where $I_N$ is the $N$ vector of source currents injected into each bus and $U_N$ is the $N$ vector of bus voltages. The complex power
+Where $I_N$ is the $N$ vector of source currents injected into each bus and $U_N$ is the $N$ vector of bus voltages.
+The complex power
 delivered to bus $k$ is:
 
 $$
@@ -216,17 +242,20 @@ $$
 $$
 
 Power flow equations are based on solving the nodal equations above to obtain the voltage magnitude and voltage angle at each node
-and then obtaining the real and reactive power flow through the branches. The following bus types can be present in the system:
+and then obtaining the real and reactive power flow through the branches.
+The following bus types can be present in the system:
 
 - Slack bus: the reference bus with known voltage and angle; in power-grid-model referred to as the [source](./components.md#source).
 - Load bus: a bus with known $P$ and $Q$.
-- Voltage controlled bus: a bus with known $P$ and $U$. Note: this bus is not supported by power-grid-model yet.
+- Voltage controlled bus: a bus with known $P$ and $U$.
+Note: this bus is not supported by power-grid-model yet.
 
 #### Newton-Raphson power flow
 
 Algorithm call: {py:class}`CalculationMethod.newton_raphson <power_grid_model.enum.CalculationMethod.newton_raphson>`
 
-This is the traditional method for power flow calculations. This method uses a Taylor series, ignoring the higher order
+This is the traditional method for power flow calculations.
+This method uses a Taylor series, ignoring the higher order
 terms, to solve the nonlinear set of equations iteratively:
 
 $$
@@ -315,14 +344,17 @@ For each iteration the following steps are executed:
 Algorithm call: {py:class}`CalculationMethod.iterative_current <power_grid_model.enum.CalculationMethod.iterative_current>`
 
 This algorithm is a Jacobi-like method for powerflow analysis.
-It has a linear convergence rate as opposed to the quadratic convergence rate in the [Newton-Raphson](#newton-raphson-power-flow) method. This means that more iterations is needed to achieve similar convergence.
-Additionally, [Newton-Raphson](#newton-raphson-power-flow) will be more robust converging in case of greater meshed configurations. Nevertheless, the iterative current algorithm will be faster most of the time.
+It has a linear convergence rate as opposed to the quadratic convergence rate in the [Newton-Raphson](#newton-raphson-power-flow) method.
+This means that more iterations is needed to achieve similar convergence.
+Additionally, [Newton-Raphson](#newton-raphson-power-flow) will be more robust converging in case of greater meshed configurations.
+Nevertheless, the iterative current algorithm will be faster most of the time.
 
 The algorithm is as follows:
 
 1. Build $Y_{bus}$ matrix
 2. Initialization of $U_N^0$ to $1$ plus the intrinsic phase shift of transformers
-3. Calculate injected currents: $I_N^i$ for $i^{th}$ iteration. The injected currents are calculated as per ZIP model of loads and generation using $U_N$.
+3. Calculate injected currents: $I_N^i$ for $i^{th}$ iteration.
+   The injected currents are calculated as per ZIP model of loads and generation using $U_N$.
    $
        \begin{eqnarray}
            I_N = \overline{S_{Z}} \cdot U_{N} + \overline{(\frac{S_{I}}{U_{N}})} \cdot |U_{N}| + \overline{(\frac{S_{P}}{U_N})}
@@ -352,7 +384,8 @@ The algorithm is as follows:
 
 1. Assume injected currents by loads $I_N=0$ since we model loads/generation as impedance.
    Admittance of each load/generation is calculated from rated power as $y=-\overline{S}$
-2. Build $Y{bus}$. Add the admittances of loads/generation to the diagonal elements.
+2. Build $Y{bus}$.
+   Add the admittances of loads/generation to the diagonal elements.
 3. Solve linear equation: $YU_N = I_N$ for $U_N$
 
 #### Linear current power flow
@@ -365,9 +398,13 @@ This approximation method will give better results when most of the load/generat
 Similar to [iterative current](#iterative-current-power-flow), batch calculations like timeseries will also be faster.
 Same reason applies here: the $Y_{bus}$ matrix does not change across batches and as a result the same factorization could be used.
 
-In practical grids most loads and generations correspond to the constant power type. Linear current would give a better approximation than [Linear](#linear-power-flow) in such case. This is because we approximate the load as current instead of impedance.
-There is a correlation in voltage error of approximation with respect to the actual voltage for all approximations. They are most accurate when the actual voltages are close to 1 p.u. and the error increases as we deviate from this level.
-When we approximate the load as impedance at 1 p.u., the voltage error has quadratic relation to the actual voltage. When it is approximated as a current at 1 p.u., the voltage error is only linearly dependent in comparison.
+In practical grids most loads and generations correspond to the constant power type.
+Linear current would give a better approximation than [Linear](#linear-power-flow) in such case.
+This is because we approximate the load as current instead of impedance.
+There is a correlation in voltage error of approximation with respect to the actual voltage for all approximations.
+They are most accurate when the actual voltages are close to 1 p.u. and the error increases as we deviate from this level.
+When we approximate the load as impedance at 1 p.u., the voltage error has quadratic relation to the actual voltage.
+When it is approximated as a current at 1 p.u., the voltage error is only linearly dependent in comparison.
 
 ### State estimation algorithms
 
@@ -447,8 +484,10 @@ By default, the [iterative linear](#iterative-linear-state-estimation) method is
 
 #### State estimation measurement aggregation
 
-There can be multiple sensors measuring the same physical quantity. For example, there can be multiple
-voltage sensors on the same bus. The measurement data can be merged into one virtual measurement using a Kalman filter:
+There can be multiple sensors measuring the same physical quantity.
+For example, there can be multiple
+voltage sensors on the same bus.
+The measurement data can be merged into one virtual measurement using a Kalman filter:
 
 $$
     \begin{eqnarray}
@@ -480,13 +519,15 @@ However, such mixing of sensor types is allowed as long as they are on different
 
 #### State estimate sensor transformations
 
-Sometimes, measurements need to be transformed between coordinate spaces. For example, current measurements are in polar coordinates (magnitude and angle), but it is beneficial to transform them to separate real and imaginary components per phase, with each their own variances.
+Sometimes, measurements need to be transformed between coordinate spaces.
+For example, current measurements are in polar coordinates (magnitude and angle), but it is beneficial to transform them to separate real and imaginary components per phase, with each their own variances.
 Variances of the results of such transformations are estimated using the common linearization approximation.
 E.g., for a real random variable $X$, the random variable $Y = F\left(X\right)$, with $F$ sufficiently well-behaved, exists.
 The variances of $Y$ can then be estimated from the variance of $X$ using
 $\text{Var}\left(Y\right) \approx \text{Var}\left(X\right) \left\|\frac{\delta f}{\delta X}\right\|^2$
 
-This approach generalizes to extension fields and to more dimensions. Both generalizations are required for current sensors.
+This approach generalizes to extension fields and to more dimensions.
+Both generalizations are required for current sensors.
 The current phasor is described by a complex random variable, which can be decomposed into a real and an imaginary component, or into a magnitude and a phasor.
 Asymmetric sensors and asymmetric calculations, on the other hand, require multidimensional approaches.
 The generalization is done as follows.
@@ -519,11 +560,14 @@ $$
 Algorithm call: {py:class}`CalculationMethod.iterative_linear <power_grid_model.enum.CalculationMethod.iterative_linear>`
 
 Linear WLS requires all measurements to be linear and only handles voltage phasor measurements including a phase angle,
-as well as complex current phasor measurements. This is only possible when all measurements are phasor unit measurements,
-which is not realistic in distribution grids. Therefore, traditional measurements are linearized prior to running the algorithm.
+as well as complex current phasor measurements.
+This is only possible when all measurements are phasor unit measurements,
+which is not realistic in distribution grids.
+Therefore, traditional measurements are linearized prior to running the algorithm.
 
 - Bus voltage: Given that the phase shift in the distribution grid is very small,
-  it is assumed that the angle shift is zero plus the intrinsic phase shift of transformers. For a certain bus `i`, the voltage
+  it is assumed that the angle shift is zero plus the intrinsic phase shift of transformers.
+  For a certain bus `i`, the voltage
   magnitude measured at that bus is translated into a voltage phasor, where $\theta_i$ is the intrinsic transformer phase shift:
 
 $$
@@ -533,9 +577,11 @@ $$
 $$
 
 - Branch current with global angle: The global angle current measurement captures
-the phase offset relative to the same predetermined reference phase against which the voltage angle is measured. It is not
+the phase offset relative to the same predetermined reference phase against which the voltage angle is measured.
+It is not
 sufficient to use the default zero-phase reference offset, because the reference point is not uniquely determined when there
-are no voltage angle measurements, resulting in ambiguities. As a result, using any global angle current sensor in the grid
+are no voltage angle measurements, resulting in ambiguities.
+As a result, using any global angle current sensor in the grid
 requires at least one voltage phasor measurement (with angle).
 
 $$
@@ -545,11 +591,15 @@ $$
 $$
 
 - Branch current with local angle: Sometimes, (accurate) voltage measurements are not available for a branch,
-which means no power measurement is possible. While it is not straightforward to use magnitude-only measurements of currents in
+which means no power measurement is possible.
+While it is not straightforward to use magnitude-only measurements of currents in
 calculations, current phasor measurements can in fact be used in cases where it is possible to obtain a reasonably accurate
-measurement of the current amplitude and the relative phase angle to the voltage. In this way, we still have enough information
-for the state estimation. The resulting local current phasor $\underline{I}_{\text{local}}$ can be translated to the global
-current phasor (see above) for iterative linear state estimation. Given the measured (linearized) voltage phasor,
+measurement of the current amplitude and the relative phase angle to the voltage.
+In this way, we still have enough information
+for the state estimation.
+The resulting local current phasor $\underline{I}_{\text{local}}$ can be translated to the global
+current phasor (see above) for iterative linear state estimation.
+Given the measured (linearized) voltage phasor,
 the current phasor is calculated as follows:
 
 $$
@@ -563,7 +613,8 @@ where $\underline{U}$ is either measured voltage magnitude at the bus or assumed
 $\theta$ is the phase angle of the voltage.
 
 - Branch/shunt power flow: To translate the power flow to a complex current phasor, the voltage at the terminal should
-also be measured, otherwise the nominal voltage with zero angle is used as an estimation. Given the measured (linearized) voltage
+also be measured, otherwise the nominal voltage with zero angle is used as an estimation.
+Given the measured (linearized) voltage
 phasor, the current phasor is calculated as follows:
 
 $$
@@ -573,7 +624,8 @@ $$
 $$
 
 - Bus power injection: Similar as above, to translate the power flow to a complex current phasor, if the bus voltage is not measured,
-the nominal voltage with zero angle will be used as an estimation. The current phasor is calculated as follows:
+the nominal voltage with zero angle will be used as an estimation.
+The current phasor is calculated as follows:
 
 $$
     \begin{eqnarray}
@@ -584,12 +636,16 @@ $$
 The aggregated apparent power flow is considered as a single measurement, with variance $\sigma_S^2 = \sigma_P^2 + \sigma_Q^2$.
 
 The assumption made in the linearization of measurements introduces a system error to the algorithm, because the phase shifts of
-bus voltages are ignored in the input measurement data. This error is corrected by applying an iterative approach to the linear WLS
-algorithm. In each iteration, the resulted voltage phase angle will be applied as the phase shift of the measured voltage phasor
+bus voltages are ignored in the input measurement data.
+This error is corrected by applying an iterative approach to the linear WLS
+algorithm.
+In each iteration, the resulted voltage phase angle will be applied as the phase shift of the measured voltage phasor
 for the next iteration:
 
-- Initialization: let $\underline{U}^{(k)}$ be the column vector of the estimated voltage phasor in the k-th iteration. Let Bus $s$
-be the slack bus, which is connected to the external network (source). $\underline{U}^{(0)}$ is initialized as follows:
+- Initialization: let $\underline{U}^{(k)}$ be the column vector of the estimated voltage phasor in the k-th iteration.
+Let Bus $s$
+be the slack bus, which is connected to the external network (source).
+$\underline{U}^{(0)}$ is initialized as follows:
   - For bus $i$, if there is no voltage measurement, assign $\underline{U}^{(0)} = e^{j \theta_i}$, where $\theta_i$ is the intrinsic
   transformer phase shift between Bus $i$ and Bus $s$.
   - For bus $i$, if there is a voltage measurement, assign $\underline{U}^{(0)} = U_{meas,i}e^{j \theta_i}$, where $U_{meas,i}$ is
@@ -598,20 +654,24 @@ be the slack bus, which is connected to the external network (source). $\underli
   - Linearize the voltage measurements by using the phase angle of the calculated voltages of iteration $k-1$.
   - Linearize the complex power flow measurements by using either the linearized voltage measurement if the bus is measured, or
   the voltage phasor result from iteration $k-1$.
-  - Compute the temporary new voltage phasor $\underline{\tilde{U}}^{(k)}$ using the pre-factorized matrix. See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
+  - Compute the temporary new voltage phasor $\underline{\tilde{U}}^{(k)}$ using the pre-factorized matrix.
+  See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
   - Normalize the voltage phasor angle by setting the angle of the slack bus to zero:
   - If the maximum deviation between $\underline{U}^{(k)}$ and $\underline{U}^{(k-1)}$ is smaller than the error tolerance $\epsilon$,
-  stop the iteration. Otherwise, continue until the maximum number of iterations is reached.
+  stop the iteration.
+  Otherwise, continue until the maximum number of iterations is reached.
 
 In the iteration process, the phase angle of voltages at each bus is updated using the last iteration;
-the system error of the phase shift converges to zero. Because the matrix is pre-built and
+the system error of the phase shift converges to zero.
+Because the matrix is pre-built and
 pre-factorized, the computation cost of each iteration is much smaller than for the [Newton-Raphson](#newton-raphson-state-estimation)
 method, where the Jacobian matrix needs to be constructed and factorized each time.
 
 Because the matrix depends on the variances of the linearized current measurements, pre-factorization
 requires assuming that the magnitudes of the voltages remain constant throughout the iteration process.
 This assumption is, of course, an approximation, and potentially results an inaccurate relative weighing
-of the power measurements. However, the difference between the solution and the actual grid state is
+of the power measurements.
+However, the difference between the solution and the actual grid state is
 usually small, because the error introduced by this is typically dominated by the following contributing
 factors (see also [this thread](https://github.com/PowerGridModel/power-grid-model/pull/951#issuecomment-2805154436)).
 
@@ -625,7 +685,8 @@ If higher precision is desired, please consider using [Newton-Raphson state esti
 ```
 
 ```{warning}
-The algorithm will assume angles to be zero by default (see the details about voltage sensors). This produces more correct outputs when the system is observable, but will prevent the calculation from raising an exception, even if it is unobservable, therefore giving faulty results.
+The algorithm will assume angles to be zero by default (see the details about voltage sensors).
+This produces more correct outputs when the system is observable, but will prevent the calculation from raising an exception, even if it is unobservable, therefore giving faulty results.
 ```
 
 #### Newton-Raphson state estimation
@@ -633,7 +694,8 @@ The algorithm will assume angles to be zero by default (see the details about vo
 Algorithm call: {py:class}`CalculationMethod.newton_raphson <power_grid_model.enum.CalculationMethod.newton_raphson>`
 
 The Newton-Raphson state estimation considers the problem as a system of real, non-linear equations.
-It iteratively solves the first order Taylor expansion of the system. It does not make any assumptions on linearization
+It iteratively solves the first order Taylor expansion of the system.
+It does not make any assumptions on linearization
 It could be more accurate and converge in less iterations than the [iterative linear](#iterative-linear-state-estimation) approach.
 However, the Jacobian matrix needs to be calculated every iteration and cannot be prefactorized, which makes it slower on average.
 
@@ -643,7 +705,8 @@ The rationale behind to calculation is similar to that of the [Newton-Raphson me
 Consequently, the iteration process differs slightly from that of [iterative linear state estimation](#iterative-linear-state-estimation), as shown below.
 
 - Initialization: let $\boldsymbol{U}^{(k)}$ be the column vector of the estimated voltage magnitude and $\boldsymbol{\theta}^{(k)}$ the column vector of the
-estimated voltage angle in k-th iteration. Let Bus $s$ be the slack bus which is connected to external network (source).
+estimated voltage angle in k-th iteration.
+Let Bus $s$ be the slack bus which is connected to external network (source).
 We initialize $\boldsymbol{U}^{(0)}$ and $\boldsymbol{\theta}^{(k)}$ as follows:
   - For Bus $i$, if there is no voltage measurement, assign $U_i^{(0)} = 1$ and $\theta_i^{(0)} = 0$,
   where $\theta_i$ is the intrinsic transformer phase shift between Bus $i$ and Bus $s$.
@@ -652,7 +715,8 @@ We initialize $\boldsymbol{U}^{(0)}$ and $\boldsymbol{\theta}^{(k)}$ as follows:
 - In iteration $k$, follow the steps below:
   - Construct and (LU-)factorize the Jacobian matrix for $\boldsymbol{x}^{(k)}$, using the network parameters.
   - Compute the temporary new voltage magnitude and angle result, $\widetilde{\boldsymbol{U}}^{(k)}$ and $\widetilde{\boldsymbol{\theta}}^{(k)}$,
-  using the prefactorized matrix. See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
+  using the prefactorized matrix.
+  See also [Matrix-prefactorization](./performance-guide.md#matrix-prefactorization)
   - Normalize the result voltage phasor angle by setting angle of slack bus to zero:
   $\underline{U}_i^{(k)} = \widetilde{\underline{U}}_i^{(k)} \times |\widetilde{\underline{U}}_s^{(k)}| / \widetilde{\underline{U}}_s^{(k)}$.
   - If the maximum deviation between $\underline{\boldsymbol{U}}^{(k)}$ and $\underline{\boldsymbol{U}}^{(k-1)}$ is smaller than the tolerance $\epsilon$,
@@ -663,11 +727,14 @@ As for the [iterative linear](#iterative-linear-state-estimation) approach, duri
 The system error of the phase shift converges to zero.
 
 ```{note}
-Newton-Raphson state estimation does not support current measurements at this moment. See also [this issue](https://github.com/PowerGridModel/power-grid-model/issues/765).
+Newton-Raphson state estimation does not support current measurements at this moment.
+See also [this issue](https://github.com/PowerGridModel/power-grid-model/issues/765).
 ```
 
 ```{warning}
-The algorithm will assume angles to be zero by default (see the details about voltage sensors). In observable systems this helps better outputting correct results. On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be prevented.
+The algorithm will assume angles to be zero by default (see the details about voltage sensors).
+In observable systems this helps better outputting correct results.
+On the other hand with unobservable systems, exceptions raised from calculations due to faulty results will be prevented.
 ```
 
 ### Short circuit calculation algorithms
@@ -691,9 +758,12 @@ Algorithm call: {py:class}`CalculationMethod.iec60909 <power_grid_model.enum.Cal
 
 The assumptions used for calculations in power-grid-model are aligned to the ones mentioned in [IEC 60909](https://webstore.iec.ch/publication/24100).
 
-- The state of the grid with respect to loads and generations are ignored for the short circuit calculation. (Note: Shunt admittances are included in calculation.)
-- The pre-fault voltage is considered in the calculation and is calculated based on the grid parameters and topology. (Excl. loads and generation)
-- The calculations are assumed to be time-independent. (Voltages are sine throughout with the fault occurring at a zero crossing of the voltage, the complexity of rotating machines and harmonics are neglected, etc.)
+- The state of the grid with respect to loads and generations are ignored for the short circuit calculation.
+  (Note: Shunt admittances are included in calculation.)
+- The pre-fault voltage is considered in the calculation and is calculated based on the grid parameters and topology.
+  (Excl. loads and generation)
+- The calculations are assumed to be time-independent.
+(Voltages are sine throughout with the fault occurring at a zero crossing of the voltage, the complexity of rotating machines and harmonics are neglected, etc.)
 - To account for the different operational conditions, a voltage scaling factor of `c` is applied to the voltage source while running short circuit calculation function.
   The factor `c` is determined by the nominal voltage of the node that the source is connected to and the API option to calculate the `minimum` or `maximum` short circuit currents.
   The table to derive `c` according to IEC 60909 is shown below.
@@ -704,7 +774,8 @@ The assumptions used for calculations in power-grid-model are aligned to the one
 | `U_nom` > 1kV  | 1.10  | 1.00  |
 
 ```{note}
-In the IEC 609090 standard, there is a difference in `c` (for `U_nom` <= 1kV) for systems with a voltage tolerance of 6% and 10%. In power-grid-model we only use the value for a 10% voltage tolerance.
+In the IEC 609090 standard, there is a difference in `c` (for `U_nom` <= 1kV) for systems with a voltage tolerance of 6% and 10%.
+In power-grid-model we only use the value for a 10% voltage tolerance.
 ```
 
 There are {py:class}`4 types <power_grid_model.enum.FaultType>` of fault situations that can occur in the grid, along with the following possible combinations of the {py:class}`associated phases <power_grid_model.enum.FaultType>`:
@@ -742,9 +813,11 @@ Power flow calculations that take the behavior of these regulators into account 
 
 ##### Control logic for power flow with automatic tap changing
 
-We provide the control logic used for tap changing. For simplicity, we demonstrate the case where the regulator control side and the transformer tap side are at different sides.
+We provide the control logic used for tap changing.
+For simplicity, we demonstrate the case where the regulator control side and the transformer tap side are at different sides.
 
-- Regulated transformers are ranked according to how close they are to {hoverxreftooltip}`sources <user_manual/components:source>` in terms of the amount of regulated transformers inbetween. In the presence of meshed grids, transformers with conflicting ranks will be ranked the last.
+- Regulated transformers are ranked according to how close they are to {hoverxreftooltip}`sources <user_manual/components:source>` in terms of the amount of regulated transformers inbetween.
+  In the presence of meshed grids, transformers with conflicting ranks will be ranked the last.
   - Transformers are regulated in order according to their ranks.
 - Initialize all transformers to their starting tap position (see {hoverxreftooltip}`user_manual/calculations:Initialization and exploitation of regulated transformers`)
 - Find the optimal state using the following procedure
@@ -827,7 +900,9 @@ The same method as for single calculations, {py:class}`power_grid_model.PowerGri
 To do this, you need to supply an `update_data` keyword argument.
 This keyword argument contains a dictionary of 2D update arrays (one array per component type).
 
-The performance for different batches vary. power-grid-model automatically makes efficient calculations whenever possible. See the [Performance Guide](performance-guide.md#topology-caching) for ways to optimally use the performance optimizations.
+The performance for different batches vary.
+power-grid-model automatically makes efficient calculations whenever possible.
+See the [Performance Guide](performance-guide.md#topology-caching) for ways to optimally use the performance optimizations.
 
 ### Batch data set
 

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -20,9 +20,12 @@ The base type for all power-grid-model components.
 | ---- | --------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------------: |
 | `id` | `int32_t` | -    | ID of a component. The ID should be unique across all components within the same scenario, e.g., you cannot have a node with `id=5` and another line with `id=5`. | &#10004; | &#10060; (see below) |
 
-If a component update is uniform and is updating all the elements with the same component type, IDs can be omitted or set to `nan`s. In any other case, the IDs need to be present in the update dataset, but cannot be changed.
+If a component update is uniform and is updating all the elements with the same component type, IDs can be omitted or set to `nan`s.
+In any other case, the IDs need to be present in the update dataset, but cannot be changed.
 
-Uniform component updates are ones that update the same number of component of the same type across scenarios. By definition, a dense update is always uniform, hence the IDs can always be optional; whereas for a sparse update, the IDs can only be optional if the index pointer is given as an arithmetic sequence of all elements (i.e. a sparse representation of a dense buffer). An example of the usage of optional IDs is given in [Power Flow Example](./Power%20Flow%20Example.ipynb)
+Uniform component updates are ones that update the same number of component of the same type across scenarios.
+By definition, a dense update is always uniform, hence the IDs can always be optional; whereas for a sparse update, the IDs can only be optional if the index pointer is given as an arithmetic sequence of all elements (i.e. a sparse representation of a dense buffer).
+An example of the usage of optional IDs is given in [Power Flow Example](./Power%20Flow%20Example.ipynb)
 
 #### Steady state output and Short circuit output
 
@@ -36,7 +39,8 @@ Uniform component updates are ones that update the same number of component of t
 * type name: `node`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`node` is a point in the grid. Physically a node can be a busbar, a joint, or other similar component.
+`node` is a point in the grid.
+Physically a node can be a busbar, a joint, or other similar component.
 
 #### Input
 
@@ -72,9 +76,13 @@ The `p` and `q` output of injection follows the `generator` reference direction 
 * type name: `branch`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`branch` is the abstract base type for the component which connects two *different* nodes. For each branch two switches
-are always defined at from- and to-side of the branch. In reality such switches may not exist. For example, a cable
-usually permanently connects two joints. In this case, the attribute `from_status` and `to_status` is always 1.
+`branch` is the abstract base type for the component which connects two *different* nodes.
+For each branch two switches
+are always defined at from- and to-side of the branch.
+In reality such switches may not exist.
+For example, a cable
+usually permanently connects two joints.
+In this case, the attribute `from_status` and `to_status` is always 1.
 
 #### Input
 
@@ -112,8 +120,10 @@ usually permanently connects two joints. In this case, the attribute `from_statu
 
 * type name: `line`
 
-`line` is a {hoverxreftooltip}`user_manual/components:branch` with specified serial impedance and shunt admittance. A cable is
-also modeled as `line`. A `line` can only connect two nodes with the same rated voltage.
+`line` is a {hoverxreftooltip}`user_manual/components:branch` with specified serial impedance and shunt admittance.
+A cable is
+also modeled as `line`.
+A `line` can only connect two nodes with the same rated voltage.
 If `i_n` is not provided, `loading` of line will be a `nan` value.
 
 #### Input
@@ -152,8 +162,10 @@ $$
 * type name: `link`
 
 `link` is a {hoverxreftooltip}`user_manual/components:branch` which usually represents a short internal cable/connection between
-two busbars inside a substation. It has a very high admittance (small impedance) which is set to a fixed per-unit value
-(equivalent to 10e6 siemens for 10kV network). Therefore, it is chosen by design that no sensors can be coupled to a `link`.
+two busbars inside a substation.
+It has a very high admittance (small impedance) which is set to a fixed per-unit value
+(equivalent to 10e6 siemens for 10kV network).
+Therefore, it is chosen by design that no sensors can be coupled to a `link`.
 There is no additional attribute for `link`.
 
 #### Electric Model
@@ -169,7 +181,8 @@ $$
 ### Transformer
 
 `transformer` is a {hoverxreftooltip}`user_manual/components:branch` which connects two nodes with possibly different voltage
-levels. An example of usage of transformer is given in [Transformer Examples](../examples/Transformer%20Examples.ipynb)
+levels.
+An example of usage of transformer is given in [Transformer Examples](../examples/Transformer%20Examples.ipynb)
 
 #### Input
 
@@ -201,7 +214,8 @@ levels. An example of usage of transformer is given in [Transformer Examples](..
 | `x_grounding_to`   | `double`                                                    | ohm (Ω)          | grounding reactance at to-side, if relevant                                                                                                                                                                                 |                  &#10060; default `0`                   | &#10060; |                                                                        |
 
 ```{note}
-It can happen that `tap_min > tap_max`. In this case the winding voltage is decreased if the tap position is
+It can happen that `tap_min > tap_max`.
+In this case the winding voltage is decreased if the tap position is
 increased.
 ```
 
@@ -234,7 +248,11 @@ Here, $s_{\text{base}}$ is a constant value determined by the solver and $u_{\te
 
 * type name: `generic_branch`
 
-`generic_branch` is a {hoverxreftooltip}`user_manual/components:branch` that connects two nodes, potentially at different voltage levels. Depending on the choice of parameters, it behaves either as a line or as a transformer. The advantage is that the input parameters are based directly on the electrical equivalent circuit model. The PI model can be used to avoid the need to convert parameters into transformer model data. Another use case is modeling a line when connecting two nodes with approximately the same voltage levels (in that case, the off-nominal ratio must be given to adapt the electrical parameters).
+`generic_branch` is a {hoverxreftooltip}`user_manual/components:branch` that connects two nodes, potentially at different voltage levels.
+Depending on the choice of parameters, it behaves either as a line or as a transformer.
+The advantage is that the input parameters are based directly on the electrical equivalent circuit model.
+The PI model can be used to avoid the need to convert parameters into transformer model data.
+Another use case is modeling a line when connecting two nodes with approximately the same voltage levels (in that case, the off-nominal ratio must be given to adapt the electrical parameters).
 
 #### Input
 
@@ -253,11 +271,16 @@ The impedance (`r1`, `x1`) and admittance (`g1`, `b1`) attributes are calculated
 ```
 
 ```{note}
-To model a three-winding transformer using the `generic_branch`, the MVA method must be applied. This means the user needs to calculate three equivalent `generic_branch` components and define an additional node to represent the common winding connection point. In rare cases, this method can result in negative electrical equivalent circuit elements. Therefore, the input parameters are not checked for negative values.
+To model a three-winding transformer using the `generic_branch`, the MVA method must be applied.
+This means the user needs to calculate three equivalent `generic_branch` components and define an additional node to represent the common winding connection point.
+In rare cases, this method can result in negative electrical equivalent circuit elements.
+Therefore, the input parameters are not checked for negative values.
 ```
 
 ```{warning}
-The parameter `k` represents the **off-nominal ratio**, not the nominal voltage ratio. This means that `k` must be explicitly provided by the user, particularly in cases involving a tap changer or a voltage transformer. The program does not automatically calculate `k` based on the nominal voltage levels of the connected nodes.
+The parameter `k` represents the **off-nominal ratio**, not the nominal voltage ratio.
+This means that `k` must be explicitly provided by the user, particularly in cases involving a tap changer or a voltage transformer.
+The program does not automatically calculate `k` based on the nominal voltage levels of the connected nodes.
 ```
 
 ```{warning}
@@ -280,7 +303,10 @@ $$
 
 * type name: `asym_line`
 
-`asym_line` is a {hoverxreftooltip}`user_manual/components:branch` with specified resistance and reactance per phase. A cable can be modelled as `line` or `asym_line`. An `asym_line` can only connect two nodes with the same rated voltage. If `i_n` is not provided, `loading` of line will be a `nan` value. The `asym_line` denotes a 3 or 4 phase line with phases `a`, `b`, `c` and optionally `n` for neutral.
+`asym_line` is a {hoverxreftooltip}`user_manual/components:branch` with specified resistance and reactance per phase.
+A cable can be modelled as `line` or `asym_line`. An `asym_line` can only connect two nodes with the same rated voltage.
+If `i_n` is not provided, `loading` of line will be a `nan` value.
+The `asym_line` denotes a 3 or 4 phase line with phases `a`, `b`, `c` and optionally `n` for neutral.
 
 #### Input
 
@@ -295,7 +321,8 @@ $$
    \end{bmatrix}
 $$
 
-This representation holds for all values `r_aa` ... `r_nn`, `x_aa` ... `x_nn` and `c_aa` ... `c_cc`. If the neutral values are not provided, the last row and column from the above matrix are omitted.
+This representation holds for all values `r_aa` ... `r_nn`, `x_aa` ... `x_nn` and `c_aa` ... `c_cc`.
+If the neutral values are not provided, the last row and column from the above matrix are omitted.
 
 | name   | data type | unit       | description                       | required                     |  update  |            valid values            |
 | ------ | --------- | ---------- | --------------------------------- | ---------------------------- | :------: | :--------------------------------: |
@@ -329,7 +356,8 @@ This representation holds for all values `r_aa` ... `r_nn`, `x_aa` ... `x_nn` an
 | `c1`   | `double`  | farad (F)  | Series shunt capacitance          | &#10024; without a c matrix  | &#10060; |               `> 0`                |
 | `i_n`  | `double`  | ampere (A) | rated current                     | &#10060;                     | &#10060; |               `> 0`                |
 
-For the r and x matrices providing values for the neutral phase is optional. To clarify which input values are required, please consult the tables below:
+For the r and x matrices providing values for the neutral phase is optional.
+To clarify which input values are required, please consult the tables below:
 
 | r_aa ... r_cc   | r_na     | r_nb     | r_nc     | r_nn     | result   | Validation Error          |
 | --------------- | -------- | -------- | -------- | -------- | -------- | ------------------------- |
@@ -351,7 +379,9 @@ For the r and x matrices providing values for the neutral phase is optional. To 
 | &#10004;        | &#10060; | &#10060; | &#10060; | &#10060; | &#10004; |                           |
 | &#10060;        | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; | MultiFieldValidationError |
 
-For the c-matrix values there are two options. Either provide all the required c-matrix values i.e. `c_aa` ... `c_cc` or provide `c0`, `c1`. Whenever both sets are supplied the powerflow calculations will use `c0`, `c1`.
+For the c-matrix values there are two options.
+Either provide all the required c-matrix values i.e. `c_aa` ... `c_cc` or provide `c0`, `c1`.
+Whenever both sets are supplied the powerflow calculations will use `c0`, `c1`.
 The table below provides guidance in providing valid input.
 
 | c_aa ... c_cc | c0       | c1       | result   | Validation Error          |
@@ -409,8 +439,10 @@ Where $Z_{\text{i,j}}$ denotes the row and column of the $Z_{\text{series}}$ mat
 * type name: `branch3`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`branch3` is the abstract base type for the component which connects three *different* nodes. For each branch3 three
-switches are always defined at side 1, 2, or 3 of the branch. In reality such switches may not exist.
+`branch3` is the abstract base type for the component which connects three *different* nodes.
+For each branch3 three
+switches are always defined at side 1, 2, or 3 of the branch.
+In reality such switches may not exist.
 
 #### Input
 
@@ -506,7 +538,8 @@ voltage levels. An example of usage of three-winding transformer is given in [Tr
 | `x_grounding_3` | `double`                                                    | ohm (Ω)          | grounding reactance at side 3, if relevant                                                                |                  &#10060; default `0`                   | &#10060; |                                                                        |
 
 ```{note}
-It can happen that `tap_min > tap_max`. In this case the winding voltage is decreased if the tap position is
+It can happen that `tap_min > tap_max`.
+In this case the winding voltage is decreased if the tap position is
 increased.
 ```
 
@@ -522,8 +555,10 @@ The calculation of series and shunt admittance from `uk`, `pk`, `i0` and `p0` is
 * type name: `appliance`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`appliance` is an abstract user which is coupled to a `node`. For each `appliance`, a switch is defined between
-the `appliance` and the `node`. The reference direction for power flows is mentioned in
+`appliance` is an abstract user which is coupled to a `node`.
+For each `appliance`, a switch is defined between
+the `appliance` and the `node`.
+The reference direction for power flows is mentioned in
 {hoverxreftooltip}`user_manual/data-model:Reference Direction`.
 
 #### Input
@@ -556,8 +591,10 @@ the `appliance` and the `node`. The reference direction for power flows is menti
 * {hoverxreftooltip}`user_manual/data-model:Reference Direction`: generator
 
 `source` is an {hoverxreftooltip}`user_manual/components:appliance` representing the external network with a
-[Thévenin's equivalence](https://en.wikipedia.org/wiki/Th%C3%A9venin%27s_theorem). It has an infinite voltage source
-with an internal impedance. The impedance is specified by convention as short circuit power.
+[Thévenin's equivalence](https://en.wikipedia.org/wiki/Th%C3%A9venin%27s_theorem).
+It has an infinite voltage source
+with an internal impedance.
+The impedance is specified by convention as short circuit power.
 
 #### Input
 
@@ -609,7 +646,8 @@ type of the load/generation with response to voltage.
 
 #### Load/Generator Concrete Types
 
-There are four concrete types of load/generator. They share similar attributes: specified active/reactive power.
+There are four concrete types of load/generator.
+They share similar attributes: specified active/reactive power.
 However, the reference direction and meaning of `RealValueInput` is different, as shown in the table below.
 
 | type name   | reference direction | meaning of `RealValueInput` |
@@ -664,7 +702,8 @@ where $\bar{u}$ is the calculated node voltage.
 * type name: `shunt`
 * {hoverxreftooltip}`user_manual/data-model:Reference Direction`: load
 
-`shunt` is an {hoverxreftooltip}`user_manual/components:appliance` with a fixed admittance (impedance). It behaves similar to a
+`shunt` is an {hoverxreftooltip}`user_manual/components:appliance` with a fixed admittance (impedance).
+It behaves similar to a
 load/generator with type `const_impedance`.
 
 #### Input
@@ -691,8 +730,11 @@ if any of the faults in any of the scenarios within a batch are not three-phase 
 * type name: `sensor`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`sensor` is an abstract type for all the sensor types. A sensor does not have any physical meaning. Rather, it provides
-measurement data for the state estimation algorithm. The state estimator uses the data to evaluate the state of the grid
+`sensor` is an abstract type for all the sensor types.
+A sensor does not have any physical meaning.
+Rather, it provides
+measurement data for the state estimation algorithm.
+The state estimator uses the data to evaluate the state of the grid
 with the highest probability.
 
 #### Input
@@ -703,14 +745,16 @@ with the highest probability.
 
 #### Output
 
-A sensor only has output for state estimation. For other calculation types, sensor output is undefined.
+A sensor only has output for state estimation.
+For other calculation types, sensor output is undefined.
 
 ### Generic Voltage Sensor
 
 * type name: `generic_voltage_sensor`
 
 `generic_voltage_sensor` is an abstract class for symmetric and asymmetric voltage sensor and derived from
-{hoverxreftooltip}`user_manual/components:sensor`. It measures the magnitude and (optionally) the angle of the voltage of
+{hoverxreftooltip}`user_manual/components:sensor`.
+It measures the magnitude and (optionally) the angle of the voltage of
 a `node`.
 
 #### Input
@@ -721,9 +765,12 @@ a `node`.
 
 #### Voltage Sensor Concrete Types
 
-There are two concrete types of voltage sensor. They share similar attributes:
-the meaning of `RealValueInput` is different, as shown in the table below. In a `sym_voltage_sensor` the measured
-voltage is a line-to-line voltage. In a `asym_voltage_sensor` the measured voltage is a 3-phase line-to-ground voltage.
+There are two concrete types of voltage sensor.
+They share similar attributes:
+the meaning of `RealValueInput` is different, as shown in the table below.
+In a `sym_voltage_sensor` the measured
+voltage is a line-to-line voltage.
+In a `asym_voltage_sensor` the measured voltage is a 3-phase line-to-ground voltage.
 
 | type name             | meaning of `RealValueInput` |
 | --------------------- | --------------------------- |
@@ -738,13 +785,14 @@ voltage is a line-to-line voltage. In a `asym_voltage_sensor` the measured volta
 | `u_angle_measured` | `RealValueInput` | rad      | measured voltage angle (only possible with phasor measurement units) | &#10024; only for state estimation when a current sensor with `global_angle` `angle_measurement_type` is present | &#10004; |              |
 
 ```{note}
-When a current sensor with `global_angle` `angle_measurement_type` is present there needs to be a voltage sensor with `u_angle_measured` in the grid as a reference angle (when performing a state estimation). 
+When a current sensor with `global_angle` `angle_measurement_type` is present there needs to be a voltage sensor with `u_angle_measured` in the grid as a reference angle (when performing a state estimation).
 ```
 
 ##### Steady state output
 
 ```{note}
-A sensor only has output for state estimation. For other calculation types, sensor output is undefined.
+A sensor only has output for state estimation.
+For other calculation types, sensor output is undefined.
 ```
 
 | name               | data type         | unit     | description                                                                                                              |
@@ -770,16 +818,20 @@ The $\pmod{2\pi}$ is handled such that $-\pi \lt \theta_{\text{angle},\text{resi
 * type name: `generic_power_sensor`
 
 `power_sensor` is an abstract class for symmetric and asymmetric power sensor and is derived from
-{hoverxreftooltip}`user_manual/components:sensor`. It measures the active/reactive power flow of a terminal. The terminal is
-either connecting an `appliance` and a `node`, or connecting the from/to end of a `branch` (except `link`) and a `node`. In case of a
+{hoverxreftooltip}`user_manual/components:sensor`.
+It measures the active/reactive power flow of a terminal.
+The terminal is
+either connecting an `appliance` and a `node`, or connecting the from/to end of a `branch` (except `link`) and a `node`.
+In case of a
 terminal between an `appliance` and a `node`, the power {hoverxreftooltip}`user_manual/data-model:Reference Direction` in the
-measurement data is the same as the reference direction of the `appliance`. For example, if a `power_sensor` is
+measurement data is the same as the reference direction of the `appliance`.
+For example, if a `power_sensor` is
 measuring a `source`, a positive `p_measured` indicates that the active power flows from the source to the node.
 
 ```{note}
 1. Due to the high admittance of a `link` it is chosen that a power sensor cannot be coupled to a `link`, even though a link is a `branch`
 
-2. The node injection power sensor gets placed on a node. 
+2. The node injection power sensor gets placed on a node.
 In the state estimation result, the power from this injection is distributed equally among the connected appliances at that node.
 Because of this distribution, at least one appliance is required to be connected to the node where an injection sensor is placed for it to function.
 ```
@@ -799,7 +851,8 @@ However, such mixing of sensor types is allowed as long as they are on different
 
 #### Power Sensor Concrete Types
 
-There are two concrete types of power sensor. They share similar attributes:
+There are two concrete types of power sensor.
+They share similar attributes:
 the meaning of `RealValueInput` is different, as shown in the table below.
 
 | type name           | meaning of `RealValueInput` |
@@ -842,7 +895,8 @@ See the documentation on [state estimation calculation methods](calculations.md#
 ##### Steady state output
 
 ```{note}
-A sensor only has output for state estimation. For other calculation types, sensor output is undefined.
+A sensor only has output for state estimation.
+For other calculation types, sensor output is undefined.
 ```
 
 | name         | data type         | unit                       | description                                                                  |
@@ -870,7 +924,8 @@ At the time of writing, state estimation with current sensors is not supported b
 * type name: `generic_current_sensor`
 
 `current_sensor` is an abstract class for symmetric and asymmetric current sensor and is derived from
-{hoverxreftooltip}`user_manual/components:sensor`. It measures the magnitude and angle of the current flow of a terminal.
+{hoverxreftooltip}`user_manual/components:sensor`.
+It measures the magnitude and angle of the current flow of a terminal.
 The terminal is connecting the from/to end of a `branch` (except `link`) and a `node`.
 
 ```{note}
@@ -898,7 +953,8 @@ However, such mixing of sensor types is allowed as long as they are on different
 At the time of writing, state estimation with current sensors is not supported by the Newton-Raphson calculation method.
 ```
 
-There are two concrete types of current sensor. They share similar attributes:
+There are two concrete types of current sensor.
+They share similar attributes:
 the meaning of `RealValueInput` is different, as shown in the table below.
 
 | type name             | meaning of `RealValueInput` |
@@ -918,7 +974,8 @@ See the documentation on [state estimation calculation methods](calculations.md#
 ##### Steady state output
 
 ```{note}
-A sensor only has output for state estimation. For other calculation types, sensor output is undefined.
+A sensor only has output for state estimation.
+For other calculation types, sensor output is undefined.
 ```
 
 | name               | data type         | unit       | description                                                                                 |
@@ -933,7 +990,9 @@ A sensor only has output for state estimation. For other calculation types, sens
 ##### Global angle current sensors
 
 Current sensors with `angle_measurement_type` equal to `AngleMeasurementType.global_angle` measure the phase of the current relative to
-some reference angle that is the same across the entire grid. This reference angle must be the same one as for [voltage phasor measurements](#generic-voltage-sensor). Because the reference point may be ambiguous in the case of current sensor measurements, the power-grid-model imposes the following requirement:
+some reference angle that is the same across the entire grid.
+This reference angle must be the same one as for [voltage phasor measurements](#generic-voltage-sensor).
+Because the reference point may be ambiguous in the case of current sensor measurements, the power-grid-model imposes the following requirement:
 
 ```{note}
 Global angle current measurements require at least one voltage angle measurement to make sense.
@@ -975,7 +1034,8 @@ The $\pmod{2\pi}$ is handled such that $-\pi \lt i_{\text{angle},\text{residual}
 * type name: `fault`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`fault` defines a short circuit location in the grid. A fault can only happen at a `node`.
+`fault` defines a short circuit location in the grid.
+A fault can only happen at a `node`.
 
 #### Input
 
@@ -989,8 +1049,10 @@ The $\pmod{2\pi}$ is handled such that $-\pi \lt i_{\text{angle},\text{residual}
 | `x_f`          | `double`                                                  | ohm (Ω) | short circuit reactance                             |                                         &#10060; default `0.0`                                          | &#10004; |                   |
 
 ```{note}
-Multiple faults may exist within one calculation. Currently, all faults in one scenario are required to have the
-same `fault_type` and `fault_phase`. Across scenarios in a batch, the `fault_type` and `fault_phase` may differ.
+Multiple faults may exist within one calculation.
+Currently, all faults in one scenario are required to have the
+same `fault_type` and `fault_phase`.
+Across scenarios in a batch, the `fault_type` and `fault_phase` may differ.
 ```
 
 ```{note}
@@ -1031,7 +1093,8 @@ The supported values of `fault_phase`, as well as its default value, are listed 
 * base: {hoverxreftooltip}`user_manual/components:base`
 
 `regulator` is an abstract regulator that is coupled to a given `regulated_object`. For each `regulator`, a switch is defined between
-the `regulator` and the `regulated_object`. Which object types are supported as `regulated_object` is regulator type-dependent.
+the `regulator` and the `regulated_object`.
+Which object types are supported as `regulated_object` is regulator type-dependent.
 
 #### Input
 
@@ -1051,7 +1114,8 @@ A transformer tap regulator regulates a component that is either a {hoverxreftoo
 The transformer tap regulator changes the `tap_pos` of the transformer it regulates in the range set by the user via `tap_min` and `tap_max` (i.e., `(tap_min <= tap_pos <= tap_max)` or `(tap_min >= tap_pos >= tap_max)`).
 It regulates the tap position so that the voltage on the control side is in the chosen voltage band.
 Other points further into the grid on the control side, away from the transformer, can also be regulated by providing the cumulative impedance across branches to that point as an additional line drop compensation.
-This line drop compensation only affects the controlled voltage and does not have any impact on the actual grid. It may therefore be treated as a virtual impedance in the grid.
+This line drop compensation only affects the controlled voltage and does not have any impact on the actual grid.
+It may therefore be treated as a virtual impedance in the grid.
 
 ```{note}
 The regulator outputs the optimal tap position of the transformer.
@@ -1074,7 +1138,8 @@ The following additional requirements exist on the input parameters.
 * The line drop compensation is small, in the sense that its product with the typical current through the transformer is much smaller (in absolute value) than the smallest change in voltage due to a change in tap position.
 * The `control_side` of a transformer regulator should be on the relatively further side to a source in the connected grid.
 
-These requirements make sure no edge cases with undefined behavior are encountered. Typical real-world power grids already satisfy these requirements and they should therefore not cause any problems.
+These requirements make sure no edge cases with undefined behavior are encountered.
+Typical real-world power grids already satisfy these requirements and they should therefore not cause any problems.
 
 #### Steady state output
 
@@ -1118,7 +1183,8 @@ $$
    \end{eqnarray}
 $$
 
-where $\underline{U}_{\text{node}}$ and $\underline{I}_{\text{transformer}}$ are the calculated voltage and current phasors at the control side and may be obtained from a regular power flow calculation. The plus sign in the last equality follows from canceling minus signs from the current direction convention and the compensation direction.
+where $\underline{U}_{\text{node}}$ and $\underline{I}_{\text{transformer}}$ are the calculated voltage and current phasors at the control side and may be obtained from a regular power flow calculation.
+The plus sign in the last equality follows from canceling minus signs from the current direction convention and the compensation direction.
 
 For example, if we want to regulate the voltage at `load_7` in the following grid, the line drop compensation impedance is the approximate impedance of `line_5`.
 

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -20,11 +20,14 @@ The base type for all power-grid-model components.
 | ---- | --------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------------: |
 | `id` | `int32_t` | -    | ID of a component. The ID should be unique across all components within the same scenario, e.g., you cannot have a node with `id=5` and another line with `id=5`. | &#10004; | &#10060; (see below) |
 
-If a component update is uniform and is updating all the elements with the same component type, IDs can be omitted or set to `nan`s.
+If a component update is uniform and is updating all the elements with the same component type, IDs can be omitted or
+set to `nan`s.
 In any other case, the IDs need to be present in the update dataset, but cannot be changed.
 
 Uniform component updates are ones that update the same number of component of the same type across scenarios.
-By definition, a dense update is always uniform, hence the IDs can always be optional; whereas for a sparse update, the IDs can only be optional if the index pointer is given as an arithmetic sequence of all elements (i.e. a sparse representation of a dense buffer).
+By definition, a dense update is always uniform, hence the IDs can always be optional; whereas for a sparse update, the
+IDs can only be optional if the index pointer is given as an arithmetic sequence of all elements (i.e. a sparse
+representation of a dense buffer).
 An example of the usage of optional IDs is given in [Power Flow Example](./Power%20Flow%20Example.ipynb)
 
 #### Steady state output and Short circuit output
@@ -77,11 +80,9 @@ The `p` and `q` output of injection follows the `generator` reference direction 
 * base: {hoverxreftooltip}`user_manual/components:base`
 
 `branch` is the abstract base type for the component which connects two *different* nodes.
-For each branch two switches
-are always defined at from- and to-side of the branch.
+For each branch two switches are always defined at from- and to-side of the branch.
 In reality such switches may not exist.
-For example, a cable
-usually permanently connects two joints.
+For example, a cable usually permanently connects two joints.
 In this case, the attribute `from_status` and `to_status` is always 1.
 
 #### Input
@@ -121,8 +122,7 @@ In this case, the attribute `from_status` and `to_status` is always 1.
 * type name: `line`
 
 `line` is a {hoverxreftooltip}`user_manual/components:branch` with specified serial impedance and shunt admittance.
-A cable is
-also modeled as `line`.
+A cable is also modeled as `line`.
 A `line` can only connect two nodes with the same rated voltage.
 If `i_n` is not provided, `loading` of line will be a `nan` value.
 
@@ -141,9 +141,8 @@ If `i_n` is not provided, `loading` of line will be a `nan` value.
 | `i_n`  | `double`  | ampere (A) | rated current                              |                 &#10060;                  | &#10060; |               `> 0`                |
 
 ```{note}
-In case of short circuit calculations, the zero-sequence parameters are required only
-if any of the faults in any of the scenarios within a batch are not three-phase faults
-(i.e. `fault_type` is not `FaultType.three_phase`).
+In case of short circuit calculations, the zero-sequence parameters are required only if any of the faults in any of the
+scenarios within a batch are not three-phase faults (i.e. `fault_type` is not `FaultType.three_phase`).
 ```
 
 #### Electric Model
@@ -161,10 +160,10 @@ $$
 
 * type name: `link`
 
-`link` is a {hoverxreftooltip}`user_manual/components:branch` which usually represents a short internal cable/connection between
-two busbars inside a substation.
-It has a very high admittance (small impedance) which is set to a fixed per-unit value
-(equivalent to 10e6 siemens for 10kV network).
+`link` is a {hoverxreftooltip}`user_manual/components:branch` which usually represents a short internal cable/connection
+between two busbars inside a substation.
+It has a very high admittance (small impedance) which is set to a fixed per-unit value (equivalent to 10e6 siemens for
+10kV network).
 Therefore, it is chosen by design that no sensors can be coupled to a `link`.
 There is no additional attribute for `link`.
 
@@ -180,8 +179,8 @@ $$
 
 ### Transformer
 
-`transformer` is a {hoverxreftooltip}`user_manual/components:branch` which connects two nodes with possibly different voltage
-levels.
+`transformer` is a {hoverxreftooltip}`user_manual/components:branch` which connects two nodes with possibly different
+voltage levels.
 An example of usage of transformer is given in [Transformer Examples](../examples/Transformer%20Examples.ipynb)
 
 #### Input
@@ -215,8 +214,7 @@ An example of usage of transformer is given in [Transformer Examples](../example
 
 ```{note}
 It can happen that `tap_min > tap_max`.
-In this case the winding voltage is decreased if the tap position is
-increased.
+In this case the winding voltage is decreased if the tap position is increased.
 ```
 
 #### Electric Model
@@ -242,17 +240,20 @@ $$
 $$
 
 where $z_{\text{base}} = 1 / y_{\text{base}} = {u_{\text{2, rated}}}^2 / s_{\text{base}}$.
-Here, $s_{\text{base}}$ is a constant value determined by the solver and $u_{\text{2, rated}}$ is rated voltage at `to_node`.
+Here, $s_{\text{base}}$ is a constant value determined by the solver and $u_{\text{2, rated}}$ is rated voltage at
+`to_node`.
 
 ### Generic Branch  
 
 * type name: `generic_branch`
 
-`generic_branch` is a {hoverxreftooltip}`user_manual/components:branch` that connects two nodes, potentially at different voltage levels.
+`generic_branch` is a {hoverxreftooltip}`user_manual/components:branch` that connects two nodes, potentially at
+different voltage levels.
 Depending on the choice of parameters, it behaves either as a line or as a transformer.
 The advantage is that the input parameters are based directly on the electrical equivalent circuit model.
 The PI model can be used to avoid the need to convert parameters into transformer model data.
-Another use case is modeling a line when connecting two nodes with approximately the same voltage levels (in that case, the off-nominal ratio must be given to adapt the electrical parameters).
+Another use case is modeling a line when connecting two nodes with approximately the same voltage levels (in that case,
+the off-nominal ratio must be given to adapt the electrical parameters).
 
 #### Input
 
@@ -267,19 +268,22 @@ Another use case is modeling a line when connecting two nodes with approximately
 | `sn`    | `double`  | volt-ampere (VA) | rated power                   | &#10060; default `0.0` | &#10060; |    `>= 0`    |
 
 ```{note}
-The impedance (`r1`, `x1`) and admittance (`g1`, `b1`) attributes are calculated with reference to the "to" side of the branch.
+The impedance (`r1`, `x1`) and admittance (`g1`, `b1`) attributes are calculated with reference to the "to" side of the
+branch.
 ```
 
 ```{note}
 To model a three-winding transformer using the `generic_branch`, the MVA method must be applied.
-This means the user needs to calculate three equivalent `generic_branch` components and define an additional node to represent the common winding connection point.
+This means the user needs to calculate three equivalent `generic_branch` components and define an additional node to
+represent the common winding connection point.
 In rare cases, this method can result in negative electrical equivalent circuit elements.
 Therefore, the input parameters are not checked for negative values.
 ```
 
 ```{warning}
 The parameter `k` represents the **off-nominal ratio**, not the nominal voltage ratio.
-This means that `k` must be explicitly provided by the user, particularly in cases involving a tap changer or a voltage transformer.
+This means that `k` must be explicitly provided by the user, particularly in cases involving a tap changer or a voltage
+transformer.
 The program does not automatically calculate `k` based on the nominal voltage levels of the connected nodes.
 ```
 
@@ -402,7 +406,8 @@ $$
 
 Where $R$ and $X$ denote the resistance and reactance matrices build from the input respectively.
 
-Whenever the neutral phase is provided in the $Z_{\text{series}}$, the $Z_{\text{series}}$ matrix will first be reduced to a 3 phase matrix $Z_{\text{reduced}}$ with a kron reduction as follows:
+Whenever the neutral phase is provided in the $Z_{\text{series}}$, the $Z_{\text{series}}$ matrix will first be reduced
+to a 3 phase matrix $Z_{\text{reduced}}$ with a kron reduction as follows:
 
 $$
    Z_{\text{aa}} = \begin{bmatrix}
@@ -440,8 +445,7 @@ Where $Z_{\text{i,j}}$ denotes the row and column of the $Z_{\text{series}}$ mat
 * base: {hoverxreftooltip}`user_manual/components:base`
 
 `branch3` is the abstract base type for the component which connects three *different* nodes.
-For each branch3 three
-switches are always defined at side 1, 2, or 3 of the branch.
+For each branch3 three switches are always defined at side 1, 2, or 3 of the branch.
 In reality such switches may not exist.
 
 #### Input
@@ -486,8 +490,10 @@ In reality such switches may not exist.
 
 ### Three-Winding Transformer
 
-`three_winding_transformer` is a {hoverxreftooltip}`user_manual/components:branch3` connects three nodes with possibly different
-voltage levels. An example of usage of three-winding transformer is given in [Transformer Examples](../examples/Transformer%20Examples.ipynb).
+`three_winding_transformer` is a {hoverxreftooltip}`user_manual/components:branch3` connects three nodes with possibly
+different voltage levels.
+An example of usage of three-winding transformer is given in
+[Transformer Examples](../examples/Transformer%20Examples.ipynb).
 
 #### Input
 
@@ -539,16 +545,17 @@ voltage levels. An example of usage of three-winding transformer is given in [Tr
 
 ```{note}
 It can happen that `tap_min > tap_max`.
-In this case the winding voltage is decreased if the tap position is
-increased.
+In this case the winding voltage is decreased if the tap position is increased.
 ```
 
 #### Electric Model
 
 `three_winding_transformer` is modelled as 3 transformers of `pi` model each connected together in star configuration.
 However, there are only 2 `pi` "legs": One at `side_1` and one in the centre of star.
-The values between windings (for e.g., `uk_12` or `pk_23`) are converted from delta to corresponding star configuration values.
-The calculation of series and shunt admittance from `uk`, `pk`, `i0` and `p0` is same as mentioned in {hoverxreftooltip}`user_manual/components:transformer`.
+The values between windings (for e.g., `uk_12` or `pk_23`) are converted from delta to corresponding star configuration
+values.
+The calculation of series and shunt admittance from `uk`, `pk`, `i0` and `p0` is same as mentioned in
+{hoverxreftooltip}`user_manual/components:transformer`.
 
 ## Appliance
 
@@ -556,10 +563,8 @@ The calculation of series and shunt admittance from `uk`, `pk`, `i0` and `p0` is
 * base: {hoverxreftooltip}`user_manual/components:base`
 
 `appliance` is an abstract user which is coupled to a `node`.
-For each `appliance`, a switch is defined between
-the `appliance` and the `node`.
-The reference direction for power flows is mentioned in
-{hoverxreftooltip}`user_manual/data-model:Reference Direction`.
+For each `appliance`, a switch is defined between the `appliance` and the `node`.
+The reference direction for power flows is mentioned in {hoverxreftooltip}`user_manual/data-model:Reference Direction`.
 
 #### Input
 
@@ -592,8 +597,7 @@ The reference direction for power flows is mentioned in
 
 `source` is an {hoverxreftooltip}`user_manual/components:appliance` representing the external network with a
 [Thévenin's equivalence](https://en.wikipedia.org/wiki/Th%C3%A9venin%27s_theorem).
-It has an infinite voltage source
-with an internal impedance.
+It has an infinite voltage source with an internal impedance.
 The impedance is specified by convention as short circuit power.
 
 #### Input
@@ -637,8 +641,8 @@ $$
 
 * type name: `generic_load_gen`
 
-`generic_load_gen` is an abstract load/generation {hoverxreftooltip}`user_manual/components:appliance` which contains only the
-type of the load/generation with response to voltage.
+`generic_load_gen` is an abstract load/generation {hoverxreftooltip}`user_manual/components:appliance` which contains
+only the type of the load/generation with response to voltage.
 
 | name   | data type                                                   | unit | description                                     | required |  update  |
 | ------ | ----------------------------------------------------------- | ---- | ----------------------------------------------- | :------: | :------: |
@@ -666,8 +670,8 @@ However, the reference direction and meaning of `RealValueInput` is different, a
 
 ##### Electric model
 
-`generic_load_gen` is modelled by using the so-called ZIP load model in power-grid-model,
-where a load/generator is represented as a composition of constant power (P), constant current (I) and constant impedance (Z).
+`generic_load_gen` is modelled by using the so-called ZIP load model in power-grid-model, where a load/generator is
+represented as a composition of constant power (P), constant current (I) and constant impedance (Z).
 
 The injection of each ZIP model type can be computed as follows:
 
@@ -703,8 +707,7 @@ where $\bar{u}$ is the calculated node voltage.
 * {hoverxreftooltip}`user_manual/data-model:Reference Direction`: load
 
 `shunt` is an {hoverxreftooltip}`user_manual/components:appliance` with a fixed admittance (impedance).
-It behaves similar to a
-load/generator with type `const_impedance`.
+It behaves similar to a load/generator with type `const_impedance`.
 
 #### Input
 
@@ -716,9 +719,8 @@ load/generator with type `const_impedance`.
 | `b0` | `double`  | siemens (S) | zero-sequence shunt susceptance     | &#10024; only for asymmetric calculation | &#10004; |
 
 ```{note}
-In case of short circuit calculations, the zero-sequence parameters are required only
-if any of the faults in any of the scenarios within a batch are not three-phase faults
-(i.e. `fault_type` is not `FaultType.three_phase`).
+In case of short circuit calculations, the zero-sequence parameters are required only if any of the faults in any of the
+scenarios within a batch are not three-phase faults (i.e. `fault_type` is not `FaultType.three_phase`).
 ```
 
 #### Electric Model
@@ -732,10 +734,8 @@ if any of the faults in any of the scenarios within a batch are not three-phase 
 
 `sensor` is an abstract type for all the sensor types.
 A sensor does not have any physical meaning.
-Rather, it provides
-measurement data for the state estimation algorithm.
-The state estimator uses the data to evaluate the state of the grid
-with the highest probability.
+Rather, it provides measurement data for the state estimation algorithm.
+The state estimator uses the data to evaluate the state of the grid with the highest probability.
 
 #### Input
 
@@ -754,8 +754,7 @@ For other calculation types, sensor output is undefined.
 
 `generic_voltage_sensor` is an abstract class for symmetric and asymmetric voltage sensor and derived from
 {hoverxreftooltip}`user_manual/components:sensor`.
-It measures the magnitude and (optionally) the angle of the voltage of
-a `node`.
+It measures the magnitude and (optionally) the angle of the voltage of a `node`.
 
 #### Input
 
@@ -766,10 +765,8 @@ a `node`.
 #### Voltage Sensor Concrete Types
 
 There are two concrete types of voltage sensor.
-They share similar attributes:
-the meaning of `RealValueInput` is different, as shown in the table below.
-In a `sym_voltage_sensor` the measured
-voltage is a line-to-line voltage.
+They share similar attributes: the meaning of `RealValueInput` is different, as shown in the table below.
+In a `sym_voltage_sensor` the measured voltage is a line-to-line voltage.
 In a `asym_voltage_sensor` the measured voltage is a 3-phase line-to-ground voltage.
 
 | type name             | meaning of `RealValueInput` |
@@ -785,7 +782,8 @@ In a `asym_voltage_sensor` the measured voltage is a 3-phase line-to-ground volt
 | `u_angle_measured` | `RealValueInput` | rad      | measured voltage angle (only possible with phasor measurement units) | &#10024; only for state estimation when a current sensor with `global_angle` `angle_measurement_type` is present | &#10004; |              |
 
 ```{note}
-When a current sensor with `global_angle` `angle_measurement_type` is present there needs to be a voltage sensor with `u_angle_measured` in the grid as a reference angle (when performing a state estimation).
+When a current sensor with `global_angle` `angle_measurement_type` is present there needs to be a voltage sensor with
+`u_angle_measured` in the grid as a reference angle (when performing a state estimation).
 ```
 
 ##### Steady state output
@@ -820,25 +818,32 @@ The $\pmod{2\pi}$ is handled such that $-\pi \lt \theta_{\text{angle},\text{resi
 `power_sensor` is an abstract class for symmetric and asymmetric power sensor and is derived from
 {hoverxreftooltip}`user_manual/components:sensor`.
 It measures the active/reactive power flow of a terminal.
-The terminal is
-either connecting an `appliance` and a `node`, or connecting the from/to end of a `branch` (except `link`) and a `node`.
-In case of a
-terminal between an `appliance` and a `node`, the power {hoverxreftooltip}`user_manual/data-model:Reference Direction` in the
-measurement data is the same as the reference direction of the `appliance`.
-For example, if a `power_sensor` is
-measuring a `source`, a positive `p_measured` indicates that the active power flows from the source to the node.
+The terminal is either connecting an `appliance` and a `node`, or connecting the from/to end of a `branch` (except
+`link`) and a `node`.
+In case of a terminal between an `appliance` and a `node`, the power
+{hoverxreftooltip}`user_manual/data-model:Reference Direction` in the measurement data is the same as the reference
+direction of the `appliance`.
+For example, if a `power_sensor` is measuring a `source`, a positive `p_measured` indicates that the active power flows
+from the source to the node.
 
 ```{note}
-1. Due to the high admittance of a `link` it is chosen that a power sensor cannot be coupled to a `link`, even though a link is a `branch`
+1. Due to the high admittance of a `link` it is chosen that a power sensor cannot be coupled to a `link`, even though a
+link is a `branch`
 
 2. The node injection power sensor gets placed on a node.
-In the state estimation result, the power from this injection is distributed equally among the connected appliances at that node.
-Because of this distribution, at least one appliance is required to be connected to the node where an injection sensor is placed for it to function.
+In the state estimation result, the power from this injection is distributed equally among the connected appliances at
+that node.
+Because of this distribution, at least one appliance is required to be connected to the node where an injection sensor
+is placed for it to function.
 ```
 
 ```{note}
-It is not possible to mix [power sensors](./components.md#generic-current-sensor) with [current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
-It is also not possible to mix [current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with [current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is not possible to mix [power sensors](./components.md#generic-current-sensor) with
+[current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is also not possible to mix
+[current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with
+[current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the
+same component.
 However, such mixing of sensor types is allowed as long as they are on different terminals.
 ```
 
@@ -852,8 +857,7 @@ However, such mixing of sensor types is allowed as long as they are on different
 #### Power Sensor Concrete Types
 
 There are two concrete types of power sensor.
-They share similar attributes:
-the meaning of `RealValueInput` is different, as shown in the table below.
+They share similar attributes: the meaning of `RealValueInput` is different, as shown in the table below.
 
 | type name           | meaning of `RealValueInput` |
 | ------------------- | --------------------------- |
@@ -883,14 +887,18 @@ Valid combinations of `power_sigma`, `p_sigma` and `q_sigma` are:
 |               |           |           | &#10060; |
 
 ```{note}
-1. If both `p_sigma` and `q_sigma` are provided, they represent the standard deviation of the active and reactive power, respectively, and the value of `power_sigma` is ignored. Any infinite component invalidates the entire measurement.
+1. If both `p_sigma` and `q_sigma` are provided, they represent the standard deviation of the active and reactive power,
+respectively, and the value of `power_sigma` is ignored. Any infinite component invalidates the entire measurement.
 
-2. If neither `p_sigma` nor `q_sigma` are provided, `power_sigma` represents the standard deviation of the apparent power.
+2. If neither `p_sigma` nor `q_sigma` are provided, `power_sigma` represents the standard deviation of the apparent
+power.
 
 3. Providing only one of `p_sigma` and `q_sigma` results in undefined behaviour.
 ```
 
-See the documentation on [state estimation calculation methods](calculations.md#state-estimation-algorithms) for details per method on how the variances are taken into account for both the active and reactive power and for the individual phases.
+See the documentation on [state estimation calculation methods](calculations.md#state-estimation-algorithms) for details
+per method on how the variances are taken into account for both the active and reactive power and for the individual
+phases.
 
 ##### Steady state output
 
@@ -929,12 +937,17 @@ It measures the magnitude and angle of the current flow of a terminal.
 The terminal is connecting the from/to end of a `branch` (except `link`) and a `node`.
 
 ```{note}
-Due to the high admittance of a `link` it is chosen that a current sensor cannot be coupled to a `link`, even though a link is a `branch`
+Due to the high admittance of a `link` it is chosen that a current sensor cannot be coupled to a `link`, even though a
+link is a `branch`.
 ```
 
 ```{note}
-It is not possible to mix [power sensors](./components.md#generic-current-sensor) with [current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
-It is also not possible to mix [current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with [current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is not possible to mix [power sensors](./components.md#generic-current-sensor) with
+[current sensors](#./components.mdgeneric-current-sensor) on the same terminal of the same component.
+It is also not possible to mix
+[current sensors with global angle measurement type](#./components.mdgeneric-current-sensor) with
+[current sensors with local angle measurement type](#./components.mdgeneric-current-sensor) on the same terminal of the
+same component.
 However, such mixing of sensor types is allowed as long as they are on different terminals.
 ```
 
@@ -954,8 +967,7 @@ At the time of writing, state estimation with current sensors is not supported b
 ```
 
 There are two concrete types of current sensor.
-They share similar attributes:
-the meaning of `RealValueInput` is different, as shown in the table below.
+They share similar attributes: the meaning of `RealValueInput` is different, as shown in the table below.
 
 | type name             | meaning of `RealValueInput` |
 | --------------------- | --------------------------- |
@@ -969,7 +981,9 @@ the meaning of `RealValueInput` is different, as shown in the table below.
 | `i_measured`       | `RealValueInput` | ampere (A) | measured current (`i`) magnitude          | &#10024; only for state estimation | &#10004; |
 | `i_angle_measured` | `RealValueInput` | rad        | measured phase angle of the current (`i`; see the [electric model](#local-angle-current-sensors) below) | &#10024; only for state estimation | &#10004; |
 
-See the documentation on [state estimation calculation methods](calculations.md#state-estimation-algorithms) for details per method on how the variances are taken into account for both the global and local angle measurement types and for the individual phases.
+See the documentation on [state estimation calculation methods](calculations.md#state-estimation-algorithms) for details
+per method on how the variances are taken into account for both the global and local angle measurement types and for the
+individual phases.
 
 ##### Steady state output
 
@@ -989,10 +1003,11 @@ For other calculation types, sensor output is undefined.
 
 ##### Global angle current sensors
 
-Current sensors with `angle_measurement_type` equal to `AngleMeasurementType.global_angle` measure the phase of the current relative to
-some reference angle that is the same across the entire grid.
+Current sensors with `angle_measurement_type` equal to `AngleMeasurementType.global_angle` measure the phase of the
+current relative to some reference angle that is the same across the entire grid.
 This reference angle must be the same one as for [voltage phasor measurements](#generic-voltage-sensor).
-Because the reference point may be ambiguous in the case of current sensor measurements, the power-grid-model imposes the following requirement:
+Because the reference point may be ambiguous in the case of current sensor measurements, the power-grid-model imposes
+the following requirement:
 
 ```{note}
 Global angle current measurements require at least one voltage angle measurement to make sense.
@@ -1006,12 +1021,15 @@ $$
 
 ##### Local angle current sensors
 
-Current sensors with `angle_measurement_type` equal to `AngleMeasurementType.local_angle` measure the phase shift between
-the voltage and the current phasor, i.e., $\text{i_angle_measured} = \text{voltage_phase} - \text{current_phase}$.
-As a result, the global current phasor depends on the local voltage phase offset and is obtained using the following formula.
+Current sensors with `angle_measurement_type` equal to `AngleMeasurementType.local_angle` measure the phase shift
+between the voltage and the current phasor, i.e.,
+$\text{i_angle_measured} = \text{voltage_phase} - \text{current_phase}$.
+As a result, the global current phasor depends on the local voltage phase offset and is obtained using the following
+formula.
 
 $$
-\underline{I} = \underline{I}_{\text{local}}^{*} \frac{\underline{U}}{|\underline{U}|} = \text{i_measured} \cdot e^{\mathrm{j} \left(\theta_{U} - \text{i_angle_measured}\right)}
+\underline{I} = \underline{I}_{\text{local}}^{*} \frac{\underline{U}}{|\underline{U}|}
+              = \text{i_measured} \cdot e^{\mathrm{j} \left(\theta_{U} - \text{i_angle_measured}\right)}
 $$
 
 ```{note}
@@ -1022,8 +1040,10 @@ As a result, the local angle current sensors have a different sign convention fr
 
 $$
    \begin{eqnarray}
-        & i_{\text{residual}} = i_{\text{measured}} - i_{\text{state}} && \\
-        & i_{\text{angle},\text{residual}} = i_{\text{angle},\text{measured}} - i_{\text{angle},\text{state}} \pmod{2 \pi}
+        & i_{\text{residual}}
+               = i_{\text{measured}} - i_{\text{state}} && \\
+        & i_{\text{angle},\text{residual}}
+               = i_{\text{angle},\text{measured}} - i_{\text{angle},\text{state}} \pmod{2 \pi}
    \end{eqnarray}
 $$
 
@@ -1050,15 +1070,13 @@ A fault can only happen at a `node`.
 
 ```{note}
 Multiple faults may exist within one calculation.
-Currently, all faults in one scenario are required to have the
-same `fault_type` and `fault_phase`.
+Currently, all faults in one scenario are required to have the same `fault_type` and `fault_phase`.
 Across scenarios in a batch, the `fault_type` and `fault_phase` may differ.
 ```
 
 ```{note}
-If any of the faults in any of the scenarios within a batch are not `three_phase`
-(i.e. `fault_type` is not `FaultType.three_phase`),
-the calculation is treated as asymmetric.
+If any of the faults in any of the scenarios within a batch are not `three_phase` (i.e. `fault_type` is not
+`FaultType.three_phase`), the calculation is treated as asymmetric.
 ```
 
 #### Steady state output
@@ -1076,8 +1094,10 @@ A `fault` has no steady state output.
 
 ##### Fault types, fault phases and default values
 
-Four types of short circuit fault are included in power-grid-model, each with their own set of supported values for `fault_phase`.
-In case the `fault_phase` is not specified or is equal to `FaultPhase.default_value`, the power-grid-model assumes a `fault_type`-dependent set of fault phases.
+Four types of short circuit fault are included in power-grid-model, each with their own set of supported values for
+`fault_phase`.
+In case the `fault_phase` is not specified or is equal to `FaultPhase.default_value`, the power-grid-model assumes a
+`fault_type`-dependent set of fault phases.
 The supported values of `fault_phase`, as well as its default value, are listed in the table below.
 
 | `fault_type`                       | supported values of `fault_phase`                 | `FaultPhase.default_value` | description                                                            |
@@ -1092,8 +1112,8 @@ The supported values of `fault_phase`, as well as its default value, are listed 
 * type name: `regulator`
 * base: {hoverxreftooltip}`user_manual/components:base`
 
-`regulator` is an abstract regulator that is coupled to a given `regulated_object`. For each `regulator`, a switch is defined between
-the `regulator` and the `regulated_object`.
+`regulator` is an abstract regulator that is coupled to a given `regulated_object`. For each `regulator`, a switch is
+defined between the `regulator` and the `regulated_object`.
 Which object types are supported as `regulated_object` is regulator type-dependent.
 
 #### Input
@@ -1109,11 +1129,15 @@ Which object types are supported as `regulated_object` is regulator type-depende
 * base: {hoverxreftooltip}`user_manual/components:regulator`
 
 `transformer_tap_regulator` defines a regulator for transformers in the grid.
-A transformer tap regulator regulates a component that is either a {hoverxreftooltip}`user_manual/components:transformer` or a {hoverxreftooltip}`user_manual/components:Three-Winding Transformer`.
+A transformer tap regulator regulates a component that is either a
+{hoverxreftooltip}`user_manual/components:transformer` or a
+{hoverxreftooltip}`user_manual/components:Three-Winding Transformer`.
 
-The transformer tap regulator changes the `tap_pos` of the transformer it regulates in the range set by the user via `tap_min` and `tap_max` (i.e., `(tap_min <= tap_pos <= tap_max)` or `(tap_min >= tap_pos >= tap_max)`).
+The transformer tap regulator changes the `tap_pos` of the transformer it regulates in the range set by the user via
+`tap_min` and `tap_max` (i.e., `(tap_min <= tap_pos <= tap_max)` or `(tap_min >= tap_pos >= tap_max)`).
 It regulates the tap position so that the voltage on the control side is in the chosen voltage band.
-Other points further into the grid on the control side, away from the transformer, can also be regulated by providing the cumulative impedance across branches to that point as an additional line drop compensation.
+Other points further into the grid on the control side, away from the transformer, can also be regulated by providing
+the cumulative impedance across branches to that point as an additional line drop compensation.
 This line drop compensation only affects the controlled voltage and does not have any impact on the actual grid.
 It may therefore be treated as a virtual impedance in the grid.
 
@@ -1134,9 +1158,13 @@ The actual grid state is not changed after calculations are done.
 
 The following additional requirements exist on the input parameters.
 
-* Depending on the resultant voltage being transformed, the voltage band must be sufficiently large: At zero line drop compensation if the expected resultant voltages are in the proximity of the rated transformer voltages, it is recommended to have the $u_{band} >= \frac{u_2}{1+ u_1 / \text{tap}_{\text{size}}}$
-* The line drop compensation is small, in the sense that its product with the typical current through the transformer is much smaller (in absolute value) than the smallest change in voltage due to a change in tap position.
-* The `control_side` of a transformer regulator should be on the relatively further side to a source in the connected grid.
+* Depending on the resultant voltage being transformed, the voltage band must be sufficiently large: At zero line drop
+  compensation if the expected resultant voltages are in the proximity of the rated transformer voltages, it is
+  recommended to have the $u_{band} >= \frac{u_2}{1+ u_1 / \text{tap}_{\text{size}}}$
+* The line drop compensation is small, in the sense that its product with the typical current through the transformer is
+  much smaller (in absolute value) than the smallest change in voltage due to a change in tap position.
+* The `control_side` of a transformer regulator should be on the relatively further side to a source in the connected
+  grid.
 
 These requirements make sure no edge cases with undefined behavior are encountered.
 Typical real-world power grids already satisfy these requirements and they should therefore not cause any problems.
@@ -1154,17 +1182,20 @@ A `transformer_tap_regulator` has no short circuit output.
 #### Electric Model
 
 The transformer tap regulator itself does not have a direct contribution to the grid state.
-Instead, it regulates the tap position of the regulated object until the voltage at the control side is in the specified voltage band:
+Instead, it regulates the tap position of the regulated object until the voltage at the control side is in the specified
+voltage band:
 
 $$
    \begin{eqnarray}
-      U_{\text{control}} \in \left[U_{\text{set}} - \frac{U_{\text{band}}}{2}, U_{\text{set}} + \frac{U_{\text{band}}}{2}\right]
+      U_{\text{control}} \in
+         \left[U_{\text{set}} - \frac{U_{\text{band}}}{2}, U_{\text{set}} + \frac{U_{\text{band}}}{2}\right]
    \end{eqnarray}
 $$
 
 ##### Line drop compensation
 
-The transformer tap regulator tries to regulate the voltage in a specified virtual location in the grid, according to the folowing model.
+The transformer tap regulator tries to regulate the voltage in a specified virtual location in the grid, according to
+the folowing model.
 
 ```txt
 tap_side   control_side                         part of grid where voltage is to be regulated
@@ -1174,19 +1205,26 @@ tap_side   control_side                         part of grid where voltage is to
      regulator <=======================================/
 ```
 
-The control voltage is the voltage at the node, compensated with the voltage drop corresponding to the specified line drop compensation.
+The control voltage is the voltage at the node, compensated with the voltage drop corresponding to the specified line
+drop compensation.
 
 $$
    \begin{eqnarray}
       & Z_{\text{compensation}} = r_{\text{compensation}} + \mathrm{j} x_{\text{compensation}} \\
-      & U_{\text{control}} = \left|\underline{U}_{\text{node}} - \underline{I}_{\text{transformer,out}} \cdot \underline{Z}_{\text{compensation}}\right| = \left|\underline{U}_{\text{node}} + \underline{I}_{\text{transformer}} \cdot \underline{Z}_{\text{compensation}}\right|
+      & U_{\text{control}} = \left|\underline{U}_{\text{node}} - \underline{I}_{\text{transformer,out}}
+                                 \cdot \underline{Z}_{\text{compensation}}\right|
+                           = \left|\underline{U}_{\text{node}} + \underline{I}_{\text{transformer}}
+                                 \cdot \underline{Z}_{\text{compensation}}\right|
    \end{eqnarray}
 $$
 
-where $\underline{U}_{\text{node}}$ and $\underline{I}_{\text{transformer}}$ are the calculated voltage and current phasors at the control side and may be obtained from a regular power flow calculation.
-The plus sign in the last equality follows from canceling minus signs from the current direction convention and the compensation direction.
+where $\underline{U}_{\text{node}}$ and $\underline{I}_{\text{transformer}}$ are the calculated voltage and current
+phasors at the control side and may be obtained from a regular power flow calculation.
+The plus sign in the last equality follows from canceling minus signs from the current direction convention and the
+compensation direction.
 
-For example, if we want to regulate the voltage at `load_7` in the following grid, the line drop compensation impedance is the approximate impedance of `line_5`.
+For example, if we want to regulate the voltage at `load_7` in the following grid, the line drop compensation impedance
+is the approximate impedance of `line_5`.
 
 ```txt
 node_1 --- transformer_4 --- node_2 --- line_5 --- node_3

--- a/docs/user_manual/data-model.md
+++ b/docs/user_manual/data-model.md
@@ -6,12 +6,15 @@ SPDX-License-Identifier: MPL-2.0
 
 # Component Type Hierarchy and Graph Data Model
 
-To represent the physical grid components and the calculation results, this library utilizes a graph data model. In this
+To represent the physical grid components and the calculation results, this library utilizes a graph data model.
+In this
 document, the graph data model is presented with the list of all components types, and their relevant input/output
 attributes.
 
-The components types are organized in an inheritance-like hierarchy. A sub-type has all the attributes from its parent
-type. The hierarchy tree of the component types is shown below.
+The components types are organized in an inheritance-like hierarchy.
+A sub-type has all the attributes from its parent
+type.
+The hierarchy tree of the component types is shown below.
 
 ```{mermaid}
 graph LR
@@ -50,7 +53,8 @@ the {py:class}`power_grid_model.power_grid_meta_data`, see [Native Data Interfac
 
 There are four generic component types: `node`, `branch`, `branch3` and `appliance`.
 A `node` is similar to a vertex in a graph, a `branch` is similar to an edge in a graph and a `branch3` connects three nodes
-together. An `appliance` is a component that is connected (coupled) to a node, and it is seen as a user of this node.
+together.
+An `appliance` is a component that is connected (coupled) to a node, and it is seen as a user of this node.
 
 The figure below shows a simple example:
 
@@ -63,7 +67,8 @@ source_5 (appliance)       sym_load_4 (appliance)             node_7
 * There are four nodes (points/vertices) in the graph of this simple grid.
 * `node_1` and `node_2` are connected by `line_3` which is a branch (edge).
 * `node_2`, `node_6`, and `node_7` are connected by `three_winding_transformer_8`, which is a `branch3`.
-* There are two appliances in the grid. `source_5` is coupled to `node_1` and `sym_load_4` is coupled
+* There are two appliances in the grid.
+  `source_5` is coupled to `node_1` and `sym_load_4` is coupled
   to `node_2`.
 
 ## Symmetry of Components and Calculation

--- a/docs/user_manual/data-model.md
+++ b/docs/user_manual/data-model.md
@@ -7,13 +7,11 @@ SPDX-License-Identifier: MPL-2.0
 # Component Type Hierarchy and Graph Data Model
 
 To represent the physical grid components and the calculation results, this library utilizes a graph data model.
-In this
-document, the graph data model is presented with the list of all components types, and their relevant input/output
-attributes.
+In this document, the graph data model is presented with the list of all components types, and their relevant
+input/output attributes.
 
 The components types are organized in an inheritance-like hierarchy.
-A sub-type has all the attributes from its parent
-type.
+A sub-type has all the attributes from its parent type.
 The hierarchy tree of the component types is shown below.
 
 ```{mermaid}
@@ -48,12 +46,13 @@ graph LR
 
 ```{note}
 The type names in the hierarchy are exactly the same as the component type names in
-the {py:class}`power_grid_model.power_grid_meta_data`, see [Native Data Interface](../advanced_documentation/native-data-interface.md).
+the {py:class}`power_grid_model.power_grid_meta_data`, see
+[Native Data Interface](../advanced_documentation/native-data-interface.md).
 ```
 
 There are four generic component types: `node`, `branch`, `branch3` and `appliance`.
-A `node` is similar to a vertex in a graph, a `branch` is similar to an edge in a graph and a `branch3` connects three nodes
-together.
+A `node` is similar to a vertex in a graph, a `branch` is similar to an edge in a graph and a `branch3` connects three
+nodes together.
 An `appliance` is a component that is connected (coupled) to a node, and it is seen as a user of this node.
 
 The figure below shows a simple example:
@@ -68,25 +67,29 @@ source_5 (appliance)       sym_load_4 (appliance)             node_7
 * `node_1` and `node_2` are connected by `line_3` which is a branch (edge).
 * `node_2`, `node_6`, and `node_7` are connected by `three_winding_transformer_8`, which is a `branch3`.
 * There are two appliances in the grid.
-  `source_5` is coupled to `node_1` and `sym_load_4` is coupled
-  to `node_2`.
+  `source_5` is coupled to `node_1` and `sym_load_4` is coupled to `node_2`.
 
 ## Symmetry of Components and Calculation
 
-It should be emphasized that the symmetry of components and calculation are two independent concepts in the power-grid-model. For
-instance, a model can consist of loads of both `sym_load` and `asym_load` types, which is symmetry on component level.
+It should be emphasized that the symmetry of components and calculation are two independent concepts in the
+power-grid-model.
+For instance, a model can consist of loads of both `sym_load` and `asym_load` types, which is symmetry on component
+level.
 Meanwhile, both symmetric and asymmetric calculations can be run on the same model:
 
 * In symmetric calculation, an asymmetric loads will be treated as a symmetric load by averaging the specified power
   through three phases.
-* In asymmetric calculation, a symmetric load will be treated as an asymmetric load by dividing the total
-  specified power equally into three phases.
+* In asymmetric calculation, a symmetric load will be treated as an asymmetric load by dividing the total specified
+  power equally into three phases.
 
 ## Reference Direction
 
-The sign of active/reactive power of the {ref}`user_manual/components:Branch`, {ref}`user_manual/components:Branch3`, {ref}`user_manual/components:Appliance` and
-{ref}`user_manual/components:Sensor` depends on the reference direction.
+The sign of active/reactive power of the {ref}`user_manual/components:Branch`, {ref}`user_manual/components:Branch3`,
+{ref}`user_manual/components:Appliance` and {ref}`user_manual/components:Sensor` depends on the reference direction.
 
-* For load reference direction, positive active/reactive power means the power flows *from the node to the appliance/sensor*.
-* For generator reference direction, positive active/reactive power means the power flows *from the appliance/sensor to the node*.
-* For `branch` and `branch3` type of components, positive active/reactive power means the power flows *from the node to the branch*.
+* For load reference direction, positive active/reactive power means the power flows *from the node to the*
+  *appliance/sensor*.
+* For generator reference direction, positive active/reactive power means the power flows *from the appliance/sensor to*
+  *the node*.
+* For `branch` and `branch3` type of components, positive active/reactive power means the power flows *from the node to*
+  *the branch*.

--- a/docs/user_manual/data-validator.md
+++ b/docs/user_manual/data-validator.md
@@ -9,12 +9,12 @@ SPDX-License-Identifier: MPL-2.0
 The power-grid-model repository provides an input/update data validator.
 For performance reasons, the input/update data is not automatically validated.
 However, it would be advisable to validate your data before constructing a PowerGridModel instance.
-An alternative approach would be to validate only when an exception is raised, but be aware that not all data errors will raise exceptions, most of them wil just yield invalid results without warning.
+An alternative approach would be to validate only when an exception is raised, but be aware that not all data errors
+will raise exceptions, most of them wil just yield invalid results without warning.
 The main validation functions and classes can be included from `power_grid_model.validation`.
 
 Two helper type definitions are used throughout the validation functions, `InputData` and `UpdateData`.
-They are not
-special types or classes, but merely type hinting aliases:
+They are not special types or classes, but merely type hinting aliases:
 
 ```python
 InputData = dict[str, np.ndarray]
@@ -28,8 +28,8 @@ Check the [example](examples/Validation%20Examples.ipynb) for an example of func
 ## Validation Errors
 
 Each validation error is an object which can be converted to a compact human-readable message using `str(error)`.
-It contains three member variables `component`, `field` and `ids`, which can be used to gather more specific information about the validation error,
-e.g. which object IDs are involved.
+It contains three member variables `component`, `field` and `ids`, which can be used to gather more specific information
+about the validation error, e.g. which object IDs are involved.
 
 ```py
 class ValidationError:
@@ -49,19 +49,21 @@ class ValidationError:
 ### Manual validation
 
 The validation functions below can be used to validate input/batch data manually.
-The functions require `input_data: InputData`, which is power-grid-model input data,
-and `symmetric: bool`, stating if the data will be used for symmetric or asymmetric calculations.
-`calculation_type: CalculationType` is optional and can be supplied to
-allow missing values for unused fields; see the [API reference](../api_reference/python-api-reference.md#enum) for more information.
-To validate update/batch data `update_data: UpdateData`,
-power-grid-model update data, should also be supplied.
+The functions require `input_data: InputData`, which is power-grid-model input data, and `symmetric: bool`, stating if
+the data will be used for symmetric or asymmetric calculations.
+`calculation_type: CalculationType` is optional and can be supplied to allow missing values for unused fields; see the
+[API reference](../api_reference/python-api-reference.md#enum) for more information.
+To validate update/batch data `update_data: UpdateData`, power-grid-model update data, should also be supplied.
 
 - `validate_input_data(input_data, calculation_type, symmetric) -> list[ValidationError]` validates input_data.
-- `validate_batch_data(input_data, update_data, calculation_type, symmetric) -> dict[int, list[ValidationError]]` validates input_data in combination with batch/update data.
+- `validate_batch_data(input_data, update_data, calculation_type, symmetric) -> dict[int, list[ValidationError]]`
+  validates input_data in combination with batch/update data.
 
 ```{note}
-When doing [batch calculations](./calculations.md#batch-calculations), the input data set by itself is not required to be valid, as long as all missing and invalid values are overwritten in all scenarios in the batch data set.
-This means, that `validate_input_data(input_data, **kwargs)` may fail, while `validate_batch_data(input_data, update_data, **kwargs)` may succeed.
+When doing [batch calculations](./calculations.md#batch-calculations), the input data set by itself is not required to
+be valid, as long as all missing and invalid values are overwritten in all scenarios in the batch data set.
+This means, that `validate_input_data(input_data, **kwargs)` may fail, while
+`validate_batch_data(input_data, update_data, **kwargs)` may succeed.
 In such cases, the latter is leading when only running batch calculations.
 Running single calculations on an incomplete input data set is, of course, unsupported.
 ```
@@ -69,19 +71,22 @@ Running single calculations on an incomplete input data set is, of course, unsup
 ### Assertions
 
 Instead of manual validation it is possible to use the assertion functions below to assert valid data.
-In the case of invalid data a `ValidationException` will be raised,
-which is an exception storing the name of the validated data, a list/dict of errors and a convenient conversion to string
-to display a summary of all the errors when printing the exception.
+In the case of invalid data a `ValidationException` will be raised, which is an exception storing the name of the
+validated data, a list/dict of errors and a convenient conversion to string to display a summary of all the errors when
+printing the exception.
 
 - `assert_valid_input_data(input_data, calculation_type, symmetric)` raises `ValidationException`
 - `assert_valid_batch_data(input_data, calculation_type, update_data, symmetric)` raises `ValidationException`
 
-Other than the result/exception type, the behaviour of these functions is the same as for the [manual validation](#manual-validation) functions.
+Other than the result/exception type, the behaviour of these functions is the same as for the
+[manual validation](#manual-validation) functions.
 
 ### Utilities
 
-- `errors_to_string(errors, name, details)` converts a set of errors to a human-readable (multi-line) string representation
+- `errors_to_string(errors, name, details)` converts a set of errors to a human-readable (multi-line) string
+  representation
 
 ```{seealso}
-For more information on the validation functions please see the [API reference](../api_reference/python-api-reference.md#validation).
+For more information on the validation functions please see the
+[API reference](../api_reference/python-api-reference.md#validation).
 ```

--- a/docs/user_manual/data-validator.md
+++ b/docs/user_manual/data-validator.md
@@ -6,12 +6,14 @@ SPDX-License-Identifier: MPL-2.0
 
 # Data Validator
 
-The power-grid-model repository provides an input/update data validator.  For performance reasons, the input/update data is not automatically validated.
+The power-grid-model repository provides an input/update data validator.
+For performance reasons, the input/update data is not automatically validated.
 However, it would be advisable to validate your data before constructing a PowerGridModel instance.
 An alternative approach would be to validate only when an exception is raised, but be aware that not all data errors will raise exceptions, most of them wil just yield invalid results without warning.
 The main validation functions and classes can be included from `power_grid_model.validation`.
 
-Two helper type definitions are used throughout the validation functions, `InputData` and `UpdateData`. They are not
+Two helper type definitions are used throughout the validation functions, `InputData` and `UpdateData`.
+They are not
 special types or classes, but merely type hinting aliases:
 
 ```python
@@ -46,9 +48,12 @@ class ValidationError:
 
 ### Manual validation
 
-The validation functions below can be used to validate input/batch data manually. The functions require `input_data: InputData`, which is power-grid-model input data,
-and `symmetric: bool`, stating if the data will be used for symmetric or asymmetric calculations. `calculation_type: CalculationType` is optional and can be supplied to
-allow missing values for unused fields; see the [API reference](../api_reference/python-api-reference.md#enum) for more information. To validate update/batch data `update_data: UpdateData`,
+The validation functions below can be used to validate input/batch data manually.
+The functions require `input_data: InputData`, which is power-grid-model input data,
+and `symmetric: bool`, stating if the data will be used for symmetric or asymmetric calculations.
+`calculation_type: CalculationType` is optional and can be supplied to
+allow missing values for unused fields; see the [API reference](../api_reference/python-api-reference.md#enum) for more information.
+To validate update/batch data `update_data: UpdateData`,
 power-grid-model update data, should also be supplied.
 
 - `validate_input_data(input_data, calculation_type, symmetric) -> list[ValidationError]` validates input_data.
@@ -57,12 +62,14 @@ power-grid-model update data, should also be supplied.
 ```{note}
 When doing [batch calculations](./calculations.md#batch-calculations), the input data set by itself is not required to be valid, as long as all missing and invalid values are overwritten in all scenarios in the batch data set.
 This means, that `validate_input_data(input_data, **kwargs)` may fail, while `validate_batch_data(input_data, update_data, **kwargs)` may succeed.
-In such cases, the latter is leading when only running batch calculations. Running single calculations on an incomplete input data set is, of course, unsupported.
+In such cases, the latter is leading when only running batch calculations.
+Running single calculations on an incomplete input data set is, of course, unsupported.
 ```
 
 ### Assertions
 
-Instead of manual validation it is possible to use the assertion functions below to assert valid data. In the case of invalid data a `ValidationException` will be raised,
+Instead of manual validation it is possible to use the assertion functions below to assert valid data.
+In the case of invalid data a `ValidationException` will be raised,
 which is an exception storing the name of the validated data, a list/dict of errors and a convenient conversion to string
 to display a summary of all the errors when printing the exception.
 

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 
 # Dataset Terminology
 
-Some terms regarding the data structures are explained here, including the definition of dataset, component, and attribute. For detailed data types used throughout `power-grid-model`, please refer to [Python API Reference](../api_reference/python-api-reference.md).
+Some terms regarding the data structures are explained here, including the definition of dataset, component, and attribute.
+For detailed data types used throughout `power-grid-model`, please refer to [Python API Reference](../api_reference/python-api-reference.md).
 
 ## Data structures
 
@@ -66,12 +67,15 @@ graph TD
 
 ```
 
-- **{py:class}`Dataset <power_grid_model.data_types.Dataset>`:** Either a single or a batch dataset. it is a dictionary with keys as the component types (eg. `line`, `node`, etc) and values as **ComponentData**
+- **{py:class}`Dataset <power_grid_model.data_types.Dataset>`:** Either a single or a batch dataset.
+  It is a dictionary with keys as the component types (eg. `line`, `node`, etc) and values as **ComponentData**
   - **{py:class}`SingleDataset <power_grid_model.data_types.SingleDataset>`:** A data type storing input data (i.e. all elements of all components) for a single scenario.
-  - **{py:class}`BatchDataset <power_grid_model.data_types.BatchDataset>`:** A data type storing update and or output data for one or more scenarios. A batch dataset can contain sparse or dense data, depending on the component.
+  - **{py:class}`BatchDataset <power_grid_model.data_types.BatchDataset>`:** A data type storing update and or output data for one or more scenarios.
+    A batch dataset can contain sparse or dense data, depending on the component.
 
 - **{py:class}`ComponentData <power_grid_model.data_types.ComponentData>`:** The data corresponding to the component.
-  - **{py:class}`DataArray <power_grid_model.data_types.DataArray>`:** A data array can be a single or a batch array. It is a numpy structured array.
+  - **{py:class}`DataArray <power_grid_model.data_types.DataArray>`:** A data array can be a single or a batch array.
+    It is a numpy structured array.
     - **{py:class}`SingleArray <power_grid_model.data_types.SingleArray>`:** A 1D numpy structured array corresponding to a single dataset.
     - **{py:class}`BatchArray <power_grid_model.data_types.BatchArray>`:** Multiple batches of data can be represented in sparse or dense forms.
       - **{py:class}`DenseBatchArray <power_grid_model.data_types.DenseBatchArray>`:** A 2D structured numpy array containing a list of components of the same type for each scenario.
@@ -82,7 +86,9 @@ graph TD
       - **{py:class}`DenseBatchColumnarData <power_grid_model.data_types.DenseBatchColumnarData>`:** A dictionary of attributes as keys and 2D/3D numpy array of `BatchColumn` type as values in a single dataset.
       - **{py:class}`SparseBatchColumnarData <power_grid_model.data_types.SparseBatchColumnarData>`:** A typed dictionary with a 1D numpy array of `Indexpointer` type under `indptr` key and `SingleColumn` under `data` which is all components flattened over all batches.
 
-- **{py:class}`IndexPointer <power_grid_model.data_types.IndexPointer>`:** A 1D numpy array of int64 type used to specify sparse batches. It indicates the range of components within a scenario. For example, an Index pointer  of [0, 1, 3, 3] indicates 4 batches with element indexed with 0 in 1st batch, [1, 2, 3] in 2nd batch and no elements in 3rd batch.
+- **{py:class}`IndexPointer <power_grid_model.data_types.IndexPointer>`:** A 1D numpy array of int64 type used to specify sparse batches.
+  It indicates the range of components within a scenario.
+  For example, an Index pointer  of [0, 1, 3, 3] indicates 4 batches with element indexed with 0 in 1st batch, [1, 2, 3] in 2nd batch and no elements in 3rd batch.
 - **{py:class}`SingleColumn <power_grid_model.data_types.SingleColumn>`:** A 1D/2D numpy array of values corresponding to a specific attribute.
 - **{py:class}`BatchColumn <power_grid_model.data_types.BatchColumn>`:** A 2D/3D numpy array of values corresponding to a specific attribute.
 
@@ -103,7 +109,8 @@ The dimensions of numpy arrays and the interpretation of each dimension is as fo
 
 ### Type of Dataset
 
-The types of `Dataset` include the following: `input`, `update`, `sym_output`, `asym_output`, and `sc_output`. They are included under the enum {py:class}`DatasetType <power_grid_model.typing.DatasetType>`.
+The types of `Dataset` include the following: `input`, `update`, `sym_output`, `asym_output`, and `sc_output`.
+They are included under the enum {py:class}`DatasetType <power_grid_model.typing.DatasetType>`.
 Exemplary datasets attributes are given in a dataset containing a `line` component.
 
 - **input:** Contains attributes relevant to configuration of grid.
@@ -112,14 +119,17 @@ Exemplary datasets attributes are given in a dataset containing a `line` compone
   - Example: `from_status`,`to_status`
 - **sym_output:** Contains attributes relevant to symmetrical steady state output of power flow or state estimation calculation.
   - Example: `p_from`, `p_to`
-- **asym_output:** Contains attributes relevant to asymmetrical steady state output of power flow or state estimation calculation. Attributes are similar to `sym_output` except some values of the asymmetrical dataset will contain detailed data for all 3 phases individually.
+- **asym_output:** Contains attributes relevant to asymmetrical steady state output of power flow or state estimation calculation.
+  Attributes are similar to `sym_output` except some values of the asymmetrical dataset will contain detailed data for all 3 phases individually.
   - Example: `p_from`, `p_to`
-- **sc_output:** Contains attributes relevant to symmetrical short circuit calculation output. Like for the `asym_output`, detailed data for all 3 phases will be provided where relevant.
+- **sc_output:** Contains attributes relevant to symmetrical short circuit calculation output.
+  Like for the `asym_output`, detailed data for all 3 phases will be provided where relevant.
   - Example: `i_from`, `i_from_angle`
 
 ## Terminologies related to data structures
 
-- **Component:** The definition of a part of a grid: e.g., `node`, `source`, `line`, etc. Check highlighted section of graph in [Component Hierarchy](./data-model.md#component-type-hierarchy-and-graph-data-model)
+- **Component:** The definition of a part of a grid: e.g., `node`, `source`, `line`, etc.
+  Check highlighted section of graph in [Component Hierarchy](./data-model.md#component-type-hierarchy-and-graph-data-model)
 
 - **Element:** A single instance of a node, source, line etc.
 
@@ -127,21 +137,29 @@ Exemplary datasets attributes are given in a dataset containing a `line` compone
 
 - **Value:** The value under an attribute, ie. id, energized, p, etc.
 
-- **Array:** All elements of one specific component, for one or more scenarios. I.e. a node array or line array. An array can be one dimensional (containing all elements of a single component for one scenario), two-dimensional (containing all elements of a single component for multiple scenarios), or it can be a sparse array, which is essentially a dictionary with a data buffer and an index pointer.
+- **Array:** All elements of one specific component, for one or more scenarios.
+  I.e. a node array or line array.
+  An array can be one dimensional (containing all elements of a single component for one scenario), two-dimensional (containing all elements of a single component for multiple scenarios), or it can be a sparse array, which is essentially a dictionary with a data buffer and an index pointer.
 
-`power-grid-model` can process many scenarios (e.g. time steps, switch states, etc.) at once, which we call a batch. The batch size is the number of scenarios.
+`power-grid-model` can process many scenarios (e.g. time steps, switch states, etc.) at once, which we call a batch.
+The batch size is the number of scenarios.
 
 - **Scenario:** A single time step / switch state topology.
 
-- **Batch:** The set of scenarios. (there is only one batch)
+- **Batch:** The set of scenarios.
+  (there is only one batch)
 
 - **Batch size:** The total number of scenarios in the batch.
 
-- **n_scenarios:** The total number of scenarios in the batch. (Same as Batch Size)
+- **n_scenarios:** The total number of scenarios in the batch.
+  (Same as Batch Size)
 
-- **n_component_elements_per_scenario:** The number of elements of a specific component for each scenario. This can be an integer (for dense batches), or a list of integers for sparse batches, where each integer in the list represents the number of elements of a specific component for the scenario corresponding to the index of the integer.
+- **n_component_elements_per_scenario:** The number of elements of a specific component for each scenario.
+  This can be an integer (for dense batches), or a list of integers for sparse batches, where each integer in the list represents the number of elements of a specific component for the scenario corresponding to the index of the integer.
 
-- **Sub-batch:** When computing in parallel, all scenarios in batch calculation are distributed over threads. Each thread handles a subset of the `Batch`, called a `Sub-batch`. This is only used internally in the C++ code.
+- **Sub-batch:** When computing in parallel, all scenarios in batch calculation are distributed over threads.
+  Each thread handles a subset of the `Batch`, called a `Sub-batch`.
+  This is only used internally in the C++ code.
 
 ## Attributes of Components
 

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -6,8 +6,10 @@ SPDX-License-Identifier: MPL-2.0
 
 # Dataset Terminology
 
-Some terms regarding the data structures are explained here, including the definition of dataset, component, and attribute.
-For detailed data types used throughout `power-grid-model`, please refer to [Python API Reference](../api_reference/python-api-reference.md).
+Some terms regarding the data structures are explained here, including the definition of dataset, component, and
+attribute.
+For detailed data types used throughout `power-grid-model`, please refer to
+ [Python API Reference](../api_reference/python-api-reference.md).
 
 ## Data structures
 
@@ -69,28 +71,45 @@ graph TD
 
 - **{py:class}`Dataset <power_grid_model.data_types.Dataset>`:** Either a single or a batch dataset.
   It is a dictionary with keys as the component types (eg. `line`, `node`, etc) and values as **ComponentData**
-  - **{py:class}`SingleDataset <power_grid_model.data_types.SingleDataset>`:** A data type storing input data (i.e. all elements of all components) for a single scenario.
-  - **{py:class}`BatchDataset <power_grid_model.data_types.BatchDataset>`:** A data type storing update and or output data for one or more scenarios.
+  - **{py:class}`SingleDataset <power_grid_model.data_types.SingleDataset>`:** A data type storing input data (i.e. all
+    elements of all components) for a single scenario.
+  - **{py:class}`BatchDataset <power_grid_model.data_types.BatchDataset>`:** A data type storing update and or output
+    data for one or more scenarios.
     A batch dataset can contain sparse or dense data, depending on the component.
 
 - **{py:class}`ComponentData <power_grid_model.data_types.ComponentData>`:** The data corresponding to the component.
   - **{py:class}`DataArray <power_grid_model.data_types.DataArray>`:** A data array can be a single or a batch array.
     It is a numpy structured array.
-    - **{py:class}`SingleArray <power_grid_model.data_types.SingleArray>`:** A 1D numpy structured array corresponding to a single dataset.
-    - **{py:class}`BatchArray <power_grid_model.data_types.BatchArray>`:** Multiple batches of data can be represented in sparse or dense forms.
-      - **{py:class}`DenseBatchArray <power_grid_model.data_types.DenseBatchArray>`:** A 2D structured numpy array containing a list of components of the same type for each scenario.
-      - **{py:class}`SparseBatchArray <power_grid_model.data_types.SparseBatchArray>`:** A typed dictionary with a 1D numpy array of `Indexpointer` type under `indptr` key and `SingleArray` under `data` key which is all components flattened over all batches.
-  - **{py:class}`ColumnarData <power_grid_model.data_types.ColumnarData>`:** A dictionary of attributes as keys and individual numpy arrays as values.
-    - **{py:class}`SingleColumnarData <power_grid_model.data_types.SingleColumnarData>`:** A dictionary of attributes as keys and `SingleColumn` as values in a single dataset.
-    - **{py:class}`BatchColumnarData <power_grid_model.data_types.BatchColumnarData>`:** Multiple batches of data can be represented in sparse or dense forms.
-      - **{py:class}`DenseBatchColumnarData <power_grid_model.data_types.DenseBatchColumnarData>`:** A dictionary of attributes as keys and 2D/3D numpy array of `BatchColumn` type as values in a single dataset.
-      - **{py:class}`SparseBatchColumnarData <power_grid_model.data_types.SparseBatchColumnarData>`:** A typed dictionary with a 1D numpy array of `Indexpointer` type under `indptr` key and `SingleColumn` under `data` which is all components flattened over all batches.
+    - **{py:class}`SingleArray <power_grid_model.data_types.SingleArray>`:** A 1D numpy structured array corresponding
+      to a single dataset.
+    - **{py:class}`BatchArray <power_grid_model.data_types.BatchArray>`:** Multiple batches of data can be represented
+      in sparse or dense forms.
+      - **{py:class}`DenseBatchArray <power_grid_model.data_types.DenseBatchArray>`:** A 2D structured numpy array
+        containing a list of components of the same type for each scenario.
+      - **{py:class}`SparseBatchArray <power_grid_model.data_types.SparseBatchArray>`:** A typed dictionary with a 1D
+        numpy array of `Indexpointer` type under `indptr` key and `SingleArray` under `data` key which is all components
+        flattened over all batches.
+  - **{py:class}`ColumnarData <power_grid_model.data_types.ColumnarData>`:** A dictionary of attributes as keys and
+    individual numpy arrays as values.
+    - **{py:class}`SingleColumnarData <power_grid_model.data_types.SingleColumnarData>`:** A dictionary of attributes as
+      keys and `SingleColumn` as values in a single dataset.
+    - **{py:class}`BatchColumnarData <power_grid_model.data_types.BatchColumnarData>`:** Multiple batches of data can be
+      represented in sparse or dense forms.
+      - **{py:class}`DenseBatchColumnarData <power_grid_model.data_types.DenseBatchColumnarData>`:** A dictionary of
+        attributes as keys and 2D/3D numpy array of `BatchColumn` type as values in a single dataset.
+      - **{py:class}`SparseBatchColumnarData <power_grid_model.data_types.SparseBatchColumnarData>`:** A typed
+        dictionary with a 1D numpy array of `Indexpointer` type under `indptr` key and `SingleColumn` under `data` which
+        is all components flattened over all batches.
 
-- **{py:class}`IndexPointer <power_grid_model.data_types.IndexPointer>`:** A 1D numpy array of int64 type used to specify sparse batches.
+- **{py:class}`IndexPointer <power_grid_model.data_types.IndexPointer>`:** A 1D numpy array of int64 type used to
+  specify sparse batches.
   It indicates the range of components within a scenario.
-  For example, an Index pointer  of [0, 1, 3, 3] indicates 4 batches with element indexed with 0 in 1st batch, [1, 2, 3] in 2nd batch and no elements in 3rd batch.
-- **{py:class}`SingleColumn <power_grid_model.data_types.SingleColumn>`:** A 1D/2D numpy array of values corresponding to a specific attribute.
-- **{py:class}`BatchColumn <power_grid_model.data_types.BatchColumn>`:** A 2D/3D numpy array of values corresponding to a specific attribute.
+  For example, an Index pointer  of [0, 1, 3, 3] indicates 4 batches with element indexed with 0 in 1st batch, [1, 2, 3]
+  in 2nd batch and no elements in 3rd batch.
+- **{py:class}`SingleColumn <power_grid_model.data_types.SingleColumn>`:** A 1D/2D numpy array of values corresponding
+  to a specific attribute.
+- **{py:class}`BatchColumn <power_grid_model.data_types.BatchColumn>`:** A 2D/3D numpy array of values corresponding to
+  a specific attribute.
 
 ### Dimensions of numpy arrays
 
@@ -117,10 +136,13 @@ Exemplary datasets attributes are given in a dataset containing a `line` compone
   - Example: `id`, `from_node`, `from_status`
 - **update:** Contains attributes relevant to multiple scenarios.
   - Example: `from_status`,`to_status`
-- **sym_output:** Contains attributes relevant to symmetrical steady state output of power flow or state estimation calculation.
+- **sym_output:** Contains attributes relevant to symmetrical steady state output of power flow or state estimation
+  calculation.
   - Example: `p_from`, `p_to`
-- **asym_output:** Contains attributes relevant to asymmetrical steady state output of power flow or state estimation calculation.
-  Attributes are similar to `sym_output` except some values of the asymmetrical dataset will contain detailed data for all 3 phases individually.
+- **asym_output:** Contains attributes relevant to asymmetrical steady state output of power flow or state estimation
+  calculation.
+  Attributes are similar to `sym_output` except some values of the asymmetrical dataset will contain detailed data for
+  all 3 phases individually.
   - Example: `p_from`, `p_to`
 - **sc_output:** Contains attributes relevant to symmetrical short circuit calculation output.
   Like for the `asym_output`, detailed data for all 3 phases will be provided where relevant.
@@ -129,7 +151,8 @@ Exemplary datasets attributes are given in a dataset containing a `line` compone
 ## Terminologies related to data structures
 
 - **Component:** The definition of a part of a grid: e.g., `node`, `source`, `line`, etc.
-  Check highlighted section of graph in [Component Hierarchy](./data-model.md#component-type-hierarchy-and-graph-data-model)
+  Check highlighted section of graph in
+  [Component Hierarchy](./data-model.md#component-type-hierarchy-and-graph-data-model)
 
 - **Element:** A single instance of a node, source, line etc.
 
@@ -139,7 +162,9 @@ Exemplary datasets attributes are given in a dataset containing a `line` compone
 
 - **Array:** All elements of one specific component, for one or more scenarios.
   I.e. a node array or line array.
-  An array can be one dimensional (containing all elements of a single component for one scenario), two-dimensional (containing all elements of a single component for multiple scenarios), or it can be a sparse array, which is essentially a dictionary with a data buffer and an index pointer.
+  An array can be one dimensional (containing all elements of a single component for one scenario), two-dimensional
+  (containing all elements of a single component for multiple scenarios), or it can be a sparse array, which is
+  essentially a dictionary with a data buffer and an index pointer.
 
 `power-grid-model` can process many scenarios (e.g. time steps, switch states, etc.) at once, which we call a batch.
 The batch size is the number of scenarios.
@@ -155,7 +180,8 @@ The batch size is the number of scenarios.
   (Same as Batch Size)
 
 - **n_component_elements_per_scenario:** The number of elements of a specific component for each scenario.
-  This can be an integer (for dense batches), or a list of integers for sparse batches, where each integer in the list represents the number of elements of a specific component for the scenario corresponding to the index of the integer.
+  This can be an integer (for dense batches), or a list of integers for sparse batches, where each integer in the list
+  represents the number of elements of a specific component for the scenario corresponding to the index of the integer.
 
 - **Sub-batch:** When computing in parallel, all scenarios in batch calculation are distributed over threads.
   Each thread handles a subset of the `Batch`, called a `Sub-batch`.

--- a/docs/user_manual/model-validation.md
+++ b/docs/user_manual/model-validation.md
@@ -71,7 +71,7 @@ A transformer can be 4 states, closed on both ends, open on both ends and open o
 The tap changing functionality is tested using a batch calculation for various tap positions.
 
 ```{note}
-- Asymmetrical calculations are possible only for grounded network transformer in pandapower. 
+- Asymmetrical calculations are possible only for grounded network transformer in pandapower.
 Hence open cases are not evaluated.
 - Relaxed tolerance parameters are used in asymmetric calculation 
 because only 'T' transformer model is available in pandapower while power-grid-model uses 'pi' model.
@@ -119,7 +119,8 @@ While source is present in all cases, this case tests two sources being used tog
 
 ### Symmetrical Load
 
-A symmetrical load can be in open or closed state. It can be of 3 types: constant power, constant impedance and constant current.
+A symmetrical load can be in open or closed state.
+It can be of 3 types: constant power, constant impedance and constant current.
 
 ```{tikz}
 :alt: sym_load
@@ -135,7 +136,8 @@ A symmetrical load can be in open or closed state. It can be of 3 types: constan
 
 ### Symmetrical generator
 
-A symmetrical generator can be in open or closed state. It can be of 3 types: constant power, constant impedance and constant current.
+A symmetrical generator can be in open or closed state.
+It can be of 3 types: constant power, constant impedance and constant current.
 
 ```{tikz}
 :alt: sym_gen
@@ -150,7 +152,7 @@ A symmetrical generator can be in open or closed state. It can be of 3 types: co
 ```
 
 ```{note}
-Only constant power implementation is possible in pandapower for asymmetrical calculations. 
+Only constant power implementation is possible in pandapower for asymmetrical calculations.
 All the Z, I and P loads are already validated for symmetrical calculation.
 ```
 
@@ -275,11 +277,13 @@ The test grid is as follows:
 
 There are 4 cases for the 4 types of fault: three_phase, single_phase_ground, two_phase, two_phase_ground.
 Each case is tested for `minimum` and `maximum` voltage scaling.
-Each case has multiple scenarios. They are combinations of following situations:
+Each case has multiple scenarios.
+They are combinations of following situations:
 
 - Valid phase combinations: abc, a, b, c, ab, bc, ac
 - Source switched on or off (highlighted in green)
-- A shunt with only `b0` value modelled to be a grounding transformer switched on or off. (highlighted in blue)
+- A shunt with only `b0` value modelled to be a grounding transformer switched on or off.
+  (highlighted in blue)
 - Fault locations (highlighted in red)
 - Fault impedance: hard ground or with impedance.
 

--- a/docs/user_manual/model-validation.md
+++ b/docs/user_manual/model-validation.md
@@ -6,9 +6,11 @@ SPDX-License-Identifier: MPL-2.0
 
 # Model validation
 
-The implementation of power-grid-model is validated using multiple test cases present in {{ "[tests/data]({}/tests/data)".format(gh_link_head_tree) }} folder.
+The implementation of power-grid-model is validated using multiple test cases present in
+{{ "[tests/data]({}/tests/data)".format(gh_link_head_tree) }} folder.
 There are 2 simple grid test case examples of power-grid-model validated using Vision and GAIA.
-A thorough validation is done using minimal test cases of each component and 2 test networks described in the following sections.
+A thorough validation is done using minimal test cases of each component and 2 test networks described in the following
+sections.
 
 ## Minimal test cases in pandapower
 
@@ -16,13 +18,15 @@ Their results are validated against the [pandapower](http://www.pandapower.org/)
 
 The cases of a differences in modelling between both the libraries are handled by theoretical workarounds.
 For example in power-grid-model, source impedance is included for all component sequences.
-In pandapower, source impedance is present only in positive sequence network whereas it considered in all sequence components in power-grid-model.
+In pandapower, source impedance is present only in positive sequence network whereas it considered in all sequence
+components in power-grid-model.
 Source impedance is then set to a low value to match this modelling difference.
 Hence, the result of source component here should be ignored.
 The output result attributes of power-grid-model are validated at a tolerance value of $\pm10^{-5}$ of respective unit.
 Both the iterative algorithms: Newton Raphson and Iterative current are validated.
 
-All the test cases can be found in {{ "[/tests/data/power_flow/pandapower]({}/tests/data/power_flow/pandapower)".format(gh_link_head_tree) }}.
+All the test cases can be found in
+{{ "[/tests/data/power_flow/pandapower]({}/tests/data/power_flow/pandapower)".format(gh_link_head_tree) }}.
 
 ### Node
 
@@ -72,9 +76,9 @@ The tap changing functionality is tested using a batch calculation for various t
 
 ```{note}
 - Asymmetrical calculations are possible only for grounded network transformer in pandapower.
-Hence open cases are not evaluated.
-- Relaxed tolerance parameters are used in asymmetric calculation 
-because only 'T' transformer model is available in pandapower while power-grid-model uses 'pi' model.
+  Hence open cases are not evaluated.
+- Relaxed tolerance parameters are used in asymmetric calculation because only 'T' transformer model is available in
+  pandapower while power-grid-model uses 'pi' model.
 ```
 
 ```{tikz}
@@ -227,7 +231,8 @@ The circuit diagram is as follows (The node 6 is same in both lines):
 
 ## Vision validation case
 
-There are 2 test grid cases included for validation against vision: A minimal example and a network containing all components supported by power-grid-model-io
+There are 2 test grid cases included for validation against vision: A minimal example and a network containing all
+components supported by power-grid-model-io.
 Their Vision files are included as well.
 
 ### Simple example
@@ -236,18 +241,23 @@ The `vision-example` is a minimal case with only node, source, cable and load.
 
 ### Network case
 
-The Vision files were exported to excel which was then converted to power-grid-model input using [power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io).
+The Vision files were exported to excel which was then converted to power-grid-model input using
+[power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io).
 The `vision-network` case has the following characteristics:
 
 - It contains 26 nodes (plus 20 from transformer load secondary node).
 - The voltage level of grid input is at 110kV from which it is stepped down to 10.5kV level.
-- On the 10.5kV level, one minimal distribution grid containing transformer loads, wind and PV generation and one additional reactance coil.
-- All the remaining supported components for which conversion to power-grid-model is supported are also connected to this level.
+- On the 10.5kV level, one minimal distribution grid containing transformer loads, wind and PV generation and one
+  additional reactance coil.
+- All the remaining supported components for which conversion to power-grid-model is supported are also connected to
+  this level.
   They include: line, reactance, special transformer, load, synchronous generator, shunt and zig-zag transformer.
 
-The cases are built taking into consideration the modelling differences between Vision and power-grid-model mentioned in the [power-grid-model-io documentation](https://power-grid-model-io.readthedocs.io/).
+The cases are built taking into consideration the modelling differences between Vision and power-grid-model mentioned in
+the [power-grid-model-io documentation](https://power-grid-model-io.readthedocs.io/).
 The node voltages and branch power flows are validated for symmetrical calculation.
-For asymmetrical output only the result attributes being validated are the ones which can be exported to excel. (ie. node voltages and branch currents)
+For asymmetrical output only the result attributes being validated are the ones which can be exported to excel. (ie.
+node voltages and branch currents)
 The absolute tolerances here are set to the least count of the Vision result export: till ie. till V and kW level.
 
 ## Short Circuit Calculation cases

--- a/docs/user_manual/performance-guide.md
+++ b/docs/user_manual/performance-guide.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: MPL-2.0
 # Guidelines for performance enhancement
 
 The `power-grid-model` is a library that shines in its ability to handle calculations at scale.
-It remains performant, even when doing calculations with one or a combination of the following extremes (non-exhaustive):
+It remains performant, even when doing calculations with one or a combination of the following extremes
+(non-exhaustive):
 
 - Large grids
 - Batch calculations with many scenarios
@@ -18,17 +19,23 @@ To use those optimizations to the fullest, we recommend our users to follow the 
 
 ## Data validity
 
-Many of our optimizations assume input data validity and rely on the fact that the provided grid is reasonably close to realistic.
-Non-convergence, underdetermined equations or other unexpected behavior may therefore be encountered when the data is not realistic.
+Many of our optimizations assume input data validity and rely on the fact that the provided grid is reasonably close to
+realistic.
+Non-convergence, underdetermined equations or other unexpected behavior may therefore be encountered when the data is
+not realistic.
 
-To keep the PGM performant, checks on hard physical bounds are offloaded to a separate tool, i.e., the [data validator](data-validator.md).
-However, these checks can be prohibitively expensive and application at scale in production environments is therefore not recommended when performance matters.
+To keep the PGM performant, checks on hard physical bounds are offloaded to a separate tool, i.e., the
+[data validator](data-validator.md).
+However, these checks can be prohibitively expensive and application at scale in production environments is therefore
+not recommended when performance matters.
 Instead, we recommend using the data validator specifically for debugging purposes.
 
 ```{note}
-Some combinations of input data are not forbidden by physics, but still pose unrealistic conditions, e.g., a source with a very low short-circuit power.
+Some combinations of input data are not forbidden by physics, but still pose unrealistic conditions, e.g., a source with
+a very low short-circuit power.
 These cases may result in unexpected behavior of the calculation core.
-Vagueness and case-dependence make it hard to check what can be considered "unrealistic", and the [data validator](data-validator.md) will therefore not catch such cases.
+Vagueness and case-dependence make it hard to check what can be considered "unrealistic", and the
+[data validator](data-validator.md) will therefore not catch such cases.
 We recommend our users to provide reasonably realistic scenarios to prevent these edge cases from happening.
 ```
 
@@ -38,24 +45,32 @@ The data format of input, output and update data can have a big effect on memory
 
 ### Input/update data volume
 
-Row-based data (created, e.g., using {py:class}`power_grid_model.initialize_array` in Python) constructs input/update data with all attributes for a given dataset type.
+Row-based data (created, e.g., using {py:class}`power_grid_model.initialize_array` in Python) constructs input/update
+data with all attributes for a given dataset type.
 However, many component attributes are optional.
 If your use case does not depend on these attributes, a lot of data is needlessly created and initialized.
-If you are running on a system where memory is the bottle-neck, using a columnar data format may reduce the memory footprint. This may or may not induce a slight computational overhead during calculations.
+If you are running on a system where memory is the bottle-neck, using a columnar data format may reduce the memory
+footprint.
+This may or may not induce a slight computational overhead during calculations.
 
 ### Output data volume
 
 For most use cases, only certain output values are relevant.
-For example, if you are only interested in line loading, outputting all other components and attributes results in unnecessary overhead.
-The output data may be a significant, if not the dominant, contributor to memory load, particularly when running large batch calculations.
-We therefore recommend restricting the output data to only the components and attributes that are used by the user in such production environments.
-In Python, it is possible to do so by using the `output_component_types` keyword argument in the `calculate_*` functions (like {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`)
+For example, if you are only interested in line loading, outputting all other components and attributes results in
+unnecessary overhead.
+The output data may be a significant, if not the dominant, contributor to memory load, particularly when running large
+batch calculations.
+We therefore recommend restricting the output data to only the components and attributes that are used by the user in
+such production environments.
+In Python, it is possible to do so by using the `output_component_types` keyword argument in the `calculate_*` functions
+(like {py:class}`power_grid_model.PowerGridModel.calculate_power_flow`)
 
 ### Database integration
 
 Most databases store their data in a columnar data format.
 Copying, reserving unused memory, and cache misses can lead to unnecessary memory usage and computational overhead.
-With the introduction of columnar data input to PGM, integrating with databases using this format becomes easier, more natural, and more efficient.
+With the introduction of columnar data input to PGM, integrating with databases using this format becomes easier, more
+natural, and more efficient.
 
 ## Batch calculations
 
@@ -68,7 +83,8 @@ Depending on the details of the batch, a number of performance optimizations are
 
 Topology is an expensive step in calculations.
 Fortunately, the topology can be cached when there are no structural changes to the power grid itself.
-For the power-grid-model, this is the case when there no changes to statuses (`from_status`, `to_status`, `status`, etc.) of the following components:
+For the power-grid-model, this is the case when there no changes to statuses (`from_status`, `to_status`, `status`,
+etc.) of the following components:
 
 1. Branches: Lines, Links, Transformers
 2. Branch3: Three winding transformer
@@ -76,23 +92,30 @@ For the power-grid-model, this is the case when there no changes to statuses (`f
 
 In particular, the topology is cached in the following way:
 
-- If none of the provided batch scenarios change the status of branches and sources, the model will re-use the pre-built internal graph/matrices for each calculation. Time-series load profile calculation is a typical use case.
-- If some batch scenarios are changing the switching status of branches and sources, the topology changes and is thus reconstructed before and after each scenario that does so. N-1 check is a typical use case.
+- If none of the provided batch scenarios change the status of branches and sources, the model will re-use the pre-built
+  internal graph/matrices for each calculation.
+  Time-series load profile calculation is a typical use case.
+- If some batch scenarios are changing the switching status of branches and sources, the topology changes and is thus
+  reconstructed before and after each scenario that does so.
+  N-1 check is a typical use case.
 
 As such, the following rule-of-thumb holds:
 
 ```{note}
-Scenarios that change the same status attributes the same way should be fed to the power-grid-model together as much as possible. 
+Scenarios that change the same status attributes the same way should be fed to the power-grid-model together as much as
+possible.
 ```
 
 In practice, this means:
 
-- In use cases that require many different parameter calculations for only a small set of different topologies, it is recommended to split the calculation in separate batches - one for each topology - to optimize performance.
+- In use cases that require many different parameter calculations for only a small set of different topologies, it is
+- recommended to split the calculation in separate batches - one for each topology - to optimize performance.
 - Otherwise, it is recommended to sort the scenarios by topology to minimize the amount of reconstructions.
 
 ### Batch data set
 
-In the [Calculations documentation](calculations.md#batch-data-set), the distinction is made between independent and dependent batches.
+In the [Calculations documentation](calculations.md#batch-data-set), the distinction is made between independent and
+dependent batches.
 Both types of batches allow for different performance optimizations.
 To ensure that the right choice is always made, the following rule-of-thumb may be used:
 
@@ -103,23 +126,28 @@ Sparsity of sampling should be reflected by sparsity in the batch update paramet
 To elaborate:
 
 - Dependent batches are useful for a sparse sampling for many different components, e.g. for N-1 checks.
-- Independent batches are useful for a dense sampling of a small subset of components, e.g. time series power flow calculation.
+- Independent batches are useful for a dense sampling of a small subset of components, e.g. time series power flow
+- calculation.
 
 ## Parallel computing
 
 If the host system supports it, parallel computation is an easy way to gain performance.
-As mentioned in the [Calculations](calculations.md#parallel-computing), letting the power-grid-model determine the amount of threads is recommended.
+As mentioned in the [Calculations](calculations.md#parallel-computing), letting the power-grid-model determine the
+amount of threads is recommended.
 
 ## Matrix prefactorization
 
-Every iteration of power-flow or state estimation has a step of solving large number of sparse linear equations, i.e. `AX=b` in matrix form.
+Every iteration of power-flow or state estimation has a step of solving large number of sparse linear equations, i.e.
+`AX=b` in matrix form.
 Computation wise this is a very expensive step.
 One major component of this step is factorization of the `A` matrix.
-In certain calculation methods, this `A` matrix and its factorization remains unchanged
-over iterations and batches (only specific cases).
+In certain calculation methods, this `A` matrix and its factorization remains unchanged over iterations and batches
+(only specific cases).
 This makes it possible to reuse the factorization, skip this step and improve performance.
 
 ```{note}
-Prefactorization over batches is possible when switching status or specified power values of load/generation or source reference voltage is modified.
-It is not possible when topology or grid parameters are modified, i.e. in switching of branches, shunt, sources or change in transformer tap positions.
+Prefactorization over batches is possible when switching status or specified power values of load/generation or source
+reference voltage is modified.
+It is not possible when topology or grid parameters are modified, i.e. in switching of branches, shunt, sources or
+change in transformer tap positions.
 ```

--- a/docs/user_manual/serialization.md
+++ b/docs/user_manual/serialization.md
@@ -8,7 +8,9 @@ SPDX-License-Identifier: MPL-2.0
 
 The power-grid-model provides tools for serialization and deserialization for datasets.
 
-Visit the [Python API Reference](../api_reference/python-api-reference.md#utils) and [C API Reference](../api_reference/power-grid-model-c-api-reference.rst) for the full documentation of the serialization tools.
+Visit the [Python API Reference](../api_reference/python-api-reference.md#utils) and
+[C API Reference](../api_reference/power-grid-model-c-api-reference.rst) for the full documentation of the serialization
+tools.
 
 ## Serialization format
 
@@ -19,123 +21,162 @@ Currently, two serialization formats are provided:
 
 ### JSON serialization format specification
 
-The JSON serialization format is a generic format and supports all [dataset types and structures](dataset-terminology.md#data-structures).
+The JSON serialization format is a generic format and supports all
+[dataset types and structures](dataset-terminology.md#data-structures).
 Rather than providing a full schema, this documentation provides the features by object.
 
 #### JSON schema root object
 
-The format consists of a [`PowerGridModelRoot`](#json-schema-root-object) JSON object containing metadata and the actual data.
+The format consists of a [`PowerGridModelRoot`](#json-schema-root-object) JSON object containing metadata and the actual
+data.
 
 - [`PowerGridModelRoot`](#json-schema-root-object): `Object`
   - `version`: `string` containing the schema version (required, current version is `"1.0"`)
   - `type`: `string` containing the dataset type, e.g. `"input"`, `"update"`, etc.
   - `is_batch`: `boolean` flag that describes whether the dataset is a batch or not.
-  - `attributes`: [`Attributes`](#json-schema-attributes-object) containing specified attributes per component type (e.g.: `"node"`).
+  - `attributes`: [`Attributes`](#json-schema-attributes-object) containing specified attributes per component type
+    (e.g.: `"node"`).
   - `data`: [`Dataset`](#json-schema-dataset-object) containing the actual dataset.
 
 #### JSON schema attributes object
 
-[`Attributes`](#json-schema-attributes-object) contains specified attributes per [`Component`](#json-schema-component) type (e.g.: `"node"`).
-It is only required for those components that contain `HomogeneousComponentData` objects and that data needs to follow the attributes listed in this object.
+[`Attributes`](#json-schema-attributes-object) contains specified attributes per [`Component`](#json-schema-component)
+type (e.g.: `"node"`).
+It is only required for those components that contain `HomogeneousComponentData` objects and that data needs to follow
+the attributes listed in this object.
 It may be empty if for data for all instances certain component is `InhomogeneousComponentData`.
 It reduces compression when a dataset largely follows the exact same pattern.
 
 - [`Attributes`](#json-schema-attributes-object): `Object`
-  - [`Component`](#json-schema-component): [`ComponentAttributes`](#json-schema-component-attributes) containing the desired [`Attribute`](#json-schema-attribute)s for that [`Component`](#json-schema-component).
+  - [`Component`](#json-schema-component): [`ComponentAttributes`](#json-schema-component-attributes) containing the
+    desired [`Attribute`](#json-schema-attribute)s for that [`Component`](#json-schema-component).
 
-For example, for an `"update"` dataset that contains only updates to the `"from_status"` attribute of `"branch"` components, it may be `{"branch": ["from_status"]}`.
+For example, for an `"update"` dataset that contains only updates to the `"from_status"` attribute of `"branch"`
+components, it may be `{"branch": ["from_status"]}`.
 
 #### JSON schema component
 
-A [`Component`](#json-schema-component) string contains the component name (see also the [Components](components.md) reference).
+A [`Component`](#json-schema-component) string contains the component name (see also the [Components](components.md)
+reference).
 E.g.: `"node"`
 
 - [`Component`](#json-schema-component): `string`
 
 #### JSON schema component attributes
 
-A [`ComponentAttributes`](#json-schema-component-attributes) array contains the desired [`Attribute`](#json-schema-attribute)s for a specific [`Component`](#json-schema-component).
+A [`ComponentAttributes`](#json-schema-component-attributes) array contains the desired
+[`Attribute`](#json-schema-attribute)s for a specific [`Component`](#json-schema-component).
 
 - [`ComponentAttributes`](#json-schema-component-attributes): `Array`
   - [`Attribute`](#json-schema-attribute): the attribute
 
 #### JSON schema attribute
 
-A [`Attribute`](#json-schema-attribute) string contains the name of an attribute of a component (see also the [Components](components.md) reference).
+A [`Attribute`](#json-schema-attribute) string contains the name of an attribute of a component (see also the
+[Components](components.md) reference).
 E.g.: `"id"`.
 
 - [`Attribute`](#json-schema-attribute): `string`
 
 #### JSON schema dataset object
 
-The [`Dataset`](#json-schema-dataset-object) object is either a [`SingleDataset`](#json-schema-single-dataset-object) if the [`is_batch`](#json-schema-root-object) field in the [`PowerGridModelRoot`](#json-schema-root-object) object is `false`, or a [`BatchDataset`](#json-schema-batch-dataset-object) otherwise.
+The [`Dataset`](#json-schema-dataset-object) object is either a [`SingleDataset`](#json-schema-single-dataset-object) if
+the [`is_batch`](#json-schema-root-object) field in the [`PowerGridModelRoot`](#json-schema-root-object) object is
+`false`, or a [`BatchDataset`](#json-schema-batch-dataset-object) otherwise.
 
-- [`Dataset`](#json-schema-dataset-object): [`SingleDataset`](#json-schema-single-dataset-object) | [`BatchDataset`](#json-schema-batch-dataset-object)
+- [`Dataset`](#json-schema-dataset-object): [`SingleDataset`](#json-schema-single-dataset-object) |
+  [`BatchDataset`](#json-schema-batch-dataset-object)
 
 #### JSON schema single dataset object
 
-A [`SingleDataset`](#json-schema-single-dataset-object) object contains the [`ComponentDataset`](#json-schema-component-dataset-object) for each component.
+A [`SingleDataset`](#json-schema-single-dataset-object) object contains the
+[`ComponentDataset`](#json-schema-component-dataset-object) for each component.
 
 - [`SingleDataset`](#json-schema-single-dataset-object): `Object`
-  - [`Component`](#json-schema-component): [`ComponentDataset`](#json-schema-component-dataset-object) the component dataset.
+  - [`Component`](#json-schema-component): [`ComponentDataset`](#json-schema-component-dataset-object) the component
+    dataset.
 
 #### JSON schema batch dataset object
 
-A [`BatchDataset`](#json-schema-batch-dataset-object) is an array containing [`SingleDataset`](#json-schema-single-dataset-object) objects for all batch scenarios.
+A [`BatchDataset`](#json-schema-batch-dataset-object) is an array containing
+[`SingleDataset`](#json-schema-single-dataset-object) objects for all batch scenarios.
 
 - [`BatchDataset`](#json-schema-batch-dataset-object): `Array`
   - [`SingleDataset`](#json-schema-single-dataset-object): a single dataset per batch scenario.
 
 **NOTE:** The actual deserialized data representation may be sparse or dense, depending on the contents.
-Regardless of whether the deserialized data representation data is sparse or dense, the serialization format remains the same.
+Regardless of whether the deserialized data representation data is sparse or dense, the serialization format remains the
+same.
 
 #### JSON schema component dataset object
 
-A [`ComponentDataset`](#json-schema-component-dataset-object) is an array of [`ComponentData`](#json-schema-component-data-object)s per component of the same type.
+A [`ComponentDataset`](#json-schema-component-dataset-object) is an array of
+[`ComponentData`](#json-schema-component-data-object)s per component of the same type.
 
 - [`ComponentDataset`](#json-schema-component-dataset-object): `Array`
   - [`ComponentData`](#json-schema-component-data-object): the data per single component.
 
-**NOTE:** The actual deserialized data representation may be row based or columnar, depending on the `data_filter` provided at deserialization (Check {py:function}`json_deserialize <power_grid_model.utils.json_deserialize>` for example).
-Regardless of whether the deserialized data representation data is row based or columnar, the serialization format remains the same.
+**NOTE:** The actual deserialized data representation may be row based or columnar, depending on the `data_filter`
+provided at deserialization (Check {py:function}`json_deserialize <power_grid_model.utils.json_deserialize>` for
+example).
+Regardless of whether the deserialized data representation data is row based or columnar, the serialization format
+remains the same.
 
 #### JSON schema component data object
 
-A [`ComponentData`](#json-schema-component-data-object) object is either a [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) object or an [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object) object
+A [`ComponentData`](#json-schema-component-data-object) object is either a
+[`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) object or an
+[`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object) object
 
-- [`ComponentData`](#json-schema-component-data-object): [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) | [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object)
+- [`ComponentData`](#json-schema-component-data-object):
+  [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) |
+  [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object)
 
 #### JSON schema homogeneous component data object
 
-A [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) object contains the actual values of a certain component following the exact order of the attributes listed in the [`attributes`](#json-schema-root-object) field in the [`PowerGridModelRoot`](#json-schema-root-object) object.
+A [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) object contains the actual values of a
+certain component following the exact order of the attributes listed in the [`attributes`](#json-schema-root-object)
+field in the [`PowerGridModelRoot`](#json-schema-root-object) object.
 
 - [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object): `Array`
   - [`AttributeValue`](#json-schema-attribute-value): the value of each attribute.
 
 #### JSON schema inhomogeneous component data object
 
-An [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object) object contains actual values per attribute of a certain component.
-Contrary to the [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object), it lists the names of the attributes for which the values are specified, so the attributes may be in arbitrary order and do not have to follow the schema listed in the [`attributes`](#json-schema-root-object) field in the [`PowerGridModelRoot`](#json-schema-root-object) object.
+An [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object) object contains actual values per
+attribute of a certain component.
+Contrary to the [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object), it lists the names of the
+attributes for which the values are specified, so the attributes may be in arbitrary order and do not have to follow the
+schema listed in the [`attributes`](#json-schema-root-object) field in the
+[`PowerGridModelRoot`](#json-schema-root-object) object.
 
 - [`InhomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object): `Object`
-  - [`Attribute`](#json-schema-attribute): [`AttributeValue`](#json-schema-attribute-value): the value of each attribute per attribute.
+  - [`Attribute`](#json-schema-attribute): [`AttributeValue`](#json-schema-attribute-value): the value of each attribute
+    per attribute.
 
 #### JSON schema attribute value
 
 The [`AttributeValue`](#json-schema-attribute-value) contains the actual value of an attribute.
-The value can be any of [`null`](#json-schema-null-absence-of-value) if it is not provided, or any of [`int32_t`](#json-schema-int32_t), [`int8_t`](#json-schema-int8_t), [`double`](#json-schema-double), [`RealValueInput`](#json-schema-realvalueinput) or [`RealValueOutput`](#json-schema-realvalueoutput).
+The value can be any of [`null`](#json-schema-null-absence-of-value) if it is not provided, or any of
+[`int32_t`](#json-schema-int32_t), [`int8_t`](#json-schema-int8_t), [`double`](#json-schema-double),
+[`RealValueInput`](#json-schema-realvalueinput) or [`RealValueOutput`](#json-schema-realvalueoutput).
 The type is listed for each attribute in [Components](components.md).
 
-- [`AttributeValue`](#json-schema-attribute-value): [`null`](#json-schema-null-absence-of-value) | [`int32_t`](#json-schema-int32_t) | [`int8_t`](#json-schema-int8_t) | [`double`](#json-schema-double) | [`RealValueInput`](#json-schema-realvalueinput) | [`RealValueOutput`](#json-schema-realvalueoutput)
+- [`AttributeValue`](#json-schema-attribute-value): [`null`](#json-schema-null-absence-of-value) |
+  [`int32_t`](#json-schema-int32_t) | [`int8_t`](#json-schema-int8_t) | [`double`](#json-schema-double) |
+  [`RealValueInput`](#json-schema-realvalueinput) | [`RealValueOutput`](#json-schema-realvalueoutput)
 
 #### JSON schema null (absence of value)
 
-**NOTE:** This is the [JSON](#json-serialization-format-specification)-specific version of [absence of value](#json-schema-null-absence-of-value).
-For [`msgpack`](#msgpack-serialization-format-specification), refer to [absence of value for `msgpack`](#msgpack-schema-nil-absence-of-value).
+**NOTE:** This is the [JSON](#json-serialization-format-specification)-specific version of
+[absence of value](#json-schema-null-absence-of-value).
+For [`msgpack`](#msgpack-serialization-format-specification), refer to
+[absence of value for `msgpack`](#msgpack-schema-nil-absence-of-value).
 
 - [absence of value](#json-schema-null-absence-of-value): `null`
 
-**NOTE:** any `nan` values for concrete `number` types represent absence of value and are represented by [`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
+**NOTE:** any `nan` values for concrete `number` types represent absence of value and are represented by
+[`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
 
 #### JSON schema int32_t
 
@@ -145,21 +186,25 @@ The type is listed for each attribute in [Components](components.md).
 
 - [`int32_t`](#json-schema-int32_t): `number`
 
-**NOTE:** the special value `-2147483648` represents absence of value and may also be represented by [`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
+**NOTE:** the special value `-2147483648` represents absence of value and may also be represented by
+[`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
 
 #### JSON schema int8_t
 
-An [`int8_t`](#json-schema-int8_t) integer `number` value usually representing an enumeration value or a discrete setting.
+An [`int8_t`](#json-schema-int8_t) integer `number` value usually representing an enumeration value or a discrete
+setting.
 It may be in the inclusive range $\left[-2^{7},+2^{7} - 1\right]$.
 The type is listed for each attribute in [Components](components.md).
 
 - [`int8_t`](#json-schema-int8_t): `number`
 
-**NOTE:** the special value `-128` represents absence of value and may also be represented by [`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
+**NOTE:** the special value `-128` represents absence of value and may also be represented by
+[`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
 
 #### JSON schema double
 
-**NOTE:** This is the [JSON](#json-serialization-format-specification)-specific version of [`double`](#json-schema-double).
+**NOTE:** This is the [JSON](#json-serialization-format-specification)-specific version of
+[`double`](#json-schema-double).
 For [`msgpack`](#msgpack-serialization-format-specification), refer to [`double` for `msgpack`](#msgpack-schema-double).
 
 A [`double`](#json-schema-double) floating point `number` or `string` value, usually representing a real.
@@ -169,41 +214,52 @@ The type is listed for each attribute in [Components](components.md).
 
 - [`double`](#json-schema-double): `number`|`string`
 
-**NOTE:** the special value `nan` represents absence of value and is represented by [`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
+**NOTE:** the special value `nan` represents absence of value and is represented by
+[`null`](#json-schema-null-absence-of-value) in the [JSON schema](#json-serialization-format-specification).
 
 #### JSON schema RealValueInput
 
 A [`RealValueInput`](#json-schema-realvalueinput) of which the data format depends on the type of calculation.
 For symmetric components, it is a [`double`](#json-schema-double).
-For asymmetric components, it is an Array of size 3 containing [`double`](#json-schema-double) or [`null`](#json-schema-null-absence-of-value) values.
+For asymmetric components, it is an Array of size 3 containing [`double`](#json-schema-double) or
+[`null`](#json-schema-null-absence-of-value) values.
 The type is listed for each attribute in [Components](components.md).
 
 - [`RealValueInput`](#json-schema-realvalueinput): [`double`](#json-schema-double) for symmetric calculations.
 - [`RealValueInput`](#json-schema-realvalueinput): `Array` of size 3 for asymmetric calculations, one for each phase.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_a` phase, if specified.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_b` phase, if specified.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_c` phase, if specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_a` phase, if
+    specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_b` phase, if
+    specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_c` phase, if
+    specified.
 
 #### JSON schema RealValueOutput
 
 A [`RealValueOutput`](#json-schema-realvalueoutput) of which the data format depends on the type of calculation.
 For symmetric calculations, it is a [`double`](#json-schema-double).
-For asymmetric calculations, it is an Array of size 3 containing [`double`](#json-schema-double) or [`null`](#json-schema-null-absence-of-value) values.
+For asymmetric calculations, it is an Array of size 3 containing [`double`](#json-schema-double) or
+[`null`](#json-schema-null-absence-of-value) values.
 The type is listed for each attribute in [Components](components.md).
 
 - [`RealValueOutput`](#json-schema-realvalueoutput): [`double`](#json-schema-double) for symmetric calculations.
 - [`RealValueOutput`](#json-schema-realvalueoutput): `Array` of size 3 for asymmetric calculations, one for each phase.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_a` phase, if specified.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_b` phase, if specified.
-  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_c` phase, if specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_a` phase, if
+    specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_b` phase, if
+    specified.
+  - [`double`](#json-schema-double) | [`null`](#json-schema-null-absence-of-value): the value for the `_c` phase, if
+    specified.
 
 #### JSON schema single dataset example
 
 The following example contains an input dataset.
-The nodes and sym_loads are represented using [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object),
+The nodes and sym_loads are represented using
+[`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object),
 the lines are represented using [`InomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object),
-while the sources are represented using a mixture of [`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object)
-and [`InomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object).
+while the sources are represented using a mixture of
+[`HomogeneousComponentData`](#json-schema-homogeneous-component-data-object) and
+[`InomogeneousComponentData`](#json-schema-inhomogeneous-component-data-object).
 
 ```json
 {
@@ -273,7 +329,8 @@ and [`InomogeneousComponentData`](#json-schema-inhomogeneous-component-data-obje
 #### JSON schema batch dataset example
 
 The following example contains a batch update dataset containing two sym_loads and one asym_load.
-Not every scenario updates all components and attributes, reducing the total amount of data necessary to represent the batch dataset.
+Not every scenario updates all components and attributes, reducing the total amount of data necessary to represent the
+batch dataset.
 
 ```json
 {
@@ -319,27 +376,35 @@ Not every scenario updates all components and attributes, reducing the total amo
 
 ### msgpack serialization format specification
 
-The msgpack serialization format is a compressed version of the [JSON serialization format](#json-serialization-format-specification) and all features supported for JSON are also supported for msgpack.
+The msgpack serialization format is a compressed version of the
+[JSON serialization format](#json-serialization-format-specification) and all features supported for JSON are also
+supported for msgpack.
 
 #### msgpack schema nil (absence of value)
 
-**NOTE:** This is the [`msgpack`](#msgpack-serialization-format-specification)-specific version of [absence of value](#msgpack-schema-nil-absence-of-value).
-For [JSON](#json-serialization-format-specification), refer to [absence of value for JSON](#json-schema-null-absence-of-value).
+**NOTE:** This is the [`msgpack`](#msgpack-serialization-format-specification)-specific version of
+[absence of value](#msgpack-schema-nil-absence-of-value).
+For [JSON](#json-serialization-format-specification), refer to
+[absence of value for JSON](#json-schema-null-absence-of-value).
 
 - [absence of value](#msgpack-schema-nil-absence-of-value): `nil` (the byte `\xc0`)
 
-**NOTE:** any `nan` values for concrete `number` types represent absence of value are represented by [`nil`](#msgpack-schema-nil-absence-of-value) in the [msgpack schema](#msgpack-serialization-format-specification).
+**NOTE:** any `nan` values for concrete `number` types represent absence of value are represented by
+[`nil`](#msgpack-schema-nil-absence-of-value) in the [msgpack schema](#msgpack-serialization-format-specification).
 
 #### msgpack schema double
 
-**NOTE:** This is the [`msgpack`](#msgpack-serialization-format-specification)-specific version of [`double`](#msgpack-schema-double).
+**NOTE:** This is the [`msgpack`](#msgpack-serialization-format-specification)-specific version of
+[`double`](#msgpack-schema-double).
 For [JSON](#json-serialization-format-specification), refer to [`double` for JSON](#json-schema-double).
 
 A [`double`](#msgpack-schema-double) floating point `number` value usually representing a real.
-Infinities are represented using the [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754) standard for double-precision floating point values representation for infinities.
+Infinities are represented using the [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754) standard for double-precision
+floating point values representation for infinities.
 Any other values are unsupported.
 The type is listed for each attribute in [Components](components.md).
 
 - [`double`](#msgpack-schema-double): `number`
 
-**NOTE:** the special value `nan` represents absence of value and may also be represented by [`nil`](#msgpack-schema-nil-absence-of-value) in the [msgpack schema](#msgpack-serialization-format-specification).
+**NOTE:** the special value `nan` represents absence of value and may also be represented by
+[`nil`](#msgpack-schema-nil-absence-of-value) in the [msgpack schema](#msgpack-serialization-format-specification).

--- a/docs/user_manual/serialization.md
+++ b/docs/user_manual/serialization.md
@@ -47,7 +47,8 @@ For example, for an `"update"` dataset that contains only updates to the `"from_
 
 #### JSON schema component
 
-A [`Component`](#json-schema-component) string contains the component name (see also the [Components](components.md) reference). E.g.: `"node"`
+A [`Component`](#json-schema-component) string contains the component name (see also the [Components](components.md) reference).
+E.g.: `"node"`
 
 - [`Component`](#json-schema-component): `string`
 
@@ -60,7 +61,8 @@ A [`ComponentAttributes`](#json-schema-component-attributes) array contains the 
 
 #### JSON schema attribute
 
-A [`Attribute`](#json-schema-attribute) string contains the name of an attribute of a component (see also the [Components](components.md) reference). E.g.: `"id"`.
+A [`Attribute`](#json-schema-attribute) string contains the name of an attribute of a component (see also the [Components](components.md) reference).
+E.g.: `"id"`.
 
 - [`Attribute`](#json-schema-attribute): `string`
 
@@ -120,7 +122,8 @@ Contrary to the [`HomogeneousComponentData`](#json-schema-homogeneous-component-
 
 #### JSON schema attribute value
 
-The [`AttributeValue`](#json-schema-attribute-value) contains the actual value of an attribute. The value can be any of [`null`](#json-schema-null-absence-of-value) if it is not provided, or any of [`int32_t`](#json-schema-int32_t), [`int8_t`](#json-schema-int8_t), [`double`](#json-schema-double), [`RealValueInput`](#json-schema-realvalueinput) or [`RealValueOutput`](#json-schema-realvalueoutput).
+The [`AttributeValue`](#json-schema-attribute-value) contains the actual value of an attribute.
+The value can be any of [`null`](#json-schema-null-absence-of-value) if it is not provided, or any of [`int32_t`](#json-schema-int32_t), [`int8_t`](#json-schema-int8_t), [`double`](#json-schema-double), [`RealValueInput`](#json-schema-realvalueinput) or [`RealValueOutput`](#json-schema-realvalueoutput).
 The type is listed for each attribute in [Components](components.md).
 
 - [`AttributeValue`](#json-schema-attribute-value): [`null`](#json-schema-null-absence-of-value) | [`int32_t`](#json-schema-int32_t) | [`int8_t`](#json-schema-int8_t) | [`double`](#json-schema-double) | [`RealValueInput`](#json-schema-realvalueinput) | [`RealValueOutput`](#json-schema-realvalueoutput)
@@ -136,7 +139,8 @@ For [`msgpack`](#msgpack-serialization-format-specification), refer to [absence 
 
 #### JSON schema int32_t
 
-An [`int32_t`](#json-schema-int32_t) is an integer `number` value usually representing an ID. It may be in the inclusive range $\left[-2^{31},+2^{31} - 1\right]$.
+An [`int32_t`](#json-schema-int32_t) is an integer `number` value usually representing an ID.
+It may be in the inclusive range $\left[-2^{31},+2^{31} - 1\right]$.
 The type is listed for each attribute in [Components](components.md).
 
 - [`int32_t`](#json-schema-int32_t): `number`
@@ -145,7 +149,8 @@ The type is listed for each attribute in [Components](components.md).
 
 #### JSON schema int8_t
 
-An [`int8_t`](#json-schema-int8_t) integer `number` value usually representing an enumeration value or a discrete setting. It may be in the inclusive range $\left[-2^{7},+2^{7} - 1\right]$.
+An [`int8_t`](#json-schema-int8_t) integer `number` value usually representing an enumeration value or a discrete setting.
+It may be in the inclusive range $\left[-2^{7},+2^{7} - 1\right]$.
 The type is listed for each attribute in [Components](components.md).
 
 - [`int8_t`](#json-schema-int8_t): `number`

--- a/tests/data/power_flow/pandapower/components/asymmetric/transformer/README.md
+++ b/tests/data/power_flow/pandapower/components/asymmetric/transformer/README.md
@@ -22,6 +22,6 @@ source_7--node_1--transformer_3--node_2              (Transformer from_status=to
 
 - Source impedance is set too low. Result of source component here should be ignored
 - Asymmetrical calculations are possible only for grounded network transformer in pandapower.
-Hence open cases are not evaluated.
-- Relaxed tolerance parameters are used in asymmetric calculation
-because only 'T' transformer model is available in pandapower while power-grid-model uses 'pi' model.
+  Hence open cases are not evaluated.
+- Relaxed tolerance parameters are used in asymmetric calculation because only 'T' transformer model is available in
+  pandapower while power-grid-model uses 'pi' model.

--- a/tests/data/power_flow/pandapower/components/symmetric/three_winding_transformer/README.md
+++ b/tests/data/power_flow/pandapower/components/symmetric/three_winding_transformer/README.md
@@ -6,11 +6,13 @@ SPDX-License-Identifier: MPL-2.0
 
 # Component Test Case: Three Winding Transformer
 
-Test case for validation of the three winding transformer component for symmetrical power flow calculations in pandapower.
+Test case for validation of the three winding transformer component for symmetrical power flow calculations in
+pandapower.
 The implementation of both the libraries are similar.
 Three 2-winding transformers are used in star connection for creating a 3 winding transformer.
 
-- A three transformer can have multiple states from the node end status being open or closed. However only the all working status is being tested here for the sake of simplicity.
+- A three transformer can have multiple states from the node end status being open or closed. However only the all
+  working status is being tested here for the sake of simplicity.
 
 The circuit diagram is as follows:
 

--- a/tests/data/power_flow/pandapower/components/symmetric/three_winding_transformer/README.md
+++ b/tests/data/power_flow/pandapower/components/symmetric/three_winding_transformer/README.md
@@ -6,7 +6,9 @@ SPDX-License-Identifier: MPL-2.0
 
 # Component Test Case: Three Winding Transformer
 
-Test case for validation of the three winding transformer component for symmetrical power flow calculations in pandapower. The implementation of both the libraries are similar. Three 2-winding transformers are used in star connection for creating a 3 winding transformer.
+Test case for validation of the three winding transformer component for symmetrical power flow calculations in pandapower.
+The implementation of both the libraries are similar.
+Three 2-winding transformers are used in star connection for creating a 3 winding transformer.
 
 - A three transformer can have multiple states from the node end status being open or closed. However only the all working status is being tested here for the sake of simplicity.
 

--- a/tests/data/power_flow/pandapower/networks/asymmetric/distribution-case/README.md
+++ b/tests/data/power_flow/pandapower/networks/asymmetric/distribution-case/README.md
@@ -10,8 +10,8 @@ Test case representing a typical distribution grid.
 The grid has 2 identical parallel transformers.
 They power a series of overhead lines and cables which supply different loads.
 
-The case is validated for ring and radial configuration by open/close position of
-one end of Line 13 in symmetrical batch calculation.
+The case is validated for ring and radial configuration by open/close position of one end of Line 13 in symmetrical
+batch calculation.
 
 The circuit diagram is as follows:
 

--- a/tests/data/power_flow/pandapower/networks/symmetric/distribution-case/README.md
+++ b/tests/data/power_flow/pandapower/networks/symmetric/distribution-case/README.md
@@ -10,8 +10,8 @@ Test case representing a typical distribution grid.
 The grid has 2 identical parallel transformers.
 They power a series of overhead lines and cables which supply different loads.
 
-The case is validated for ring and radial configuration by open/close position of
-one end of Line 13 in asymmetrical batch calculation.
+The case is validated for ring and radial configuration by open/close position of one end of Line 13 in asymmetrical
+batch calculation.
 
 Note: the transformer result values cannot be validated because of modelling differences
 

--- a/tests/data/state_estimation/current-sensor/power-from-global-current-sensor/README.md
+++ b/tests/data/state_estimation/current-sensor/power-from-global-current-sensor/README.md
@@ -7,9 +7,12 @@ SPDX-License-Identifier: MPL-2.0
 # Power sensor from Global Current Sensor test case
 
 This test case is used to validate the output values from the global current sensor.
-To verify the correctness of the results, the input from the global current sensor is transformed into power sensor input.
+To verify the correctness of the results, the input from the global current sensor is transformed into power sensor
+input.
 At the time of writing, the power sensor component has already been validated.
-However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
+However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies
+between the results obtained from the current sensor and those from the power sensor due to the approximate nature of
+the calculation method.
 
 ## Conversion from Global Current Sensor to Power Sensor
 

--- a/tests/data/state_estimation/current-sensor/power-from-global-current-sensor/README.md
+++ b/tests/data/state_estimation/current-sensor/power-from-global-current-sensor/README.md
@@ -6,7 +6,10 @@ SPDX-License-Identifier: MPL-2.0
 
 # Power sensor from Global Current Sensor test case
 
-This test case is used to validate the output values from the global current sensor. To verify the correctness of the results, the input from the global current sensor is transformed into power sensor input. At the time of writing, the power sensor component has already been validated. However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
+This test case is used to validate the output values from the global current sensor.
+To verify the correctness of the results, the input from the global current sensor is transformed into power sensor input.
+At the time of writing, the power sensor component has already been validated.
+However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
 
 ## Conversion from Global Current Sensor to Power Sensor
 

--- a/tests/data/state_estimation/current-sensor/power-from-local-current-sensor/README.md
+++ b/tests/data/state_estimation/current-sensor/power-from-local-current-sensor/README.md
@@ -7,9 +7,12 @@ SPDX-License-Identifier: MPL-2.0
 # Power sensor from Local Current Sensor test case
 
 This test case is used to validate the output values from the local current sensor.
-To verify the correctness of the results, the input from the local current sensor is transformed into power sensor input.
+To verify the correctness of the results, the input from the local current sensor is transformed into power sensor
+input.
 At the time of writing, the power sensor component has already been validated.
-However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
+However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies
+between the results obtained from the current sensor and those from the power sensor due to the approximate nature of
+the calculation method.
 
 ## Conversion from Local Current Sensor to Power Sensor
 

--- a/tests/data/state_estimation/current-sensor/power-from-local-current-sensor/README.md
+++ b/tests/data/state_estimation/current-sensor/power-from-local-current-sensor/README.md
@@ -6,7 +6,10 @@ SPDX-License-Identifier: MPL-2.0
 
 # Power sensor from Local Current Sensor test case
 
-This test case is used to validate the output values from the local current sensor. To verify the correctness of the results, the input from the local current sensor is transformed into power sensor input. At the time of writing, the power sensor component has already been validated. However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
+This test case is used to validate the output values from the local current sensor.
+To verify the correctness of the results, the input from the local current sensor is transformed into power sensor input.
+At the time of writing, the power sensor component has already been validated.
+However, keep in mind that for state estimation using the iterative linear method, there may be small discrepancies between the results obtained from the current sensor and those from the power sensor due to the approximate nature of the calculation method.
 
 ## Conversion from Local Current Sensor to Power Sensor
 

--- a/tests/data/state_estimation/distribution-case/README.md
+++ b/tests/data/state_estimation/distribution-case/README.md
@@ -13,8 +13,8 @@ They power a series of overhead lines and cables which supply different loads.
 Symmetrical voltage sensors are installed on all nodes and power sensors are installed at both ends of lines and
 transformers.
 
-The case is validated for ring and radial configuration by open/close position of
-one end of Line 13 in symmetrical batch calculation.
+The case is validated for ring and radial configuration by open/close position of one end of Line 13 in symmetrical
+batch calculation.
 
 The circuit diagram is as follows:
 


### PR DESCRIPTION
Part 2 of homogenizing docs: all lines shall have a maximum line length 120

Part 1 in #1012 

Exceptions:

* Tables (always excluded)
* Code blocks (up to the developer - i tried to homogenize as much as possible, but some things like `mermaid` are line-break sensitive)
* Single-line inline LaTeX statements (using `<!-- markdownlint-disable-line MD013 -->`)
