### PR TITLE
Clean-up main model: clang tidy bis

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -261,11 +261,8 @@ struct YBusStructure {
         // end of y_bus_entry_indptr is same as size of entry
         assert(y_bus_entry_indptr.back() == static_cast<Idx>(y_bus_element.size()));
 
-        // construct transpose entry
-        lu_transpose_entry.resize(nnz_counter_lu);
-        // default transpose_entry[i] = i
-        std::iota( // NOLINT(modernize-use-ranges) // not yet supported by some compilers
-            lu_transpose_entry.begin(), lu_transpose_entry.end(), 0);
+        lu_transpose_entry = IdxRange{nnz_counter_lu} | std::ranges::to<IdxVector>();
+
         // fill off-diagonal, loop all the branches
         for (auto const [entry_1, entry_2] : off_diag_map) {
             // for each branch entry tf and ft, they are transpose to each other

--- a/tests/cpp_unit_tests/test_dataset.cpp
+++ b/tests/cpp_unit_tests/test_dataset.cpp
@@ -1067,14 +1067,11 @@ TEST_CASE_TEMPLATE("Test dataset (common)", DatasetType, ConstDataset, MutableDa
                 check_get_individual_scenario();
             }
             SUBCASE("columnar") {
-                auto a_id_buffer = std::vector<ID>(a_elements_per_scenario * batch_size);
-                auto a_a1_buffer = std::vector<double>(a_elements_per_scenario * batch_size);
+                auto a_id_buffer =
+                    std::views::iota(0, a_elements_per_scenario * batch_size) | std::ranges::to<std::vector<ID>>();
+                auto a_a1_buffer =
+                    std::views::iota(0, a_elements_per_scenario * batch_size) | std::ranges::to<std::vector<double>>();
                 auto b_indptr = std::vector<Idx>{0, 0, 3};
-
-                std::iota( // NOLINT(modernize-use-ranges) // not yet supported by some compilers
-                    a_id_buffer.begin(), a_id_buffer.end(), ID{0});
-                std::iota( // NOLINT(modernize-use-ranges) // not yet supported by some compilers
-                    a_a1_buffer.begin(), a_a1_buffer.end(), 0.0);
 
                 add_homogeneous_buffer(dataset, A::name, a_elements_per_scenario, nullptr);
                 add_attribute_buffer(dataset, A::name, "id", static_cast<void*>(a_id_buffer.data()));


### PR DESCRIPTION
Re-applies the fixes as proposed in #1111 that were unable to be resolved because of the old GCC/G++ versions in the conda build and code quality checks now that #1113 has upgraded the GCC/G++ version in the conda build and removed the GCC/G++ dependency from the code quality build.