### PR TITLE
Data validator: relax requirement that p_sigma and q_sigma cannot mix normal and infinite values

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -885,11 +885,12 @@ Valid combinations of `power_sigma`, `p_sigma` and `q_sigma` are:
 |               |           |           | &#10060; |
 
 ```{note}
-1. If both `p_sigma` and `q_sigma` are provided, they represent the standard deviation of the active and reactive power,
-respectively, and the value of `power_sigma` is ignored. Any infinite component invalidates the entire measurement.
+1. If both `p_sigma` and `q_sigma` are provided (i.e., not NaN), they represent the standard deviation of the active and
+reactive power, respectively, and the value of `power_sigma` is ignored. Any infinite component disables the entire
+measurement.
 
 2. If neither `p_sigma` nor `q_sigma` are provided, `power_sigma` represents the standard deviation of the apparent
-power.
+power. If it is infinite, it disables the entire measurement.
 
 3. Providing only one of `p_sigma` and `q_sigma` results in undefined behaviour.
 ```

--- a/src/power_grid_model/validation/_rules.py
+++ b/src/power_grid_model/validation/_rules.py
@@ -920,16 +920,11 @@ def valid_p_q_sigma(data: SingleDataset, component: ComponentType) -> list[PQSig
     q_sigma = data[component]["q_sigma"]
     p_nan = np.isnan(p_sigma)
     q_nan = np.isnan(q_sigma)
-    p_inf = np.isinf(p_sigma)
-    q_inf = np.isinf(q_sigma)
     mis_match = p_nan != q_nan
-    mis_match |= np.logical_xor(p_inf, q_inf)  # infinite sigmas are supported if they are both infinite
     if p_sigma.ndim > 1:  # if component == 'asym_power_sensor':
         mis_match = mis_match.any(axis=-1)
         mis_match |= np.logical_xor(p_nan.any(axis=-1), p_nan.all(axis=-1))
         mis_match |= np.logical_xor(q_nan.any(axis=-1), q_nan.all(axis=-1))
-        mis_match |= np.logical_xor(p_inf.any(axis=-1), p_inf.all(axis=-1))
-        mis_match |= np.logical_xor(q_inf.any(axis=-1), q_inf.all(axis=-1))
 
     if mis_match.any():
         ids = data[component]["id"][mis_match].flatten().tolist()

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -634,7 +634,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, 0.1, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="mixed nans for some sensor - asym_power_sensor"
+            id="mixed nans for some sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -644,31 +644,31 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.inf, 0.1, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="mixed infs for some sensor - asym_power_sensor"
+            id="mixed infs for some sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[0.1, np.nan, np.nan]] * 3, [[np.nan, np.nan, np.nan]] * 3],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="all nan except one phase p_sigma - asym_power_sensor"
+            id="all nan except one phase p_sigma - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[0.1, np.inf, np.inf]] * 3, [[np.inf, np.inf, np.inf]] * 3],
             [InvalidIdError, NotUniqueError],
-            id="all inf except one phase p_sigma - asym_power_sensor"
+            id="all inf except one phase p_sigma - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[np.nan, np.nan, np.nan]] * 3, [[0.1, np.nan, np.nan]] * 3],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="all nan except one phase q_sigma - asym_power_sensor"
+            id="all nan except one phase q_sigma - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[np.inf, np.inf, np.inf]] * 3, [[0.1, np.inf, np.inf]] * 3],
             [InvalidIdError, NotUniqueError],
-            id="all inf except one phase q_sigma - asym_power_sensor"
+            id="all inf except one phase q_sigma - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -678,7 +678,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, np.nan, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="one sensor mixed nans - asym_power_sensor"
+            id="one sensor mixed nans - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -688,7 +688,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.inf, np.inf, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="one sensor mixed infs - asym_power_sensor"
+            id="one sensor mixed infs - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -698,7 +698,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="q_sigma of one sensor nan - asym_power_sensor"
+            id="q_sigma of one sensor nan - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -708,7 +708,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.inf, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="q_sigma of one sensor inf - asym_power_sensor"
+            id="q_sigma of one sensor inf - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -718,7 +718,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="p_sigma of one sensor nan - asym_power_sensor"
+            id="p_sigma of one sensor nan - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -728,7 +728,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="p_sigma of one sensor inf - asym_power_sensor"
+            id="p_sigma of one sensor inf - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -738,7 +738,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="all nan except one attribute for one phase for one sensor - asym_power_sensor"
+            id="all nan except one attribute for one phase for one sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -748,7 +748,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="all inf except one attribute for one phase for one sensor - asym_power_sensor"
+            id="all inf except one attribute for one phase for one sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -758,7 +758,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
-            id="all nan except one phase for one sensor - asym_power_sensor"
+            id="all nan except one phase for one sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,
@@ -768,7 +768,7 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError],
-            id="all inf except one phase for one sensor - asym_power_sensor"
+            id="all inf except one phase for one sensor - asym_power_sensor",
         ),
         pytest.param(
             ComponentType.asym_power_sensor,

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -572,32 +572,61 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
 @pytest.mark.parametrize(
     ("sensor_type", "values", "error_types"),
     [
-        (
+        pytest.param(
             ComponentType.sym_power_sensor,
             [[np.nan, np.nan], [], []],
             [InvalidIdError, NotUniqueError],
+            id="both nan - sym_power_sensor",
         ),
-        (
+        pytest.param(
+            ComponentType.sym_power_sensor,
+            [[np.inf, np.inf], [], []],
+            [InvalidIdError, NotUniqueError],
+            id="both inf - sym_power_sensor",
+        ),
+        pytest.param(
             ComponentType.sym_power_sensor,
             [[0.1, np.nan], [], []],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="q_sigma nan - sym_power_sensor",
         ),
-        (
+        pytest.param(
+            ComponentType.sym_power_sensor,
+            [[0.1, np.inf], [], []],
+            [InvalidIdError, NotUniqueError],
+            id="q_sigma inf - sym_power_sensor",
+        ),
+        pytest.param(
             ComponentType.sym_power_sensor,
             [[np.nan, 0.1], [], []],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="p_sigma nan - sym_power_sensor",
         ),
-        (
+        pytest.param(
+            ComponentType.sym_power_sensor,
+            [[np.inf, 0.1], [], []],
+            [InvalidIdError, NotUniqueError],
+            id="p_sigma inf - sym_power_sensor",
+        ),
+        pytest.param(
             ComponentType.sym_power_sensor,
             [[0.1, 0.1], [], []],
             [InvalidIdError, NotUniqueError],
+            id="no nan or inf - sym_power_sensor",
         ),
-        (
+        pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[np.nan, np.nan, np.nan]] * 3, [[np.nan, np.nan, np.nan]] * 3],
             [InvalidIdError, NotUniqueError],
+            id="all nan - asym_power_sensor",
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [[], [[np.inf, np.inf, np.inf]] * 3, [[np.inf, np.inf, np.inf]] * 3],
+            [InvalidIdError, NotUniqueError],
+            id="all inf - asym_power_sensor",
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -605,18 +634,43 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, 0.1, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="mixed nans for some sensor - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[0.1, np.inf, 0.1], [0.1, np.inf, 0.1], [0.1, 0.1, 0.1]],
+                [[np.inf, 0.1, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="mixed infs for some sensor - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[0.1, np.nan, np.nan]] * 3, [[np.nan, np.nan, np.nan]] * 3],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="all nan except one phase p_sigma - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [[], [[0.1, np.inf, np.inf]] * 3, [[np.inf, np.inf, np.inf]] * 3],
+            [InvalidIdError, NotUniqueError],
+            id="all inf except one phase p_sigma - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[np.nan, np.nan, np.nan]] * 3, [[0.1, np.nan, np.nan]] * 3],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="all nan except one phase q_sigma - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [[], [[np.inf, np.inf, np.inf]] * 3, [[0.1, np.inf, np.inf]] * 3],
+            [InvalidIdError, NotUniqueError],
+            id="all inf except one phase q_sigma - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -624,8 +678,19 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, np.nan, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="one sensor mixed nans - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[0.1, 0.1, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+                [[np.inf, np.inf, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="one sensor mixed infs - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -633,8 +698,19 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[np.nan, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="q_sigma of one sensor nan - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+                [[np.inf, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="q_sigma of one sensor inf - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -642,8 +718,19 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="p_sigma of one sensor nan - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[np.inf, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+                [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="p_sigma of one sensor inf - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -651,8 +738,19 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="all nan except one attribute for one phase for one sensor - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[np.inf, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+                [[0.1, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="all inf except one attribute for one phase for one sensor - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [
                 [],
@@ -660,11 +758,23 @@ def test_validate_values__infinite_sigmas(sensor_type, parameter):
                 [[0.1, np.nan, np.nan], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
             ],
             [InvalidIdError, NotUniqueError, PQSigmaPairError],
+            id="all nan except one phase for one sensor - asym_power_sensor"
         ),
-        (
+        pytest.param(
+            ComponentType.asym_power_sensor,
+            [
+                [],
+                [[0.1, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+                [[0.1, np.inf, np.inf], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
+            ],
+            [InvalidIdError, NotUniqueError],
+            id="all inf except one phase for one sensor - asym_power_sensor"
+        ),
+        pytest.param(
             ComponentType.asym_power_sensor,
             [[], [[0.1, 0.1, 0.1]] * 3, [[0.1, 0.1, 0.1]] * 3],
             [InvalidIdError, NotUniqueError],
+            id="no nan or inf - asym_power_sensor",
         ),
     ],
 )


### PR DESCRIPTION
The PGM documentation specifies the following regarding `p_sigma` and `q_sigma`:

> 1. If both p_sigma and q_sigma are provided, they represent the standard deviation of the active and reactive power, respectively, and the value of power_sigma is ignored. Any infinite component invalidates the entire measurement.
> 2. If neither p_sigma nor q_sigma are provided, power_sigma represents the standard deviation of the apparent power.
> 3. Providing only one of p_sigma and q_sigma results in undefined behaviour.

The underlying consequence is that:

> If any component of p_sigma and q_sigma is infinite, then they all shall be infinite.

There are a couple problems with this:

1. The phrasing is slightly misleading, because there is ambiguity between whether `invalidates the entire sensor` means `is not supported` or that it `disables the entire sensor`.
2. Above all, how the PGM actually handles infinite sigmas should be an implementation detail. The PGM core already handles this edge case correctly cfr. https://github.com/PowerGridModel/power-grid-model/blob/main/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/measured_values.hpp#L380-L381 .
3. Whether to specify only 1 or all components as infinite is business logic from a user perspective - not a PGM requirement.

This requirement is therefore nonsensical and should not live in the generic PGM data validator. If anything, it should live in some kind of strict business-logic-aware use-case specific data validator.

This PR therefore relaxes the statement and updates the documentation to explain the intention it more clearly.