### PR TITLE
Feature/timer using codes

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/calculation_info.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "logging.hpp"
+
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -11,6 +13,6 @@
 
 namespace power_grid_model {
 
-using CalculationInfo = std::map<std::string, double, std::less<>>;
+using CalculationInfo = std::map<LoggingTag, double>;
 
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
@@ -14,6 +14,8 @@ namespace common::logging {
 enum class LoggingTag : Idx {
     unknown = -1,
     log = 0,
+    total = 100000,       // TODO(mgovers): find other error code?
+    build_model = 101000, // TODO(mgovers): find other error code?
     timer = 1,
     total_single_calculation_in_thread = 0100,
     total_batch_calculation_in_thread = 0200,
@@ -23,11 +25,24 @@ enum class LoggingTag : Idx {
     scenario_exception = 1300,
     recover_from_bad = 1400,
     prepare = 2100,
+    create_math_solver = 2210,
     math_calculation = 2200,
-    iterative_pf_solver_max_num_iter = 2226,
-    ilse_max_num_iter = 2228,
-    nrse_max_num_iter = 2229, // used to be duplicate number
+    math_solver = 2220,
+    initialize_calculation = 2221,
+    preprocess_measured_value = 102221, // TODO(mgovers): find other error code + make plural?
+    prepare_matrix = 2222,
+    prepare_matrix_including_prefactorization = 102222, // TODO(mgovers): find other error code
+    prepare_matrices = 1002222,                         // TODO(mgovers): find other error code
+    initialize_voltages = 2223,
+    calculate_rhs = 2224,
+    prepare_lhs_rhs = 102224, // TODO(mgovers): find other error code
+    solve_sparse_linear_equation = 2225,
+    solve_sparse_linear_equation_prefactorized = 102225, // TODO(mgovers): find other error code
+    iterate_unknown = 2226,
+    calculate_math_result = 2227,
     produce_output = 3000,
+    iterative_pf_solver_max_num_iter = 1002226, // TODO(mgovers): find other error code
+    max_num_iter = 1002228,                     // TODO(mgovers): find other error code
 };
 
 constexpr auto to_string(LoggingTag tag) {
@@ -55,19 +70,42 @@ constexpr auto to_string(LoggingTag tag) {
         return "Recover from bad"s;
     case prepare:
         return "Prepare"s;
+    case create_math_solver:
+        return "Create math solver"s;
     case math_calculation:
         return "Math calculation"s;
-    case iterative_pf_solver_max_num_iter:
-        // return "Iterative PF solver max num iter"s;
-        return "Max number of iterations"s;
-    case ilse_max_num_iter:
-        // return "ILSE max num iter"s;
-        return "Max number of iterations"s;
-    case nrse_max_num_iter:
-        // return "NRSE max num iter"s;
-        return "Max number of iterations"s;
+    case math_solver:
+        return "Math solver"s;
+    case initialize_calculation:
+        return "Initialize calculation"s;
+    case preprocess_measured_value:
+        return "Pre-process measured value"s; // TODO(mgovers): make plural
+    case prepare_matrix:
+        return "Prepare matrix"s;
+    case prepare_matrix_including_prefactorization:
+        return "Prepare matrix, including pre-factorization"s;
+    case prepare_matrices:
+        return "Prepare the matrices"s; // TODO(mgovers): combine or properly split up?
+    case initialize_voltages:
+        return "Initialize voltages"s;
+    case calculate_rhs:
+        return "Calculate rhs"s; // TODO(mgovers): capitalize?
+    case prepare_lhs_rhs:
+        return "Prepare LHS rhs"s;
+    case solve_sparse_linear_equation:
+        return "Solve sparse linear equation"s;
+    case solve_sparse_linear_equation_prefactorized:
+        return "Solve sparse linear equation (pre-factorized)"s;
+    case iterate_unknown:
+        return "Iterate unknown"s;
+    case calculate_math_result:
+        return "Calculate math result"s;
     case produce_output:
         return "Produce output"s;
+    case iterative_pf_solver_max_num_iter:
+        return "Max number of iterations"s; // TODO(mgovers): different messages?
+    case max_num_iter:
+        return "Max number of iterations"s; // TODO(mgovers): different messages?
     default:
         return "unknown"s;
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
@@ -54,6 +54,10 @@ constexpr auto to_string(LoggingTag tag) {
         return "log"s;
     case timer:
         return "timer"s;
+    case total:
+        return "Total"s;
+    case build_model:
+        return "Build model"s;
     case total_single_calculation_in_thread:
         return "Total single calculation in thread"s;
     case total_batch_calculation_in_thread:
@@ -73,7 +77,7 @@ constexpr auto to_string(LoggingTag tag) {
     case create_math_solver:
         return "Create math solver"s;
     case math_calculation:
-        return "Math calculation"s;
+        return "Math Calculation"s; // TODO(mgovers): make capitalization consistent
     case math_solver:
         return "Math solver"s;
     case initialize_calculation:

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/logging.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "common.hpp"
+
+#include <string_view>
+
+namespace power_grid_model {
+namespace common::logging {
+
+enum class LoggingTag : Idx {
+    unknown = -1,
+    log = 0,
+    timer = 1,
+    total_single_calculation_in_thread = 0100,
+    total_batch_calculation_in_thread = 0200,
+    copy_model = 1100,
+    update_model = 1200,
+    restore_model = 1201,
+    scenario_exception = 1300,
+    recover_from_bad = 1400,
+    prepare = 2100,
+    math_calculation = 2200,
+    iterative_pf_solver_max_num_iter = 2226,
+    ilse_max_num_iter = 2228,
+    nrse_max_num_iter = 2229, // used to be duplicate number
+    produce_output = 3000,
+};
+
+constexpr auto to_string(LoggingTag tag) {
+    using enum LoggingTag;
+    using namespace std::string_literals;
+
+    switch (tag) {
+    case log:
+        return "log"s;
+    case timer:
+        return "timer"s;
+    case total_single_calculation_in_thread:
+        return "Total single calculation in thread"s;
+    case total_batch_calculation_in_thread:
+        return "Total batch calculation in thread"s;
+    case copy_model:
+        return "Copy model"s;
+    case update_model:
+        return "Update model"s;
+    case restore_model:
+        return "Restore model"s;
+    case scenario_exception:
+        return "Scenario exception"s;
+    case recover_from_bad:
+        return "Recover from bad"s;
+    case prepare:
+        return "Prepare"s;
+    case math_calculation:
+        return "Math calculation"s;
+    case iterative_pf_solver_max_num_iter:
+        // return "Iterative PF solver max num iter"s;
+        return "Max number of iterations"s;
+    case ilse_max_num_iter:
+        // return "ILSE max num iter"s;
+        return "Max number of iterations"s;
+    case nrse_max_num_iter:
+        // return "NRSE max num iter"s;
+        return "Max number of iterations"s;
+    case produce_output:
+        return "Produce output"s;
+    default:
+        return "unknown"s;
+    }
+}
+
+} // namespace common::logging
+
+using common::logging::LoggingTag;
+
+} // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/timer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/timer.hpp
@@ -60,23 +60,9 @@ class Timer {
         if (info_ != nullptr) {
             auto const now = Clock::now();
             auto const duration = Duration(now - start_);
-            info_->operator[](Timer::make_key(code_)) += (double)duration.count();
+            info_->operator[](code_) += (double)duration.count();
             info_ = nullptr;
         }
-    }
-
-    static std::string make_key(LoggingTag code) {
-        std::stringstream ss;
-        ss << std::setw(4) << std::setfill('0') << static_cast<std::underlying_type_t<LoggingTag>>(code) << ".";
-        auto key = ss.str();
-        for (size_t i = 0, n = key.length() - 1; i < n; ++i) {
-            if (key[i] == '0') {
-                break;
-            }
-            key += "\t";
-        }
-        key += common::logging::to_string(code);
-        return key;
     }
 };
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
@@ -61,22 +61,22 @@ class JobDispatch {
 
             CalculationInfo thread_info;
 
-            Timer t_total(thread_info, 0200, "Total batch calculation in thread");
+            Timer t_total{thread_info, LoggingTag::total_batch_calculation_in_thread};
 
             auto const copy_adapter_functor = [&base_adapter, &thread_info]() {
-                Timer const t_copy_adapter_functor(thread_info, 1100, "Copy model");
+                Timer const t_copy_adapter_functor{thread_info, LoggingTag::copy_model};
                 return Adapter{base_adapter};
             };
 
             auto adapter = copy_adapter_functor();
 
             auto setup = [&adapter, &update_data, &thread_info](Idx scenario_idx) {
-                Timer const t_update_model(thread_info, 1200, "Update model");
+                Timer const t_update_model{thread_info, LoggingTag::update_model};
                 adapter.setup(update_data, scenario_idx);
             };
 
             auto winddown = [&adapter, &thread_info]() {
-                Timer const t_restore_model(thread_info, 1201, "Restore model");
+                Timer const t_restore_model{thread_info, LoggingTag::restore_model};
                 adapter.winddown();
             };
 
@@ -96,7 +96,7 @@ class JobDispatch {
                 scenario_exception_handler(adapter, exceptions, thread_info), std::move(recover_from_bad));
 
             for (Idx scenario_idx = start; scenario_idx < n_scenarios; scenario_idx += stride) {
-                Timer const t_total_single(thread_info, 0100, "Total single calculation in thread");
+                Timer const t_total_single{thread_info, LoggingTag::total_single_calculation_in_thread};
                 calculate_scenario(scenario_idx);
             }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/calculation_info.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/calculation_info.hpp
@@ -11,7 +11,7 @@
 namespace power_grid_model::main_core {
 
 inline CalculationInfo& merge_into(CalculationInfo& destination, CalculationInfo const& source) {
-    static auto const key = Timer::make_key(2226, "Max number of iterations");
+    static auto const key = Timer::make_key(LoggingTag::iterative_pf_solver_max_num_iter);
     for (auto const& [k, v] : source) {
         if (k == key) {
             destination[k] = std::max(destination[k], v);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/calculation_info.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/calculation_info.hpp
@@ -11,7 +11,9 @@
 namespace power_grid_model::main_core {
 
 inline CalculationInfo& merge_into(CalculationInfo& destination, CalculationInfo const& source) {
-    static auto const key = Timer::make_key(LoggingTag::iterative_pf_solver_max_num_iter);
+    static constexpr auto key =
+        LoggingTag::iterative_pf_solver_max_num_iter; // TODO(mgovers) also add LoggingTag::max_num_iter; this is a bug
+                                                      // in main
     for (auto const& [k, v] : source) {
         if (k == key) {
             destination[k] = std::max(destination[k], v);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -423,14 +423,14 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         calculation_info_ = CalculationInfo{};
         // prepare
         auto const& input = [this, prepare_input_ = std::forward<PrepareInputFn>(prepare_input)] {
-            Timer const timer(calculation_info_, 2100, "Prepare");
+            Timer const timer{calculation_info_, LoggingTag::prepare};
             prepare_solvers<sym>();
             assert(is_topology_up_to_date_ && is_parameter_up_to_date<sym>());
             return prepare_input_(n_math_solvers_);
         }();
         // calculate
         return [this, &input, solve_ = std::forward<SolveFn>(solve)] {
-            Timer const timer(calculation_info_, 2200, "Math Calculation");
+            Timer const timer{calculation_info_, LoggingTag::math_calculation};
             auto& solvers = get_solvers<sym>();
             auto& y_bus_vec = get_y_bus<sym>();
             std::vector<SolverOutputType> solver_output;
@@ -595,7 +595,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
             }
         };
 
-        Timer const t_output(calculation_info_, 3000, "Produce output");
+        Timer const t_output{calculation_info_, LoggingTag::produce_output};
         main_core::utils::run_functor_with_all_types_return_void<ComponentType...>(output_func);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -137,8 +137,8 @@ template <symmetry_tag sym_type> class IterativeLinearSESolver {
         sub_timer.stop();
         main_timer.stop();
 
-        auto const key = Timer::make_key(LoggingTag::max_num_iter);
-        calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
+        calculation_info[LoggingTag::max_num_iter] =
+            std::max(calculation_info[LoggingTag::max_num_iter], static_cast<double>(num_iter));
 
         return output;
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -137,7 +137,7 @@ template <symmetry_tag sym_type> class IterativeLinearSESolver {
         sub_timer.stop();
         main_timer.stop();
 
-        auto const key = Timer::make_key(2228, "Max number of iterations");
+        auto const key = Timer::make_key(LoggingTag::ilse_max_num_iter);
         calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
 
         return output;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
@@ -75,7 +75,7 @@ template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
         // Manually stop timers to avoid "Max number of iterations" to be included in the timing.
         main_timer.stop();
 
-        auto const key = Timer::make_key(2226, "Max number of iterations");
+        auto const key = Timer::make_key(LoggingTag::iterative_pf_solver_max_num_iter);
         calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
 
         return output;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
@@ -34,11 +34,11 @@ template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
         output.u.resize(n_bus_);
         double max_dev = std::numeric_limits<double>::infinity();
 
-        Timer main_timer{calculation_info, 2220, "Math solver"};
+        Timer main_timer{calculation_info, LoggingTag::math_solver};
 
         // initialize
         {
-            Timer const sub_timer{calculation_info, 2221, "Initialize calculation"};
+            Timer const sub_timer{calculation_info, LoggingTag::initialize_calculation};
             // Further initialization specific to the derived solver
             derived_solver.initialize_derived_solver(y_bus, input, output);
         }
@@ -52,24 +52,24 @@ template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
             }
             {
                 // Prepare the matrices of linear equations to be solved
-                Timer const sub_timer{calculation_info, 2222, "Prepare the matrices"};
+                Timer const sub_timer{calculation_info, LoggingTag::prepare_matrices};
                 derived_solver.prepare_matrix_and_rhs(y_bus, input, output.u);
             }
             {
                 // Solve the linear equations
-                Timer const sub_timer{calculation_info, 2223, "Solve sparse linear equation"};
+                Timer const sub_timer{calculation_info, LoggingTag::solve_sparse_linear_equation};
                 derived_solver.solve_matrix();
             }
             {
                 // Calculate maximum deviation of voltage at any bus
-                Timer const sub_timer{calculation_info, 2224, "Iterate unknown"};
+                Timer const sub_timer{calculation_info, LoggingTag::iterate_unknown};
                 max_dev = derived_solver.iterate_unknown(output.u);
             }
         }
 
         // calculate math result
         {
-            Timer const sub_timer{calculation_info, 2225, "Calculate math result"};
+            Timer const sub_timer{calculation_info, LoggingTag::calculate_math_result};
             calculate_result(y_bus, input, output);
         }
         // Manually stop timers to avoid "Max number of iterations" to be included in the timing.

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_pf_solver.hpp
@@ -75,8 +75,8 @@ template <symmetry_tag sym, typename DerivedSolver> class IterativePFSolver {
         // Manually stop timers to avoid "Max number of iterations" to be included in the timing.
         main_timer.stop();
 
-        auto const key = Timer::make_key(LoggingTag::iterative_pf_solver_max_num_iter);
-        calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
+        calculation_info[LoggingTag::iterative_pf_solver_max_num_iter] =
+            std::max(calculation_info[LoggingTag::iterative_pf_solver_max_num_iter], static_cast<double>(num_iter));
 
         return output;
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/linear_pf_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/linear_pf_solver.hpp
@@ -68,20 +68,20 @@ template <symmetry_tag sym_type> class LinearPFSolver {
         SolverOutput<sym> output;
         output.u.resize(n_bus_);
 
-        Timer const main_timer(calculation_info, 2220, "Math solver");
+        Timer const main_timer{calculation_info, LoggingTag::math_solver};
 
         // prepare matrix
-        Timer sub_timer(calculation_info, 2221, "Prepare matrix");
+        Timer sub_timer{calculation_info, LoggingTag::prepare_matrix};
         detail::copy_y_bus<sym>(y_bus, mat_data_);
         prepare_matrix_and_rhs(y_bus, input, output);
 
         // solve
         // u vector will have I_injection for slack bus for now
-        sub_timer = Timer(calculation_info, 2222, "Solve sparse linear equation");
+        sub_timer = Timer{calculation_info, LoggingTag::solve_sparse_linear_equation};
         sparse_solver_.prefactorize_and_solve(mat_data_, perm_, output.u, output.u);
 
         // calculate math result
-        sub_timer = Timer(calculation_info, 2223, "Calculate math result");
+        sub_timer = Timer{calculation_info, LoggingTag::calculate_math_result};
         calculate_result(y_bus, input, output);
 
         // output

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/math_solver.hpp
@@ -85,7 +85,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
 
         // construct model if needed
         if (!iec60909_sc_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             iec60909_sc_solver_.emplace(y_bus, topo_ptr_);
         }
 
@@ -119,7 +119,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
     SolverOutput<sym> run_power_flow_newton_raphson(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
                                                     CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!newton_raphson_pf_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             newton_raphson_pf_solver_.emplace(y_bus, topo_ptr_);
         }
         return newton_raphson_pf_solver_.value().run_power_flow(y_bus, input, err_tol, max_iter, calculation_info);
@@ -128,7 +128,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
     SolverOutput<sym> run_power_flow_linear(PowerFlowInput<sym> const& input, double /* err_tol */, Idx /* max_iter */,
                                             CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!linear_pf_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             linear_pf_solver_.emplace(y_bus, topo_ptr_);
         }
         return linear_pf_solver_.value().run_power_flow(y_bus, input, calculation_info);
@@ -137,7 +137,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
     SolverOutput<sym> run_power_flow_iterative_current(PowerFlowInput<sym> const& input, double err_tol, Idx max_iter,
                                                        CalculationInfo& calculation_info, YBus<sym> const& y_bus) {
         if (!iterative_current_pf_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             iterative_current_pf_solver_.emplace(y_bus, topo_ptr_);
         }
         return iterative_current_pf_solver_.value().run_power_flow(y_bus, input, err_tol, max_iter, calculation_info);
@@ -155,7 +155,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
                                                             YBus<sym> const& y_bus) {
         // construct model if needed
         if (!iterative_linear_se_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             iterative_linear_se_solver_.emplace(y_bus, topo_ptr_);
         }
 
@@ -169,7 +169,7 @@ template <symmetry_tag sym> class MathSolver : public MathSolverBase<sym> {
                                                           YBus<sym> const& y_bus) {
         // construct model if needed
         if (!newton_raphson_se_solver_.has_value()) {
-            Timer const timer(calculation_info, 2210, "Create math solver");
+            Timer const timer{calculation_info, LoggingTag::create_math_solver};
             newton_raphson_se_solver_.emplace(y_bus, topo_ptr_);
         }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -197,7 +197,7 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
         sub_timer.stop();
         main_timer.stop();
 
-        auto const key = Timer::make_key(2228, "Max number of iterations");
+        auto const key = Timer::make_key(LoggingTag::nrse_max_num_iter);
         calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
 
         return output;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -182,7 +182,7 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
             sub_timer = Timer{calculation_info, LoggingTag::prepare_lhs_rhs};
             prepare_matrix_and_rhs(y_bus, measured_values, output.u);
             // solve with prefactorization
-            sub_timer = Timer{calculation_info, LoggingTag::solve_sparse_linear_equation_prefactorized};
+            sub_timer = Timer{calculation_info, LoggingTag::solve_sparse_linear_equation};
             sparse_solver_.prefactorize_and_solve(data_gain_, perm_, delta_x_rhs_, delta_x_rhs_,
                                                   observability_result.use_perturbation());
             sub_timer = Timer{calculation_info, LoggingTag::iterate_unknown};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -197,8 +197,8 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
         sub_timer.stop();
         main_timer.stop();
 
-        auto const key = Timer::make_key(LoggingTag::max_num_iter);
-        calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
+        calculation_info[LoggingTag::max_num_iter] =
+            std::max(calculation_info[LoggingTag::max_num_iter], static_cast<double>(num_iter));
 
         return output;
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -161,16 +161,16 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
         output.bus_injection.resize(n_bus_);
         double max_dev = std::numeric_limits<double>::max();
 
-        main_timer = Timer(calculation_info, 2220, "Math solver");
+        main_timer = Timer{calculation_info, LoggingTag::math_solver};
 
         // preprocess measured value
-        sub_timer = Timer(calculation_info, 2221, "Pre-process measured value");
+        sub_timer = Timer{calculation_info, LoggingTag::preprocess_measured_value};
         MeasuredValues<sym> const measured_values{y_bus.shared_topology(), input};
         auto const observability_result =
             observability_check(measured_values, y_bus.math_topology(), y_bus.y_bus_structure());
 
         // initialize voltage with initial angle
-        sub_timer = Timer(calculation_info, 2223, "Initialize voltages");
+        sub_timer = Timer{calculation_info, LoggingTag::initialize_voltages};
         initialize_unknown(output.u, measured_values);
 
         // loop to iterate
@@ -179,25 +179,25 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
             if (num_iter++ == max_iter) {
                 throw IterationDiverge{max_iter, max_dev, err_tol};
             }
-            sub_timer = Timer(calculation_info, 2224, "Prepare LHS rhs");
+            sub_timer = Timer{calculation_info, LoggingTag::prepare_lhs_rhs};
             prepare_matrix_and_rhs(y_bus, measured_values, output.u);
             // solve with prefactorization
-            sub_timer = Timer(calculation_info, 2225, "Solve sparse linear equation");
+            sub_timer = Timer{calculation_info, LoggingTag::solve_sparse_linear_equation_prefactorized};
             sparse_solver_.prefactorize_and_solve(data_gain_, perm_, delta_x_rhs_, delta_x_rhs_,
                                                   observability_result.use_perturbation());
-            sub_timer = Timer(calculation_info, 2226, "Iterate unknown");
+            sub_timer = Timer{calculation_info, LoggingTag::iterate_unknown};
             max_dev = iterate_unknown(output.u, measured_values);
         };
 
         // calculate math result
-        sub_timer = Timer(calculation_info, 2227, "Calculate math result");
+        sub_timer = Timer{calculation_info, LoggingTag::calculate_math_result};
         detail::calculate_se_result<sym>(y_bus, measured_values, output);
 
         // Manually stop timers to avoid "Max number of iterations" to be included in the timing.
         sub_timer.stop();
         main_timer.stop();
 
-        auto const key = Timer::make_key(LoggingTag::nrse_max_num_iter);
+        auto const key = Timer::make_key(LoggingTag::max_num_iter);
         calculation_info[key] = std::max(calculation_info[key], static_cast<double>(num_iter));
 
         return output;

--- a/tests/benchmark_cpp/benchmark.cpp
+++ b/tests/benchmark_cpp/benchmark.cpp
@@ -110,9 +110,9 @@ struct PowerGridBenchmark {
 
         {
             std::cout << "*****Run with initialization*****\n";
-            Timer const t_total(info, 0000, "Total");
+            Timer const t_total{info, LoggingTag::total};
             {
-                Timer const t_build(info, 1000, "Build model");
+                Timer const t_build{info, LoggingTag::build_model};
                 main_model = std::make_unique<MainModel>(50.0, input.get_dataset(), get_math_solver_dispatcher());
             }
             run(single_scenario);
@@ -121,7 +121,7 @@ struct PowerGridBenchmark {
         info.clear();
         {
             std::cout << "\n*****Run without initialization*****\n";
-            Timer const t_total(info, 0000, "Total");
+            Timer const t_total{info, LoggingTag::total};
             run(single_scenario);
         }
         print(info);
@@ -129,7 +129,7 @@ struct PowerGridBenchmark {
         if (batch_size > 0) {
             info.clear();
             std::cout << "\n*****Run with batch calculation*****\n";
-            Timer const t_total(info, 0000, "Total");
+            Timer const t_total{info, LoggingTag::total};
             run(batch_size);
         }
         print(info);

--- a/tests/benchmark_cpp/benchmark.cpp
+++ b/tests/benchmark_cpp/benchmark.cpp
@@ -20,6 +20,20 @@ MathSolverDispatcher const& get_math_solver_dispatcher() {
     return math_solver_dispatcher;
 }
 
+std::string make_key(LoggingTag code) {
+    std::stringstream ss;
+    ss << std::setw(4) << std::setfill('0') << static_cast<std::underlying_type_t<LoggingTag>>(code) << ".";
+    auto key = ss.str();
+    for (size_t i = 0, n = key.length() - 1; i < n; ++i) {
+        if (key[i] == '0') {
+            break;
+        }
+        key += "\t";
+    }
+    key += common::logging::to_string(code);
+    return key;
+}
+
 auto get_benchmark_run_title(Option const& option, MainModelOptions const& model_options) {
     auto const mv_ring_type = option.has_mv_ring ? "meshed grid" : "radial grid";
     auto const sym_type =
@@ -139,7 +153,7 @@ struct PowerGridBenchmark {
 
     static void print(CalculationInfo const& info) {
         for (auto const& [key, val] : info) {
-            std::cout << key << ": " << val << '\n';
+            std::cout << make_key(key) << ": " << val << '\n';
         }
     }
 


### PR DESCRIPTION
* [ ] Directly pass only the code to `Timer` instead of code + name
* [ ] Homogenize some of the duplicated codes (to be followed up)
* [ ] Use the code to store the `CalculationInfo` instead of a string key constructed from code + name
* [ ] Format the `CalculationInfo` when actually producing the output
