### PR TITLE
CI: bump compilers

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -79,11 +79,11 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build gcc-13 g++-13 clang-18
+          sudo apt-get install -y ninja-build gcc-14 g++-14 clang-18
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -s /usr/bin/gcc-13 /usr/local/bin/gcc
-          sudo ln -s /usr/bin/g++-13 /usr/local/bin/g++
+          sudo ln -s /usr/bin/gcc-14 /usr/local/bin/gcc
+          sudo ln -s /usr/bin/g++-14 /usr/local/bin/g++
 
       - name: Enable brew
         run: |
@@ -150,7 +150,7 @@ jobs:
           install\${{ env.PRESET }}\bin\power_grid_model_package_test; if(!$?) { Exit $LASTEXITCODE }
 
   build-cpp-test-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         build-option: [ debug, release ]

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -59,7 +59,7 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 
 * MSVC >= 19.0
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
-* Clang CL >= 17.0
+* Clang CL >= 19.0
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 
 #### macOS

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -65,7 +65,7 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 #### macOS
 
 * Clang >= 17.0
-  * Latest release tested in CI
+  * Latest XCode release tested in CI
 
 ### Build System for CMake Project
 

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -45,11 +45,11 @@ Below is a list of tested compilers:
 
 #### Linux
 
-* gcc >= 13.0
+* gcc >= 14.0
   * Version 14.x tested using the version in the `manylinux_2_28` container.
   * Version 14.x tested using the musllinux build with custom compiler
-  * Version 13.x tested in CI
-* Clang >= 17.0
+  * Version 14.x tested in CI
+* Clang >= 18.0
   * Version 18.x tested in CI
   * Version 18.x tested in CI with code quality checks
 
@@ -57,14 +57,14 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 
 #### Windows
 
-* MSVC >= 17.5
+* MSVC >= 19.0
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 * Clang CL >= 17.0
   * Latest release tested in CI (e.g. Visual Studio 2022, IDE or build tools)
 
 #### macOS
 
-* Clang >= 15.0
+* Clang >= 18.0
   * Latest release tested in CI
 
 ### Build System for CMake Project
@@ -226,8 +226,8 @@ You can use this example in Windows Subsystem for Linux (WSL), or in a physical/
 Append the following lines into the file `${HOME}/.bashrc`.
 
 ```shell
-export CXX=clang++-18            # or g++-13
-export CC=clang-18               # gcc-13
+export CXX=clang++-18            # or g++-14
+export CC=clang-18               # or gcc-14
 export CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew
 export LLVM_COV=llvm-cov-18
 export CLANG_TIDY=clang-tidy-18  # only if you want to use one of the clang-tidy presets

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -64,7 +64,7 @@ You can define the environment variable `CXX` to for example `clang++` to specif
 
 #### macOS
 
-* Clang >= 18.0
+* Clang >= 17.0
   * Latest release tested in CI
 
 ### Build System for CMake Project


### PR DESCRIPTION
gcc-14 is available on Ubuntu 24.04: https://packages.ubuntu.com/noble/gcc-14
Even though we do not have to use new things, gcc-14 actually contained some backported performance improvements (that came from a bug filed to the C++26 standard but that was actually also retroactively applied to older C++ versions).

Given the following disclaimer in the build guide, we can bump the list it refers to without breaking any user workflows:

> Below is a list of tested compilers:
