### PR TITLE
Testing: split cpp unit tests

### DIFF
--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -37,7 +37,6 @@ target_link_libraries(power_grid_model_unit_tests_auxiliary
     PRIVATE
         power_grid_model
         doctest::doctest
-        nlohmann_json nlohmann_json::nlohmann_json
 )
 
 doctest_discover_tests(power_grid_model_unit_tests_auxiliary)


### PR DESCRIPTION
Splits the unit tests into individual targets. This has 2 benefits:

1. it is much faster to develop things deep in the core. We won't have to wait - for instance - to build the entire main model when you only want to make a simple unit test in `statistics.hpp` pass. Instead, set the build target to the respective CMake unit test target, build and iterate.
2. it is much clearer which files are tested and which ones are not. This will improve our confidence in the code-base.

This is an enabler for testability of the job dispatch logic