### PR TITLE
Update (three_winding_transformer["clock_13"] = [5]) Transformer Examples.ipynb

### DIFF
--- a/docs/examples/Transformer Examples.ipynb
+++ b/docs/examples/Transformer Examples.ipynb
@@ -386,7 +386,7 @@
     "three_winding_transformer[\"winding_2\"] = [1]\n",
     "three_winding_transformer[\"winding_3\"] = [1]\n",
     "three_winding_transformer[\"clock_12\"] = [5]\n",
-    "three_winding_transformer[\"clock_13\"] = [-7]  # supports periodic input\n",
+    "three_winding_transformer[\"clock_13\"] = [5]  # supports periodic input\n",
     "three_winding_transformer[\"tap_side\"] = [0]\n",
     "three_winding_transformer[\"tap_pos\"] = [0]\n",
     "three_winding_transformer[\"tap_min\"] = [-10]\n",


### PR DESCRIPTION
**Fixes issue**: `# three_winding_transformer["clock_13"] = [5]`

ValidationException: There is a validation error in input_data: Field 'clock_13' is not between (or at) 0 and 12 for 1 three_winding_transformer.

three_winding_transformer["clock_13"] = [-7] # supports periodic input
-->
three_winding_transformer["clock_13"] = [5] # supports periodic input

The "clock" parameter in a transformer's vector group represents the phase shift between the windings. This is specified using a number from 0 to 11, analogous to the hours on a clock face [1]. Each integer step corresponds to a 30-degree phase shift [2]. 

For example, a clock number of 1 signifies a -30 degree phase shift, and 11 signifies a +30 degree (or -330 degree) shift [3].

The value -7 is outside the valid 0-11 range required by the validation function. While comment suggests you expected periodic input to be handled (e.g., wrapping -7 to a valid number), the validation function requires the value to be explicitly within the standard range.

To represent a phase shift equivalent to "-7 hours" on a clock, you can use modular arithmetic. On a 12-hour clock, -7 is the same as +5 (12 - 7 = 5). Therefore, the correct value for clock_13 is 5.

1. https://electrical-engineering-portal.com/understanding-vector-group-transformer-1
2. https://www.quora.com/Why-can-the-phase-shifts-of-transformers-be-represented-by-the-clock-number-in-vector-groups
3. https://metapowersolutions.com/what-is-a-transformer-vector-group/