### PR TITLE
Documentation: update expressions of transformer electric model

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -240,8 +240,6 @@ $$
 $$
 
 where $z_{\text{base,transformer}} = 1 / y_{\text{base,transformer}} = {u_{\text{2}}}^2 / s_{\text{n}}$.
-Here, $s_{\text{n}}$ is the rated power of the transformer and $u_{\text{2}}$ is rated voltage at
-`to_node`.
 
 ### Generic Branch  
 


### PR DESCRIPTION
### Changes proposed in this PR include:

> Expressions of transformer electric model is updated so that it matches the implementation in the PGM core. The rendered expressions before and after this change are shown below.

Before:
<img width="503" height="386" alt="before" src="https://github.com/user-attachments/assets/8b6be008-0315-48b6-963d-042d79b167d7" />

After:
<img width="442" height="346" alt="MathJax_rendering" src="https://github.com/user-attachments/assets/5da12b90-527a-4889-86df-58114648c3a7" />


### Could you please pay extra attention to the points below when reviewing the PR:

> A compatible renderer is needed to render the LaTeX syntax `eqnarray` properly, which already existed before this change. In my case, MathJax renders correctly and KaTeX does not.

Rendered result with KaTeX:
<img width="554" height="268" alt="KaTeX_rendering" src="https://github.com/user-attachments/assets/a6148f4d-b51e-4790-b76e-d8538f70a676" />


### Checks

- [ ] This change only involves a Markdown file, i.e., `docs/user_manual/components.md`. 
