### PR TITLE
fix typo source electric modeling docs

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -620,7 +620,7 @@ Its value can be computed using following equations:
 $$
    \begin{eqnarray}
         & z_{\text{source}} = \frac{s_{\text{base}}}{s_k} \\
-        & x_1 = z_{\text{source}} \sqrt{1+ \left(\frac{r}{x}\right)^2} \\
+        & x_1 = \frac{z_{\text{source}}}{\sqrt{1+ \left(\frac{r}{x}\right)^2}} \\
         & r_1 = x_1 \cdot \left(\frac{r}{x}\right)
    \end{eqnarray}
 $$
@@ -631,8 +631,8 @@ where $s_{\text{base}}$ is a constant value determined by the solver, and $\frac
 
 $$
    \begin{eqnarray}
-        & z_{\text{source,0}} = z_{\text{source}} \cdot \frac{z_0}{z_1}\\
-        & x_0 = z_{\text{source,0}} \sqrt{1 + \left(\frac{r}{x}\right)^2}\\
+        & z_{\text{source,0}} = z_{\text{source}} \cdot \frac{z_0}{z_1} \\
+        & x_0 = \frac{z_{\text{source,0}}}{\sqrt{1 + \left(\frac{r}{x}\right)^2}} \\
         & r_0 = x_0 \cdot \left(\frac{r}{x}\right)
    \end{eqnarray}
 $$


### PR DESCRIPTION
NOTE: the modeling was done correctly in the calculation core: https://github.com/PowerGridModel/power-grid-model/blob/feature/fix-typo-source-modeling-docs/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp#L37-L43

## Verification
### Before
$$
r_1^2 + x_1^2 = x_1^2 \left(\frac{r}{x}\right)^2 + x_1^2 = x_1^2 \left(\left(\frac{r}{x}\right)^2 + 1\right) = \left(z_{\text{source}}^2 \left(1 + \left(\frac{r}{x}\right)^2\right)\right)\left(\left(\frac{r}{x}\right)^2+ 1\right) = z_{\text{source}}^2 \left(1 + \left(\frac{r}{x}\right)^2\right)^2
$$

### After
$$
r_1^2 + x_1^2 = x_1^2 \left(\frac{r}{x}\right)^2 + x_1^2 = x_1^2 \left(\left(\frac{r}{x}\right)^2 + 1\right) = \frac{z_{\text{source}}^2 }{\left(1 + \left(\frac{r}{x}\right)^2\right)}\left(\left(\frac{r}{x}\right)^2+ 1\right) = z_{\text{source}}^2 \frac{\left(1 + \left(\frac{r}{x}\right)^2\right)}{\left(\left(\frac{r}{x}\right)^2+ 1\right)} = z_{\text{source}}^2
$$