### PR TITLE
Compiler support: enable C++23 in PGM core compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project (power_grid_model VERSION ${PGM_VERSION})
 
 option(PGM_ENABLE_DEV_BUILD "Enable developer build (e.g.: tests)" OFF)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -40,7 +40,7 @@ In this way, minimum effort should be necessary to port the library to other pla
 
 ### Compiler Support
 
-You need a C++ compiler with C++20 support.
+You need a C++ compiler with C++23 support.
 Below is a list of tested compilers:
 
 #### Linux

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/grouped_index_vector.hpp
@@ -9,11 +9,7 @@
 #include "iterator_facade.hpp"
 #include "typing.hpp"
 
-#include <boost/iterator/zip_iterator.hpp>
-#include <boost/range.hpp>
-#include <boost/range/adaptor/indexed.hpp>
-#include <boost/range/counting_range.hpp>
-
+#include <algorithm>
 #include <ranges>
 
 /*
@@ -272,13 +268,8 @@ inline auto enumerated_zip_sequence(grouped_idx_vector_type auto const& first,
                                     grouped_idx_vector_type auto const&... rest) {
     assert(((first.size() == rest.size()) && ...));
 
-    auto const indices = boost::counting_range(Idx{}, first.size());
-
-    auto const zip_begin =
-        boost::make_zip_iterator(boost::make_tuple(std::cbegin(indices), std::cbegin(first), std::cbegin(rest)...));
-    auto const zip_end =
-        boost::make_zip_iterator(boost::make_tuple(std::cend(indices), std::cend(first), std::cend(rest)...));
-    return boost::make_iterator_range(zip_begin, zip_end);
+    auto const indices = IdxRange{first.size()};
+    return std::views::zip(indices, first, rest...);
 }
 
 } // namespace power_grid_model

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
@@ -11,6 +11,7 @@
 #include "common/iterator_facade.hpp"
 #include "container_fwd.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <functional>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
@@ -11,9 +11,8 @@
 #include "common/iterator_facade.hpp"
 #include "container_fwd.hpp"
 
-#include <boost/range.hpp>
-
 #include <array>
+#include <cassert>
 #include <functional>
 #include <memory>
 #include <numeric>

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/container.hpp
@@ -188,7 +188,7 @@ class Container<RetrievableTypes<GettableTypes...>, StorageableTypes...> {
         assert(construction_complete_);
         assert(seq >= 0);
         std::array<Idx, num_storageable + 1> const& cum_size = cum_size_[get_cls_pos_v<Gettable, GettableTypes...>];
-        auto const found = std::upper_bound(cum_size.begin(), cum_size.end(), seq);
+        auto const found = std::ranges::upper_bound(cum_size, seq);
         assert(found != cum_size.end());
         auto const group = static_cast<Idx>(std::distance(cum_size.cbegin(), found) - 1);
         return Idx2D{.group = group, .pos = seq - cum_size[group]};

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -7,9 +7,6 @@
 
 #include <doctest/doctest.h>
 
-#include <boost/range/adaptors.hpp>
-#include <boost/range/irange.hpp>
-
 #include <ranges>
 
 namespace power_grid_model {


### PR DESCRIPTION
This PR unlocks and enables features (that may be relevant to us) like:

* multi-dimensional subscript operator
* `std::to_underlying` for enums
* `std::views::zip` (shown as an example)
* monadic operations for `std::optional`
* `<expected>`
* `std::unreachable`
* `std::ranges::to` to construct new containers from another range
* formatting ranges
* `std::ranges::contains`

To show the usage, the dependency of the `common` directory on `boost` is entirely removed because `std::views::zip` was unlocked. It worked out of the box, and it even simplifies the code.

See also https://en.cppreference.com/w/cpp/compiler_support/23.html