### PR TITLE
Linting and Formatting: adding Pylint checks to Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,9 @@ select = [
     "FURB",
     "FLY",
     "SLOT",
+    "PL"
 ]
-ignore = ["SIM108", "SIM118", "SIM110", "SIM211"]
+ignore = ["SIM108", "SIM118", "SIM110", "SIM211", "PLR2004"]
 
 [tool.ruff.lint.isort]
 # Imports that are imported using keyword "as" and are from the same source - are combined.
@@ -123,6 +124,8 @@ combine-as-imports = true
 [tool.ruff.lint.per-file-ignores]
 # Ignore `F811` (redefinition violations) in all examples notebooks since we use redefinition.
 "docs/examples/*.ipynb" = ["F811", "E402"]
+# Pylint was only run in src directory before moving to Ruff
+"tests/*" = ["PL"]
 
 [tool.mypy]
 follow_imports = "silent"

--- a/src/power_grid_model/_core/power_grid_core.py
+++ b/src/power_grid_model/_core/power_grid_core.py
@@ -466,7 +466,7 @@ class PowerGridCore:
         pass  # pragma: no cover
 
     @make_c_binding
-    def dataset_mutable_add_buffer(  # type: ignore[empty-body]
+    def dataset_mutable_add_buffer(  # type: ignore[empty-body]  # noqa: PLR0913
         self,
         dataset: MutableDatasetPtr,
         component: str,

--- a/src/power_grid_model/_core/power_grid_model.py
+++ b/src/power_grid_model/_core/power_grid_model.py
@@ -238,7 +238,7 @@ class PowerGridModel:
             decode_error=decode_error,
         )
 
-    def _calculate_impl(
+    def _calculate_impl(  # noqa: PLR0913
         self,
         calculation_type: CalculationType,
         symmetric: bool,
@@ -303,7 +303,7 @@ class PowerGridModel:
 
         return output_data
 
-    def _calculate_power_flow(
+    def _calculate_power_flow(  # noqa: PLR0913
         self,
         *,
         symmetric: bool = True,
@@ -340,7 +340,7 @@ class PowerGridModel:
             experimental_features=experimental_features,
         )
 
-    def _calculate_state_estimation(
+    def _calculate_state_estimation(  # noqa: PLR0913
         self,
         *,
         symmetric: bool = True,
@@ -375,7 +375,7 @@ class PowerGridModel:
             experimental_features=experimental_features,
         )
 
-    def _calculate_short_circuit(
+    def _calculate_short_circuit(  # noqa: PLR0913
         self,
         *,
         calculation_method: CalculationMethod | str = CalculationMethod.iec60909,
@@ -409,7 +409,7 @@ class PowerGridModel:
             experimental_features=experimental_features,
         )
 
-    def calculate_power_flow(
+    def calculate_power_flow(  # noqa: PLR0913
         self,
         *,
         symmetric: bool = True,
@@ -508,7 +508,7 @@ class PowerGridModel:
             tap_changing_strategy=tap_changing_strategy,
         )
 
-    def calculate_state_estimation(
+    def calculate_state_estimation(  # noqa: PLR0913
         self,
         *,
         symmetric: bool = True,
@@ -602,7 +602,7 @@ class PowerGridModel:
             decode_error=decode_error,
         )
 
-    def calculate_short_circuit(
+    def calculate_short_circuit(  # noqa: PLR0913
         self,
         *,
         calculation_method: CalculationMethod | str = CalculationMethod.iec60909,

--- a/src/power_grid_model/validation/_rules.py
+++ b/src/power_grid_model/validation/_rules.py
@@ -241,7 +241,7 @@ def all_less_or_equal(
     return none_match_comparison(data, component, field, not_less_or_equal, ref_value, NotLessOrEqualError)
 
 
-def all_between(
+def all_between(  # noqa: PLR0913
     data: SingleDataset,
     component: ComponentType,
     field: str,
@@ -281,7 +281,7 @@ def all_between(
     )
 
 
-def all_between_or_at(
+def all_between_or_at(  # noqa: PLR0913
     data: SingleDataset,
     component: ComponentType,
     field: str,
@@ -331,7 +331,7 @@ def all_between_or_at(
     )
 
 
-def none_match_comparison(
+def none_match_comparison(  # noqa: PLR0913
     data: SingleDataset,
     component: ComponentType,
     field: str,
@@ -554,7 +554,7 @@ def all_valid_enum_values(
     return []
 
 
-def all_valid_associated_enum_values(
+def all_valid_associated_enum_values(  # noqa: PLR0913
     data: SingleDataset,
     component: ComponentType,
     field: str,

--- a/src/power_grid_model/validation/_validation.py
+++ b/src/power_grid_model/validation/_validation.py
@@ -279,7 +279,7 @@ def _process_power_sigma_and_p_q_sigma(
         power_sigma[mask] = np.nansum(q_sigma[mask], axis=asym_axes)
 
 
-def validate_required_values(
+def validate_required_values(  # noqa: PLR0915
     data: SingleDataset, calculation_type: CalculationType | None = None, symmetric: bool = True
 ) -> list[MissingValueError]:
     """
@@ -631,7 +631,7 @@ def validate_branch3(data: SingleDataset, component: ComponentType) -> list[Vali
     return errors
 
 
-def validate_three_winding_transformer(data: SingleDataset) -> list[ValidationError]:
+def validate_three_winding_transformer(data: SingleDataset) -> list[ValidationError]:  # noqa: PLR0915
     errors = validate_branch3(data, ComponentType.three_winding_transformer)
     errors += _all_greater_than_zero(data, ComponentType.three_winding_transformer, "u1")
     errors += _all_greater_than_zero(data, ComponentType.three_winding_transformer, "u2")


### PR DESCRIPTION
This implementation is based on a version of the repository before moving to Ruff, which can be accessed here:
https://github.com/PowerGridModel/power-grid-model/tree/c127b2cf42ff179fe985f91688e10a7cf2671a90

As per the previous implementation, Pylint only ran on src files, thus I tried to mimic the behavior:
https://github.com/PowerGridModel/power-grid-model/blob/c127b2cf42ff179fe985f91688e10a7cf2671a90/.pre-commit-config.yaml

Most of the noqa comments alligned with the pylint version:
https://github.com/PowerGridModel/power-grid-model/blob/c127b2cf42ff179fe985f91688e10a7cf2671a90/src/power_grid_model/validation/_rules.py

Most misalignments happened in src/power_grid_model/_core/power_grid_model.py, where the old pylint version did not have comments but now there was a need for them. A possible explanation could be: https://github.com/pylint-dev/pylint/issues/8667

