### PR TITLE
Trigger pivot perturbation based on each possibly ill-conditioned one

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/iterative_linear_se_solver.hpp
@@ -100,12 +100,14 @@ template <symmetry_tag sym_type> class IterativeLinearSESolver {
         MeasuredValues<sym> const measured_values{y_bus.shared_topology(), input};
         auto const observability_result =
             observability_check(measured_values, y_bus.math_topology(), y_bus.y_bus_structure());
+        std::pair<bool, std::vector<int8_t>> const possibly_ill_conditioned_pivots{
+            observability_result.use_perturbation(), observability_result.row_is_possibly_ill_conditioned};
 
         // prepare matrix
         sub_timer = Timer{log, LogEvent::prepare_matrix_including_prefactorization};
         prepare_matrix(y_bus, measured_values);
         // prefactorize
-        sparse_solver_.prefactorize(data_gain_, perm_, observability_result.use_perturbation());
+        sparse_solver_.prefactorize(data_gain_, perm_, possibly_ill_conditioned_pivots);
 
         // initialize voltage with initial angle
         sub_timer = Timer{log, LogEvent::initialize_voltages}; // TODO(mgovers): make scoped subtimers

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/newton_raphson_se_solver.hpp
@@ -166,8 +166,11 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
         // preprocess measured value
         sub_timer = Timer{log, LogEvent::preprocess_measured_value};
         MeasuredValues<sym> const measured_values{y_bus.shared_topology(), input};
+
         auto const observability_result =
             observability_check(measured_values, y_bus.math_topology(), y_bus.y_bus_structure());
+        std::pair<bool, std::vector<int8_t>> const possibly_ill_conditioned_pivots{
+            observability_result.use_perturbation(), observability_result.row_is_possibly_ill_conditioned};
 
         // initialize voltage with initial angle
         sub_timer = Timer{log, LogEvent::initialize_voltages};
@@ -184,7 +187,7 @@ template <symmetry_tag sym_type> class NewtonRaphsonSESolver {
             // solve with prefactorization
             sub_timer = Timer{log, LogEvent::solve_sparse_linear_equation};
             sparse_solver_.prefactorize_and_solve(data_gain_, perm_, delta_x_rhs_, delta_x_rhs_,
-                                                  observability_result.use_perturbation());
+                                                  possibly_ill_conditioned_pivots);
             sub_timer = Timer{log, LogEvent::iterate_unknown};
             max_dev = iterate_unknown(output.u, measured_values);
         };


### PR DESCRIPTION
This PR aims to improve the pivot perturbation scheme currently used, based on a finer grained criteria.

Before, we would judge if the whole matrix was ill-conditioned (prior to performing the LU decomposition), whereas with this PR we aim to judge the ill-condition on a per pivot basis. Furthermore, because of this we had to use the off diagonal infinite norm of the matrix to judge the pivot's size in order to avoid introducing fake observability, but now, we would be able to use the full infinite norm without having that issue.

In addition, with this PR we aim to resolve the edge cases reported in #1118 (to be solved only once the full observability check is in place, see https://github.com/PowerGridModel/power-grid-model/issues/1085), as well as make pivot perturbation more robust for radial grids. The scheme used is described in more detail in https://github.com/PowerGridModel/power-grid-model/pull/1118#issuecomment-3290768879.