### PR TITLE
Clean-up main model: migrate reset calculation info to job dispatch

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_adapter.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_adapter.hpp
@@ -86,7 +86,6 @@ class JobAdapter<MainModel, ComponentList<ComponentType...>>
     std::mutex calculation_info_mutex_;
 
     void calculate_impl(MutableDataset const& result_data, Idx scenario_idx) const {
-        model_reference_.get().reset_calculation_info();
         MainModel::calculator(options_.get(), model_reference_.get(), result_data.get_individual_scenario(scenario_idx),
                               false);
     }
@@ -94,7 +93,6 @@ class JobAdapter<MainModel, ComponentList<ComponentType...>>
     void cache_calculate_impl() const {
         // calculate once to cache topology, ignore results, all math solvers are initialized
         try {
-            model_reference_.get().reset_calculation_info();
             MainModel::calculator(options_.get(), model_reference_.get(),
                                   {
                                       false,
@@ -138,6 +136,7 @@ class JobAdapter<MainModel, ComponentList<ComponentType...>>
     }
 
     CalculationInfo get_calculation_info_impl() const { return model_reference_.get().calculation_info(); }
+    void reset_calculation_info_impl() { model_reference_.get().reset_calculation_info(); }
 
     void thread_safe_add_calculation_info_impl(CalculationInfo const& info) {
         std::lock_guard const lock{calculation_info_mutex_};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_adapter.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_adapter.hpp
@@ -86,6 +86,7 @@ class JobAdapter<MainModel, ComponentList<ComponentType...>>
     std::mutex calculation_info_mutex_;
 
     void calculate_impl(MutableDataset const& result_data, Idx scenario_idx) const {
+        model_reference_.get().reset_calculation_info();
         MainModel::calculator(options_.get(), model_reference_.get(), result_data.get_individual_scenario(scenario_idx),
                               false);
     }
@@ -93,6 +94,7 @@ class JobAdapter<MainModel, ComponentList<ComponentType...>>
     void cache_calculate_impl() const {
         // calculate once to cache topology, ignore results, all math solvers are initialized
         try {
+            model_reference_.get().reset_calculation_info();
             MainModel::calculator(options_.get(), model_reference_.get(),
                                   {
                                       false,

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
@@ -24,6 +24,7 @@ class JobDispatch {
     static BatchParameter batch_calculation(Adapter& adapter, ResultDataset const& result_data,
                                             UpdateDataset const& update_data, Idx threading = sequential) {
         if (update_data.empty()) {
+            adapter.reset_calculation_info();
             adapter.calculate(result_data);
             return BatchParameter{};
         }
@@ -38,6 +39,7 @@ class JobDispatch {
         }
 
         // calculate once to cache, ignore results
+        adapter.reset_calculation_info();
         adapter.cache_calculate();
 
         // error messages
@@ -86,6 +88,7 @@ class JobDispatch {
             };
 
             auto run = [&adapter, &result_data, &thread_info](Idx scenario_idx) {
+                adapter.reset_calculation_info();
                 adapter.calculate(result_data, scenario_idx);
                 main_core::merge_into(thread_info, adapter.get_calculation_info());
             };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_interface.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_interface.hpp
@@ -68,6 +68,13 @@ template <typename Adapter> class JobInterface {
     {
         return static_cast<const Adapter*>(this)->get_calculation_info_impl();
     }
+    CalculationInfo reset_calculation_info()
+        requires requires(Adapter& adapter) { // NOSONAR
+            { adapter.reset_calculation_info_impl() } -> std::same_as<CalculationInfo>;
+        }
+    {
+        return static_cast<Adapter*>(this)->reset_calculation_info_impl();
+    }
 
     void thread_safe_add_calculation_info(CalculationInfo const& info)
         requires requires(Adapter& adapter) { // NOSONAR

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_interface.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_interface.hpp
@@ -68,12 +68,12 @@ template <typename Adapter> class JobInterface {
     {
         return static_cast<const Adapter*>(this)->get_calculation_info_impl();
     }
-    CalculationInfo reset_calculation_info()
+    void reset_calculation_info()
         requires requires(Adapter& adapter) { // NOSONAR
-            { adapter.reset_calculation_info_impl() } -> std::same_as<CalculationInfo>;
+            { adapter.reset_calculation_info_impl() } -> std::same_as<void>;
         }
     {
-        return static_cast<Adapter*>(this)->reset_calculation_info_impl();
+        static_cast<Adapter*>(this)->reset_calculation_info_impl();
     }
 
     void thread_safe_add_calculation_info(CalculationInfo const& info)

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -420,7 +420,6 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         using sym = typename SolverOutputType::sym;
 
         assert(construction_complete_);
-        calculation_info_ = CalculationInfo{};
         // prepare
         auto const& input = [this, prepare_input_ = std::forward<PrepareInputFn>(prepare_input)] {
             Timer const timer{calculation_info_, LogEvent::prepare};
@@ -558,6 +557,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         assert(construction_complete_);
         main_core::merge_into(calculation_info_, info);
     }
+    void reset_calculation_info() { calculation_info_ = CalculationInfo{}; }
+
     auto const& state() const {
         assert(construction_complete_);
         return state_;

--- a/tests/benchmark_cpp/benchmark.cpp
+++ b/tests/benchmark_cpp/benchmark.cpp
@@ -99,7 +99,7 @@ std::string make_key(LogEvent code) {
         }
         key += "\t";
     }
-    key += common::logging::to_string(code);
+    key += to_string(code);
     return key;
 }
 


### PR DESCRIPTION
The location where the calculation info was reset is quite opaque. To more explicitly show the calculation 

NOTE: this does not solve the actual issue that main model owns its own info, nor the fact that the location where the reset is done is somewhere halfway through the calculation. It merely makes it more visible what happens under the hood.

* [x] Run Benchmark and make sure that there are no regressions like the one introduced in #1087

Relates to #1082 (reinstigated the original logic to allow benchmarking against original main)
Relates to #1093 (this PR is an enabler for follow-up improvements similar to #1093, but it is not a blocker for it)