### PR TITLE
Pre-commit checks: improve naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,11 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
+        name: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+        name: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.0
     hooks:


### PR DESCRIPTION
Change the name from `ruff check` to `ruff-check` (and idem for format) for easier copy-paste-rerun

before
```
> pre-commit run ruff-check
ruff check..........................................(no files to check)Skipped
> pre-commit run ruff-format
ruff format..........................................(no files to check)Skipped
```
after
```
> pre-commit run ruff-check
ruff-check..........................................(no files to check)Skipped
> pre-commit run ruff-format
ruff-format..........................................(no files to check)Skipped
```