### PR TITLE
Cleanup main model: Clean up templates and variadics from y bus

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
@@ -51,7 +51,7 @@ template <class T, class U> struct MainModelType;
 template <class... ExtraRetrievableType, class... ComponentType>
 struct MainModelType<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentList<ComponentType...>> {
 
-    // using ComponentContainer = Container<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentType...>;
+    using ComponentContainer = Container<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentType...>;
     // using MainModelState = main_core::MainModelState<ComponentContainer>;
     using ComponentTypesTuple = std::tuple<std::type_identity<ComponentType>...>;
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
@@ -6,6 +6,7 @@
 
 #include "../all_components.hpp"
 #include "../container.hpp"
+#include "state.hpp"
 
 #include <array>
 #include <vector>
@@ -28,5 +29,44 @@ template <class... Types, class Functor> constexpr void run_functor_with_all_typ
 template <class... Types, class Functor> constexpr auto run_functor_with_all_types_return_array(Functor functor) {
     return std::array { functor.template operator()<Types>()... };
 }
+
+template <typename Tuple> struct tuple_type_identities_to_tuple_types;
+
+template <typename... Ts> struct tuple_type_identities_to_tuple_types<std::tuple<std::type_identity<Ts>...>> {
+    using type = std::tuple<Ts...>;
+};
+
+template <typename... Types, typename... SubTypes>
+constexpr auto filter_tuple_types(std::tuple<std::type_identity<Types>...> /*types_tuple*/,
+                                  std::tuple<std::type_identity<SubTypes>...> /*sub_types_tuple*/) {
+    constexpr auto sub_type_in_type = []<typename T>() { return (std::is_same_v<T, SubTypes> || ...); };
+
+    return std::tuple_cat(std::conditional_t<sub_type_in_type.template operator()<Types>(),
+                                             std::tuple<typename std::type_identity<Types>>, std::tuple<>>{}...);
+}
+
+// main model implementation template
+template <class T, class U> struct MainModelType;
+
+template <class... ExtraRetrievableType, class... ComponentType>
+struct MainModelType<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentList<ComponentType...>> {
+
+    // using ComponentContainer = Container<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentType...>;
+    // using MainModelState = main_core::MainModelState<ComponentContainer>;
+    using ComponentTypesTuple = std::tuple<std::type_identity<ComponentType>...>;
+
+    using TopologyTypesTuple =
+        std::tuple<std::type_identity<Node>, std::type_identity<Branch>, std::type_identity<Branch3>,
+                   std::type_identity<Source>, std::type_identity<Shunt>, std::type_identity<GenericLoadGen>,
+                   std::type_identity<GenericVoltageSensor>, std::type_identity<GenericPowerSensor>,
+                   std::type_identity<GenericCurrentSensor>, std::type_identity<Regulator>>;
+    // using TopologyConnectionTypes = std::tuple<std::type_identity<Branch>, std::type_identity<Branch3>,
+    // std::type_identity<Source>>;
+
+    using topology_sequence = typename tuple_type_identities_to_tuple_types<decltype(filter_tuple_types(
+        ComponentTypesTuple{}, TopologyTypesTuple{}))>::type;
+
+    static constexpr size_t n_component_types = main_core::utils::n_types<ComponentType...>;
+};
 
 } // namespace power_grid_model::main_core::utils

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/core_utils.hpp
@@ -36,35 +36,59 @@ template <typename... Ts> struct tuple_type_identities_to_tuple_types<std::tuple
     using type = std::tuple<Ts...>;
 };
 
-template <typename... Types, typename... SubTypes>
-constexpr auto filter_tuple_types(std::tuple<std::type_identity<Types>...> /*types_tuple*/,
-                                  std::tuple<std::type_identity<SubTypes>...> /*sub_types_tuple*/) {
-    constexpr auto sub_type_in_type = []<typename T>() { return (std::is_same_v<T, SubTypes> || ...); };
+template <typename Tuple>
+using tuple_type_identities_to_tuple_types_t = typename tuple_type_identities_to_tuple_types<Tuple>::type;
+
+template <typename... Types, typename... SelectTypes>
+constexpr auto filter_tuple_types(std::tuple<std::type_identity<Types>...>,
+                                  std::tuple<std::type_identity<SelectTypes>...>) {
+    constexpr auto sub_type_in_type = []<typename T>() { return (std::is_same_v<T, SelectTypes> || ...); };
 
     return std::tuple_cat(std::conditional_t<sub_type_in_type.template operator()<Types>(),
                                              std::tuple<typename std::type_identity<Types>>, std::tuple<>>{}...);
 }
 
+// concept validate_component_types_c =
+//     dependent_type_check<Source, Node, ComponentType...> && dependent_type_check<Line, Node, ComponentType...> &&
+//     dependent_type_check<ThreeWindingTransformer, Node, ComponentType...> &&
+//     dependent_type_check<Shunt, Node, ComponentType...> &&
+//     dependent_type_check<GenericLoadGen, Node, ComponentType...> &&
+//     dependent_type_check<GenericVoltageSensor, Node, ComponentType...>;
+
 // main model implementation template
 template <class T, class U> struct MainModelType;
 
 template <class... ExtraRetrievableType, class... ComponentType>
+// TODO: discussion on checking dependent types can also be done here.
+// requires validate_component_types_c<ComponentType...>
 struct MainModelType<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentList<ComponentType...>> {
 
     using ComponentContainer = Container<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentType...>;
-    // using MainModelState = main_core::MainModelState<ComponentContainer>;
-    using ComponentTypesTuple = std::tuple<std::type_identity<ComponentType>...>;
+    using MainModelState = main_core::MainModelState<ComponentContainer>;
+    using ExtraRetrievableTypesTuple = std::tuple<std::type_identity<ExtraRetrievableType>...>;
+    using ComponentTypesTuple = std::tuple<ComponentType...>;
 
-    using TopologyTypesTuple =
+    // TODO: Clean up using-s
+    using _AllTypesTuple =
+        std::tuple<std::type_identity<ComponentType>..., std::type_identity<ExtraRetrievableType>...>;
+    // TODO: Would making a unique be necessary? We have Node mentioned as a ExtraRetrievableType and ComponentType so
+    // summing up is possible but maybe not appropriate. Would it be better to handle them both separately? using
+    // _AllTypesTupleUnique = typename tuple_type_identities_to_tuple_types<decltype(filter_tuple_types(
+    // _TopologyTypesTuple{}, _AllTypesTuple{}))>::type;
+
+    using _ComponentTypesTuple = std::tuple<std::type_identity<ComponentType>...>;
+    using _TopologyTypesTuple =
         std::tuple<std::type_identity<Node>, std::type_identity<Branch>, std::type_identity<Branch3>,
                    std::type_identity<Source>, std::type_identity<Shunt>, std::type_identity<GenericLoadGen>,
                    std::type_identity<GenericVoltageSensor>, std::type_identity<GenericPowerSensor>,
                    std::type_identity<GenericCurrentSensor>, std::type_identity<Regulator>>;
-    // using TopologyConnectionTypes = std::tuple<std::type_identity<Branch>, std::type_identity<Branch3>,
-    // std::type_identity<Source>>;
+    using _TopologyConnectionTypes =
+        std::tuple<std::type_identity<Branch>, std::type_identity<Branch3>, std::type_identity<Source>>;
 
-    using topology_sequence = typename tuple_type_identities_to_tuple_types<decltype(filter_tuple_types(
-        ComponentTypesTuple{}, TopologyTypesTuple{}))>::type;
+    using TopologyTypesTuple =
+        tuple_type_identities_to_tuple_types_t<decltype(filter_tuple_types(_TopologyTypesTuple{}, _AllTypesTuple{}))>;
+    using TopologyConnectionTypesTuple = tuple_type_identities_to_tuple_types_t<decltype(filter_tuple_types(
+        _TopologyConnectionTypes{}, _AllTypesTuple{}))>;
 
     static constexpr size_t n_component_types = main_core::utils::n_types<ComponentType...>;
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/y_bus.hpp
@@ -8,8 +8,54 @@
 
 namespace power_grid_model::main_core {
 
-template <symmetry_tag sym, typename ComponentContainer, typename... ComponentType>
-void prepare_y_bus(MainModelState<ComponentContainer> const& state_, Idx n_math_solvers_, MathState& math_state_) {
+namespace detail {
+template <std::derived_from<Branch> ComponentType, typename ComponentContainer>
+constexpr void add_to_increment(std::vector<MathModelParamIncrement>& increments,
+                                MainModelState<ComponentContainer> const& state, Idx2D const& changed_component_idx) {
+    Idx2D const math_idx =
+        state.topo_comp_coup->branch[main_core::get_component_sequence_idx<Branch>(state, changed_component_idx)];
+    if (math_idx.group == isolated_component) {
+        return;
+    }
+    // assign parameters
+    increments[math_idx.group].branch_param_to_change.push_back(math_idx.pos);
+}
+
+template <std::derived_from<Branch3> ComponentType, typename ComponentContainer>
+constexpr void add_to_increment(std::vector<MathModelParamIncrement>& increments,
+                                MainModelState<ComponentContainer> const& state, Idx2D const& changed_component_idx) {
+    Idx2DBranch3 const math_idx =
+        state.topo_comp_coup->branch3[main_core::get_component_sequence_idx<Branch3>(state, changed_component_idx)];
+    if (math_idx.group == isolated_component) {
+        return;
+    }
+    // assign parameters, branch3 param consists of three branch parameters
+    for (size_t branch2 = 0; branch2 < 3; ++branch2) {
+        increments[math_idx.group].branch_param_to_change.push_back(math_idx.pos[branch2]);
+    }
+}
+
+template <std::same_as<Shunt> ComponentType, typename ComponentContainer>
+constexpr void add_to_increment(std::vector<MathModelParamIncrement>& increments,
+                                MainModelState<ComponentContainer> const& state, Idx2D const& changed_component_idx) {
+    Idx2D const math_idx =
+        state.topo_comp_coup->shunt[main_core::get_component_sequence_idx<Shunt>(state, changed_component_idx)];
+    if (math_idx.group == isolated_component) {
+        return;
+    }
+    // assign parameters
+    increments[math_idx.group].shunt_param_to_change.push_back(math_idx.pos);
+}
+
+// default implementation for other components, does nothing
+template <typename ComponentType, typename ComponentContainer>
+constexpr void add_to_increment(std::vector<MathModelParamIncrement>& /* increments */,
+                                MainModelState<ComponentContainer> const& /* state */,
+                                Idx2D const& /* changed_component_idx */) {}
+} // namespace detail
+
+template <symmetry_tag sym, typename MainModelType>
+void prepare_y_bus(typename MainModelType::MainModelState const& state_, Idx n_math_solvers_, MathState& math_state_) {
     std::vector<YBus<sym>>& y_bus_vec = main_core::get_y_bus<sym>(math_state_);
     // also get the vector of other Y_bus (sym -> asym, or asym -> sym)
     std::vector<YBus<other_symmetry_t<sym>>>& other_y_bus_vec =
@@ -19,14 +65,6 @@ void prepare_y_bus(MainModelState<ComponentContainer> const& state_, Idx n_math_
         bool const other_y_bus_exist = (!other_y_bus_vec.empty());
         y_bus_vec.reserve(n_math_solvers_);
         auto math_params = get_math_param<sym>(state_, n_math_solvers_);
-
-        // Check the branch and shunt indices
-        constexpr auto branch_param_in_seq_map =
-            std::array{main_core::utils::index_of_component<Line, ComponentType...>,
-                       main_core::utils::index_of_component<Link, ComponentType...>,
-                       main_core::utils::index_of_component<Transformer, ComponentType...>};
-        constexpr auto shunt_param_in_seq_map =
-            std::array{main_core::utils::index_of_component<Shunt, ComponentType...>};
 
         for (Idx i = 0; i != n_math_solvers_; ++i) {
             // construct from existing Y_bus structure if possible
@@ -38,66 +76,25 @@ void prepare_y_bus(MainModelState<ComponentContainer> const& state_, Idx n_math_
                 y_bus_vec.emplace_back(state_.math_topology[i],
                                        std::make_shared<MathModelParam<sym> const>(std::move(math_params[i])));
             }
-
-            y_bus_vec.back().set_branch_param_idx(
-                IdxVector{branch_param_in_seq_map.begin(), branch_param_in_seq_map.end()});
-            y_bus_vec.back().set_shunt_param_idx(
-                IdxVector{shunt_param_in_seq_map.begin(), shunt_param_in_seq_map.end()});
         }
     }
 }
 
-template <symmetry_tag sym, typename ComponentContainer, typename... ComponentType>
-static std::vector<MathModelParamIncrement> get_math_param_increment(
-    MainModelState<ComponentContainer>& received_state, Idx n_math_solvers_,
-    std::array<std::vector<Idx2D>, main_core::utils::n_types<ComponentType...>> const& parameter_changed_components_) {
-    using AddToIncrement =
-        void (*)(std::vector<MathModelParamIncrement>&, MainModelState<ComponentContainer> const&, Idx2D const&);
-
-    static constexpr std::array<AddToIncrement, main_core::utils::n_types<ComponentType...>> add_to_increments{
-        [](std::vector<MathModelParamIncrement>& increments, MainModelState<ComponentContainer> const& state,
-           Idx2D const& changed_component_idx) {
-            if constexpr (std::derived_from<ComponentType, Branch>) {
-                Idx2D const math_idx =
-                    state.topo_comp_coup
-                        ->branch[main_core::get_component_sequence_idx<Branch>(state, changed_component_idx)];
-                if (math_idx.group == isolated_component) {
-                    return;
-                }
-                // assign parameters
-                increments[math_idx.group].branch_param_to_change.push_back(math_idx.pos);
-            } else if constexpr (std::derived_from<ComponentType, Branch3>) {
-                Idx2DBranch3 const math_idx =
-                    state.topo_comp_coup
-                        ->branch3[main_core::get_component_sequence_idx<Branch3>(state, changed_component_idx)];
-                if (math_idx.group == isolated_component) {
-                    return;
-                }
-                // assign parameters, branch3 param consists of three branch parameters
-                for (size_t branch2 = 0; branch2 < 3; ++branch2) {
-                    increments[math_idx.group].branch_param_to_change.push_back(math_idx.pos[branch2]);
-                }
-            } else if constexpr (std::same_as<ComponentType, Shunt>) {
-                Idx2D const math_idx =
-                    state.topo_comp_coup
-                        ->shunt[main_core::get_component_sequence_idx<Shunt>(state, changed_component_idx)];
-                if (math_idx.group == isolated_component) {
-                    return;
-                }
-                // assign parameters
-                increments[math_idx.group].shunt_param_to_change.push_back(math_idx.pos);
-            }
-        }...};
+template <typename MainModelType>
+static std::vector<MathModelParamIncrement>
+get_math_param_increment(typename MainModelType::MainModelState state, Idx n_math_solvers_,
+                         typename MainModelType::SequenceIdx const& parameter_changed_components_) {
 
     std::vector<MathModelParamIncrement> math_param_increment(n_math_solvers_);
 
-    for (size_t i = 0; i < main_core::utils::n_types<ComponentType...>; ++i) {
-        auto const& changed_type_components = parameter_changed_components_[i];
-        auto const& add_type_to_increment = add_to_increments[i];
-        for (auto const& changed_component : changed_type_components) {
-            add_type_to_increment(math_param_increment, received_state, changed_component);
-        }
-    }
+    MainModelType::run_functor_with_all_component_types_return_void(
+        [&math_param_increment, &state, &parameter_changed_components_]<typename CompType>() {
+            static constexpr auto comp_index = MainModelType::template index_of_component<CompType>;
+            for (auto const& changed_component : std::get<comp_index>(parameter_changed_components_)) {
+                detail::add_to_increment<CompType, typename MainModelType::ComponentContainer>(
+                    math_param_increment, state, changed_component);
+            }
+        });
 
     return math_param_increment;
 }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
@@ -78,7 +78,7 @@ class MainModel {
     */
     BatchParameter calculate(Options const& options, MutableDataset const& result_data,
                              ConstDataset const& update_data) {
-        JobAdapter<Impl, AllComponents> adapter{std::ref(impl()), std::ref(options)};
+        JobAdapter<Impl> adapter{std::ref(impl()), std::ref(options)};
         return JobDispatch::batch_calculation(adapter, result_data, update_data, options.threading);
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -649,7 +649,7 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         if (!is_topology_up_to_date_) {
             rebuild_topology();
         }
-        main_core::prepare_y_bus<sym, ComponentContainer, ComponentType...>(state_, n_math_solvers_, math_state_);
+        main_core::prepare_y_bus<sym, MainModelType>(state_, n_math_solvers_, math_state_);
 
         if (n_math_solvers_ != static_cast<Idx>(solvers.size())) {
             assert(solvers.empty());
@@ -671,8 +671,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
             std::vector<MathModelParam<sym>> const math_params =
                 main_core::get_math_param<sym>(state_, n_math_solvers_);
             std::vector<MathModelParamIncrement> const math_param_increments =
-                main_core::get_math_param_increment<sym, ComponentContainer, ComponentType...>(
-                    state_, n_math_solvers_, parameter_changed_components_);
+                main_core::get_math_param_increment<MainModelType>(state_, n_math_solvers_,
+                                                                   parameter_changed_components_);
             if (last_updated_calculation_symmetry_mode_ == is_symmetric_v<sym>) {
                 main_core::update_y_bus(math_state_, math_params, math_param_increments);
             } else {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -128,6 +128,9 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
     using ComponentContainer = Container<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentType...>;
     using MainModelState = main_core::MainModelState<ComponentContainer>;
 
+    using MainModelType = main_core::utils::MainModelType<ExtraRetrievableTypes<ExtraRetrievableType...>,
+                                                          ComponentList<ComponentType...>>;
+
     using SequenceIdxView = std::array<std::span<Idx2D const>, main_core::utils::n_types<ComponentType...>>;
     using OwnedUpdateDataset = std::tuple<std::vector<typename ComponentType::UpdateType>...>;
 
@@ -315,7 +318,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         construction_complete_ = true;
 #endif // !NDEBUG
         state_.components.set_construction_complete();
-        state_.comp_topo = std::make_shared<ComponentTopology const>(main_core::construct_topology(state_.components));
+        state_.comp_topo =
+            std::make_shared<ComponentTopology const>(main_core::construct_topology<MainModelType>(state_.components));
     }
 
     void reset_solvers() {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -627,7 +627,8 @@ class MainModelImpl<ExtraRetrievableTypes<ExtraRetrievableType...>, ComponentLis
         assert(construction_complete_);
         // clear old solvers
         reset_solvers();
-        ComponentConnections const comp_conn = main_core::construct_components_connections(state_.components);
+        ComponentConnections const comp_conn =
+            main_core::construct_components_connections<MainModelType>(state_.components);
         // re build
         Topology topology{*state_.comp_topo, comp_conn};
         std::tie(state_.math_topology, state_.topo_comp_coup) = topology.build_topology();

--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -72,6 +72,7 @@ doctest_discover_tests(power_grid_model_unit_tests_component)
 add_executable(power_grid_model_unit_tests_main_core
     "test_entry_point.cpp"
     "test_main_core_output.cpp"
+    "test_core_utils.cpp"
 )
 
 target_link_libraries(power_grid_model_unit_tests_main_core

--- a/tests/cpp_unit_tests/test_core_utils.cpp
+++ b/tests/cpp_unit_tests/test_core_utils.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+#include <power_grid_model/container.hpp>
+#include <power_grid_model/main_core/core_utils.hpp>
+
+#include <doctest/doctest.h>
+
+namespace power_grid_model::main_core::utils {
+
+namespace {
+// TODO test with a non used type
+struct AComponent {};
+} // namespace
+
+TEST_CASE("MainModelType") {
+
+    SUBCASE("Node Source") {
+        using ModelType = MainModelType<ExtraRetrievableTypes<Base, Node, Appliance>, ComponentList<Node, Source>>;
+        CHECK(true);
+        static_assert(std::is_same_v<typename ModelType::ComponentContainer,
+                                     Container<ExtraRetrievableTypes<Base, Node, Appliance>, Node, Source>>);
+        static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Node, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Source>>);
+        static_assert(ModelType::n_component_types == 2);
+    }
+    SUBCASE("Node Line Source") {
+        using ModelType =
+            MainModelType<ExtraRetrievableTypes<Base, Node, Branch, Appliance>, ComponentList<Node, Line, Source>>;
+
+        static_assert(
+            std::is_same_v<typename ModelType::ComponentContainer,
+                           Container<ExtraRetrievableTypes<Base, Node, Branch, Appliance>, Node, Line, Source>>);
+        static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Node, Line, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Branch, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
+        static_assert(ModelType::n_component_types == 3);
+    }
+    SUBCASE("Different component order: Line Source Node") {
+        using ModelType =
+            MainModelType<ExtraRetrievableTypes<Base, Node, Branch, Appliance>, ComponentList<Line, Source, Node>>;
+
+        static_assert(
+            std::is_same_v<typename ModelType::ComponentContainer,
+                           Container<ExtraRetrievableTypes<Base, Node, Branch, Appliance>, Line, Source, Node>>);
+        static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Line, Source, Node>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Branch, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
+        static_assert(ModelType::n_component_types == 3);
+    }
+    SUBCASE("Bad case: Line Source") {
+        // TODO rewrite for checking fail instead of pass
+        using ModelType = MainModelType<ExtraRetrievableTypes<Base, Branch, Appliance>, ComponentList<Line, Source>>;
+
+        static_assert(std::is_same_v<typename ModelType::ComponentContainer,
+                                     Container<ExtraRetrievableTypes<Base, Branch, Appliance>, Line, Source>>);
+        static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Line, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Branch, Source>>);
+        static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
+        static_assert(ModelType::n_component_types == 2);
+    }
+
+    // TODO add static_assert(std::constructible_from<ModelType, double, meta_data::MetaData const&,
+    // MathSolverDispatcher const&>);
+}
+
+} // namespace power_grid_model::main_core::utils

--- a/tests/cpp_unit_tests/test_core_utils.cpp
+++ b/tests/cpp_unit_tests/test_core_utils.cpp
@@ -24,7 +24,7 @@ TEST_CASE("MainModelType") {
         static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Node, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Source>>);
-        static_assert(ModelType::n_component_types == 2);
+        static_assert(ModelType::n_types == 2);
     }
     SUBCASE("Node Line Source") {
         using ModelType =
@@ -36,7 +36,7 @@ TEST_CASE("MainModelType") {
         static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Node, Line, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Branch, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
-        static_assert(ModelType::n_component_types == 3);
+        static_assert(ModelType::n_types == 3);
     }
     SUBCASE("Different component order: Line Source Node") {
         using ModelType =
@@ -48,7 +48,7 @@ TEST_CASE("MainModelType") {
         static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Line, Source, Node>>);
         static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Node, Branch, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
-        static_assert(ModelType::n_component_types == 3);
+        static_assert(ModelType::n_types == 3);
     }
     SUBCASE("Bad case: Line Source") {
         // TODO rewrite for checking fail instead of pass
@@ -59,7 +59,7 @@ TEST_CASE("MainModelType") {
         static_assert(std::is_same_v<typename ModelType::ComponentTypesTuple, std::tuple<Line, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyTypesTuple, std::tuple<Branch, Source>>);
         static_assert(std::is_same_v<typename ModelType::TopologyConnectionTypesTuple, std::tuple<Branch, Source>>);
-        static_assert(ModelType::n_component_types == 2);
+        static_assert(ModelType::n_types == 2);
     }
 
     // TODO add static_assert(std::constructible_from<ModelType, double, meta_data::MetaData const&,


### PR DESCRIPTION
**Fixes issue**: Continuation of https://github.com/PowerGridModel/power-grid-model/pull/1109

### Changes proposed in this PR include:

Change templates to use MainModelType. Moved to a new PR as this includes logic change too.
Splitting the function does not seem less performant but increases readability.