### PR TITLE
Fix nightly: RUF043

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ select = [
 ]
 
 ignore = [
-    "UP038", # deprecated, https://docs.astral.sh/ruff/rules/non-pep604-isinstance/#deprecation
     "PT019" # flags false positives
 ]
 

--- a/tests/unit/test_buffer_handling.py
+++ b/tests/unit/test_buffer_handling.py
@@ -111,7 +111,7 @@ def test__get_buffer_properties__batch_requested_for_single_data(component_type,
     schema = power_grid_meta_data[DatasetType.update][component_type]
 
     with pytest.raises(
-        ValueError, match="Incorrect/inconsistent data provided: single data provided but batch data expected."
+        ValueError, match=r"Incorrect\/inconsistent data provided: single data provided but batch data expected"
     ):
         get_buffer_properties(data, schema=schema, is_batch=True, batch_size=BATCH_DATASET_NDIM)
 
@@ -138,7 +138,7 @@ def test__get_buffer_properties__single_requested_for_batch(component_type, is_s
             get_buffer_properties(data, schema=schema, is_batch=False, batch_size=None)
     else:
         with pytest.raises(
-            ValueError, match="Incorrect/inconsistent data provided: batch data provided but single data expected."
+            ValueError, match=r"Incorrect\/inconsistent data provided: batch data provided but single data expected"
         ):
             get_buffer_properties(data, schema=schema, is_batch=False, batch_size=None)
 
@@ -233,7 +233,7 @@ def test__get_raw_attribute_data_view_fail(component, attribute):
     assert old_shape[-1] == asym_dense_batch_last_dim
     assert updated_shape[-1] == unsupported_asym_dense_batch_last_dim
 
-    with pytest.raises(ValueError, match="Given data has a different schema than supported."):
+    with pytest.raises(ValueError, match="Given data has a different schema than supported"):
         get_buffer_view(data, schema=schema, is_batch=True)
 
 
@@ -322,5 +322,5 @@ def test__get_raw_attribute_data_view_directly_fail(component, attr_data_shape, 
     arr = np.zeros(attr_data_shape)
     schema = power_grid_meta_data[DatasetType.update][component]
 
-    with pytest.raises(ValueError, match="Given data has a different schema than supported."):
+    with pytest.raises(ValueError, match="Given data has a different schema than supported"):
         _get_raw_attribute_data_view(arr, schema, attribute)

--- a/tests/unit/test_data_handling.py
+++ b/tests/unit/test_data_handling.py
@@ -168,5 +168,5 @@ def test_dtype_compatibility_check_compatible():
 def test_dtype_compatibility_check__error():
     nodes = initialize_array(DT.sym_output, CT.node, (1, 2))
     data = {CT.node: nodes.astype(nodes.dtype.newbyteorder("S"))}
-    with pytest.raises(ValueError, match="Data type does not match schema."):
+    with pytest.raises(ValueError, match="Data type does not match schema"):
         CMutableDataset(data, DT.sym_output)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -48,7 +48,7 @@ def test_const_dataset__empty_dataset(dataset_type):
     assert info.elements_per_scenario() == {}
     assert info.total_elements() == {}
 
-    with pytest.raises(ValueError, match="The dataset type could not be deduced."):
+    with pytest.raises(ValueError, match="The dataset type could not be deduced"):
         CConstDataset(data={})
 
 
@@ -173,7 +173,7 @@ def test_const_dataset__mixed_batch_size(dataset_type):
         ComponentType.node: np.zeros(shape=(2, 3), dtype=power_grid_meta_data[dataset_type][ComponentType.node]),
         ComponentType.line: np.zeros(shape=(3, 3), dtype=power_grid_meta_data[dataset_type][ComponentType.line]),
     }
-    with pytest.raises(ValueError, match="Dataset must have a consistent batch size across all components."):
+    with pytest.raises(ValueError, match="Dataset must have a consistent batch size across all components"):
         CConstDataset(data, dataset_type)
 
 
@@ -209,5 +209,5 @@ def test_const_dataset__different_dtype(dataset_type, dtype, supported):
         result = CConstDataset(data, dataset_type)
         assert result.get_info().total_elements() == {ComponentType.node: 3}
     else:
-        with pytest.raises(ValueError, match="Data type does not match schema."):
+        with pytest.raises(ValueError, match="Data type does not match schema"):
             CConstDataset(data, dataset_type)

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -575,8 +575,8 @@ def test_get_and_verify_batch_sizes_inconsistent_batch_sizes_two_components():
     update_data: BatchDataset = {"foo": np.empty(shape=(3, 3)), "bar": np.empty(shape=(2, 3))}
     with pytest.raises(
         ValueError,
-        match="Inconsistent number of batches in batch data. "
-        "Component 'bar' contains 2 batches, while 'foo' contained 3 batches.",
+        match=r"Inconsistent number of batches in batch data\. "
+        r"Component \'bar\' contains 2 batches, while \'foo\' contained 3 batches\.",
     ):
         get_and_verify_batch_sizes(update_data)
 
@@ -589,8 +589,8 @@ def test_convert_get_and_verify_batch_sizes_inconsistent_batch_sizes_more_than_t
     }
     with pytest.raises(
         ValueError,
-        match="Inconsistent number of batches in batch data. "
-        "Component 'baz' contains 2 batches, while bar/foo contained 3 batches.",
+        match=r"Inconsistent number of batches in batch data\. "
+        r"Component \'baz\' contains 2 batches, while bar\/foo contained 3 batches\.",
     ):
         get_and_verify_batch_sizes(update_data)
 
@@ -598,7 +598,7 @@ def test_convert_get_and_verify_batch_sizes_inconsistent_batch_sizes_more_than_t
 @patch("power_grid_model._core.utils.get_and_verify_batch_sizes")
 def test_convert_batch_dataset_to_batch_list_missing_key_sparse(_mock: MagicMock):
     update_data: BatchDataset = {"foo": {"a": np.empty(3), "data": np.empty(3)}}  # type: ignore
-    with pytest.raises(KeyError, match="Invalid data for 'foo' component. Missing 'indptr' in sparse batch data. "):
+    with pytest.raises(KeyError, match=r"Invalid data for \'foo\' component\. Missing \'indptr\' in sparse batch data"):
         convert_batch_dataset_to_batch_list(update_data)
 
 
@@ -607,7 +607,7 @@ def test_convert_batch_dataset_to_batch_list_invalid_type_sparse(_mock: MagicMoc
     update_data: BatchDataset = {"foo": "wrong type"}  # type: ignore
     with pytest.raises(
         TypeError,
-        match="Invalid data for 'foo' component. Expecting a 1D/2D Numpy structured array or a dictionary of such.",
+        match=r"Invalid data for \'foo\' component\. Expecting a 1D\/2D Numpy structured array or a dictionary of such",
     ):
         convert_batch_dataset_to_batch_list(update_data)
 
@@ -789,7 +789,7 @@ def test_get_dataset_type(dataset_type):
 
 
 def test_get_dataset_type__empty_data():
-    with pytest.raises(ValueError, match="At least one component should have row based data."):
+    with pytest.raises(ValueError, match="At least one component should have row based data"):
         get_dataset_type(data={})
 
 

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -691,7 +691,7 @@ def test_json_serialize_empty_dataset(dataset_type, use_compact_list: bool):
         assert isinstance(result, str)
         assert result == reference
 
-        with pytest.raises(ValueError, match="At least one component should have row based data."):
+        with pytest.raises(ValueError, match="At least one component should have row based data"):
             json_serialize({}, use_compact_list=use_compact_list, indent=indent)
 
 
@@ -713,7 +713,7 @@ def test_msgpack_serialize_empty_dataset(dataset_type, use_compact_list):
     reference = empty_dataset(dataset_type)
     assert from_msgpack(msgpack_serialize({}, dataset_type, use_compact_list=use_compact_list)) == reference
 
-    with pytest.raises(ValueError, match="At least one component should have row based data."):
+    with pytest.raises(ValueError, match="At least one component should have row based data"):
         json_serialize({}, use_compact_list=use_compact_list)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -108,9 +108,9 @@ def test_get_dataset_batch_size_mixed():
             "indptr": np.array([0, 2, 3]),
         },
     }
-    with pytest.raises(ValueError, match="Inconsistent number of batches in batch data."):
+    with pytest.raises(ValueError, match="Inconsistent number of batches in batch data"):
         get_dataset_batch_size(data_dense)
-    with pytest.raises(ValueError, match="Inconsistent number of batches in batch data."):
+    with pytest.raises(ValueError, match="Inconsistent number of batches in batch data"):
         get_dataset_batch_size(data_sparse)
 
 

--- a/tests/unit/validation/test_rules.py
+++ b/tests/unit/validation/test_rules.py
@@ -673,7 +673,7 @@ def test_not_all_missing():
         assert len(errors) == 1
         assert errors == [MultiFieldValidationError("foo_test", ["foo", "bar", "baz"], [1])]
 
-        with pytest.raises(ValueError, match="The fields parameter must contain at least 2 fields.") as excinfo:
+        with pytest.raises(ValueError, match="The fields parameter must contain at least 2 fields") as excinfo:
             not_all_missing(invalid, ["bar"], "foo_test")
 
         assert excinfo.type is ValueError

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -88,11 +88,13 @@ def test_assert_valid_data_structure():
 
     # Invalid component type
     input_with_wrong_component = {ComponentType.node: node_input, "some_random_component": line_input}
-    with pytest.raises(KeyError, match="Unknown component 'some_random_component' in DatasetType.input data."):
+    with pytest.raises(KeyError, match=r"Unknown component \'some_random_component\' in DatasetType\.input data"):
         assert_valid_data_structure(input_with_wrong_component, DatasetType.input)
 
     input_with_wrong_data_type = {ComponentType.node: node_input, ComponentType.line: [1, 2, 3]}
-    with pytest.raises(TypeError, match="Unexpected data type list for 'ComponentType.line' DatasetType.input data "):
+    with pytest.raises(
+        TypeError, match=r"Unexpected data type list for \'ComponentType\.line\' DatasetType\.input data"
+    ):
         assert_valid_data_structure(input_with_wrong_data_type, DatasetType.input)
 
 


### PR DESCRIPTION
Nightly is failing due to `ruff`s rule RUF043 introduced in its last release. See https://github.com/PowerGridModel/power-grid-model/pull/1115#issuecomment-3284977965 for more details.