### PR TITLE
Performance: Using swapping in places explicit copying could been avoided

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
@@ -105,7 +105,7 @@ inline auto build_dense_mapping_comparison_sort(IdxVector const& idx_B_in_A, Idx
     result.reorder.reserve(mapping_to_from.size());
 
     // Use structured bindings to avoid copying from pairs
-    for (auto&& [value, orig_idx] : mapping_to_from) {
+    for (auto [value, orig_idx] : mapping_to_from) {
         result.indvector.push_back(value);
         result.reorder.push_back(orig_idx);
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
@@ -103,11 +103,12 @@ inline auto build_dense_mapping_comparison_sort(IdxVector const& idx_B_in_A, Idx
     DenseIndexMapping result;
     result.indvector.reserve(mapping_to_from.size());
     result.reorder.reserve(mapping_to_from.size());
-    std::ranges::transform(mapping_to_from, std::back_inserter(result.indvector),
-                           [](DenseEntry const& to_from) { return to_from.first; });
 
-    std::ranges::transform(mapping_to_from, std::back_inserter(result.reorder),
-                           [](DenseEntry const& to_from) { return to_from.second; });
+    // Use structured bindings and move to avoid copying
+    for (auto&& [value, orig_idx] : mapping_to_from) {
+        result.indvector.push_back(std::move(value));
+        result.reorder.push_back(std::move(orig_idx));
+    }
 
     return result;
 }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/index_mapping.hpp
@@ -104,10 +104,10 @@ inline auto build_dense_mapping_comparison_sort(IdxVector const& idx_B_in_A, Idx
     result.indvector.reserve(mapping_to_from.size());
     result.reorder.reserve(mapping_to_from.size());
 
-    // Use structured bindings and move to avoid copying
+    // Use structured bindings to avoid copying from pairs
     for (auto&& [value, orig_idx] : mapping_to_from) {
-        result.indvector.push_back(std::move(value));
-        result.reorder.push_back(std::move(orig_idx));
+        result.indvector.push_back(value);
+        result.reorder.push_back(orig_idx);
     }
 
     return result;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -52,7 +52,7 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
         counter[i] += counter[i - 1];
     }
     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
+        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element);
     }
 
     // swap vectors to avoid copying
@@ -67,7 +67,7 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
         counter[i] += counter[i - 1];
     }
     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
+        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element);
     }
 
     // final swap to get result back in vec

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -40,39 +40,67 @@ inline void append_element_vector(std::vector<YBusElementMap>& vec, Idx first_bu
 
 // counting sort element
 inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
-    // temp vec for swapping
-    std::vector<YBusElementMap> temp_vec(vec.size());
+    // count vec
+    std::vector<YBusElementMap> count_vec(vec.size());
     IdxVector counter(n_bus, 0);
-
-    // sort column first
+    // sort column
     for (YBusElementMap const& element : vec) {
         ++counter[element.pos.second];
     }
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
+    for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
+        count_vec[--counter[it_element->pos.second]] = *it_element;
     }
-
-    // swap vectors to avoid copying
-    vec.swap(temp_vec);
-
-    // sort row second
+    // sort row
     std::ranges::fill(counter, 0);
-    for (YBusElementMap const& element : vec) {
+    for (YBusElementMap const& element : count_vec) {
         ++counter[element.pos.first];
     }
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
+    for (auto it_element = count_vec.crbegin(); it_element != count_vec.crend(); ++it_element) {
+        vec[--counter[it_element->pos.first]] = *it_element;
     }
-
-    // final swap to get result back in vec
-    vec.swap(temp_vec);
 }
+
+// // counting sort element
+// inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
+//     // temp vec for swapping
+//     std::vector<YBusElementMap> temp_vec(vec.size());
+//     IdxVector counter(n_bus, 0);
+
+//     // sort column first
+//     for (YBusElementMap const& element : vec) {
+//         ++counter[element.pos.second];
+//     }
+//     for (size_t i = 1, n = counter.size(); i != n; ++i) {
+//         counter[i] += counter[i - 1];
+//     }
+//     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+//         temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
+//     }
+
+//     // swap vectors to avoid copying
+//     vec.swap(temp_vec);
+
+//     // sort row second
+//     std::ranges::fill(counter, 0);
+//     for (YBusElementMap const& element : vec) {
+//         ++counter[element.pos.first];
+//     }
+//     for (size_t i = 1, n = counter.size(); i != n; ++i) {
+//         counter[i] += counter[i - 1];
+//     }
+//     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+//         temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
+//     }
+
+//     // final swap to get result back in vec
+//     vec.swap(temp_vec);
+// }
 
 // y bus structure
 struct YBusStructure {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -40,10 +40,11 @@ inline void append_element_vector(std::vector<YBusElementMap>& vec, Idx first_bu
 
 // counting sort element
 inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
-    // count vec
-    std::vector<YBusElementMap> count_vec(vec.size());
+    // temp vec for swapping
+    std::vector<YBusElementMap> temp_vec(vec.size());
     IdxVector counter(n_bus, 0);
-    // sort column
+
+    // sort column first
     for (YBusElementMap const& element : vec) {
         ++counter[element.pos.second];
     }
@@ -51,19 +52,26 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
         counter[i] += counter[i - 1];
     }
     for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
-        count_vec[--counter[it_element->pos.second]] = *it_element;
+        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element);
     }
-    // sort row
+
+    // swap vectors to avoid copying
+    vec.swap(temp_vec);
+
+    // sort row second
     std::ranges::fill(counter, 0);
-    for (YBusElementMap const& element : count_vec) {
+    for (YBusElementMap const& element : vec) {
         ++counter[element.pos.first];
     }
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = count_vec.crbegin(); it_element != count_vec.crend(); ++it_element) {
-        vec[--counter[it_element->pos.first]] = *it_element;
+    for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
+        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element);
     }
+
+    // final swap to get result back in vec
+    vec.swap(temp_vec);
 }
 
 // y bus structure

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -52,8 +52,7 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
         counter[i] += counter[i - 1];
     }
     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        --counter[it_element->pos.second];
-        temp_vec[counter[it_element->pos.second]] = std::move(*it_element);
+        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
     }
 
     // swap vectors to avoid copying
@@ -68,8 +67,7 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
         counter[i] += counter[i - 1];
     }
     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-        --counter[it_element->pos.first];
-        temp_vec[counter[it_element->pos.first]] = std::move(*it_element);
+        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
     }
 
     // final swap to get result back in vec

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -40,67 +40,39 @@ inline void append_element_vector(std::vector<YBusElementMap>& vec, Idx first_bu
 
 // counting sort element
 inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
-    // count vec
-    std::vector<YBusElementMap> count_vec(vec.size());
+    // temp vec for swapping
+    std::vector<YBusElementMap> temp_vec(vec.size());
     IdxVector counter(n_bus, 0);
-    // sort column
+
+    // sort column first
     for (YBusElementMap const& element : vec) {
         ++counter[element.pos.second];
     }
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
-        count_vec[--counter[it_element->pos.second]] = *it_element;
+    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
     }
-    // sort row
+
+    // swap vectors to avoid copying
+    vec.swap(temp_vec);
+
+    // sort row second
     std::ranges::fill(counter, 0);
-    for (YBusElementMap const& element : count_vec) {
+    for (YBusElementMap const& element : vec) {
         ++counter[element.pos.first];
     }
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = count_vec.crbegin(); it_element != count_vec.crend(); ++it_element) {
-        vec[--counter[it_element->pos.first]] = *it_element;
+    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
     }
+
+    // final swap to get result back in vec
+    vec.swap(temp_vec);
 }
-
-// // counting sort element
-// inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
-//     // temp vec for swapping
-//     std::vector<YBusElementMap> temp_vec(vec.size());
-//     IdxVector counter(n_bus, 0);
-
-//     // sort column first
-//     for (YBusElementMap const& element : vec) {
-//         ++counter[element.pos.second];
-//     }
-//     for (size_t i = 1, n = counter.size(); i != n; ++i) {
-//         counter[i] += counter[i - 1];
-//     }
-//     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-//         temp_vec[--counter[it_element->pos.second]] = std::move(*it_element); // NOSONAR
-//     }
-
-//     // swap vectors to avoid copying
-//     vec.swap(temp_vec);
-
-//     // sort row second
-//     std::ranges::fill(counter, 0);
-//     for (YBusElementMap const& element : vec) {
-//         ++counter[element.pos.first];
-//     }
-//     for (size_t i = 1, n = counter.size(); i != n; ++i) {
-//         counter[i] += counter[i - 1];
-//     }
-//     for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
-//         temp_vec[--counter[it_element->pos.first]] = std::move(*it_element); // NOSONAR
-//     }
-
-//     // final swap to get result back in vec
-//     vec.swap(temp_vec);
-// }
 
 // y bus structure
 struct YBusStructure {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/y_bus.hpp
@@ -51,8 +51,9 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.second]] = std::move(*it_element);
+    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+        --counter[it_element->pos.second];
+        temp_vec[counter[it_element->pos.second]] = std::move(*it_element);
     }
 
     // swap vectors to avoid copying
@@ -66,8 +67,9 @@ inline void counting_sort_element(std::vector<YBusElementMap>& vec, Idx n_bus) {
     for (size_t i = 1, n = counter.size(); i != n; ++i) {
         counter[i] += counter[i - 1];
     }
-    for (auto it_element = vec.crbegin(); it_element != vec.crend(); ++it_element) {
-        temp_vec[--counter[it_element->pos.first]] = std::move(*it_element);
+    for (auto it_element = vec.rbegin(); it_element != vec.rend(); ++it_element) {
+        --counter[it_element->pos.first];
+        temp_vec[counter[it_element->pos.first]] = std::move(*it_element);
     }
 
     // final swap to get result back in vec

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -447,7 +447,7 @@ TEST_CASE("Test counting_sort_element") {
         // (0,0), (0,1), (1,0), (1,2), (2,1), (2,1), (2,2)
         std::vector<std::pair<Idx, Idx>> expected_positions = {{0, 0}, {0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 1}, {2, 2}};
 
-        Idx n_bus = 3;
+        Idx const n_bus = 3;
         counting_sort_element(vec, n_bus);
 
         // Verify sorting
@@ -503,14 +503,14 @@ TEST_CASE("Test counting_sort_element") {
 
     SUBCASE("Test large sparse matrix scenario") {
         std::vector<YBusElementMap> vec;
-        Idx n_bus = 10;
+        Idx const n_bus = 10;
 
         // Add elements in reverse order to test sorting thoroughly
-        for (Idx row : std::ranges::reverse{IdxRange{n_bus}}) {
-            for (Idx col = std::ranges::reverse{IdxRange{n_bus}}) {
-                if ((row + col) % 3 == 0) { // Sparse pattern
-                    vec.push_back({{row, col}, {bff, row * n_bus + col}});
-                }
+        for (Idx i = n_bus * n_bus - 1; i != static_cast<Idx>(-1); --i) {
+            Idx const row = i / n_bus;
+            Idx const col = i % n_bus;
+            if ((row + col) % 3 == 0) { // Sparse pattern
+                vec.push_back({{row, col}, {bff, row * n_bus + col}});
             }
         }
 

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -506,8 +506,8 @@ TEST_CASE("Test counting_sort_element") {
         Idx n_bus = 10;
 
         // Add elements in reverse order to test sorting thoroughly
-        for (Idx row = n_bus - 1; row != static_cast<Idx>(-1); --row) {
-            for (Idx col = n_bus - 1; col != static_cast<Idx>(-1); --col) {
+        for (Idx row : std::ranges::reverse{IdxRange{n_bus}}) {
+            for (Idx col = std::ranges::reverse{IdxRange{n_bus}}) {
                 if ((row + col) % 3 == 0) { // Sparse pattern
                     vec.push_back({{row, col}, {bff, row * n_bus + col}});
                 }

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -429,17 +429,18 @@ TEST_CASE("Incremental update y-bus") {
 TEST_CASE("Test counting_sort_element") {
     using math_solver::counting_sort_element;
     using math_solver::YBusElementMap;
+    using enum power_grid_model::YBusElementType;
 
     SUBCASE("Test basic sorting") {
         // Create test data: elements at various matrix positions
         std::vector<YBusElementMap> vec = {
-            {{2, 1}, {YBusElementType::bft, 5}},   // pos (2,1)
-            {{0, 0}, {YBusElementType::bff, 0}},   // pos (0,0)
-            {{1, 2}, {YBusElementType::btf, 3}},   // pos (1,2)
-            {{0, 1}, {YBusElementType::bft, 1}},   // pos (0,1)
-            {{2, 1}, {YBusElementType::shunt, 6}}, // pos (2,1) - same position as first
-            {{1, 0}, {YBusElementType::btf, 2}},   // pos (1,0)
-            {{2, 2}, {YBusElementType::btt, 7}},   // pos (2,2)
+            {{2, 1}, {bft, 5}},   // pos (2,1)
+            {{0, 0}, {bff, 0}},   // pos (0,0)
+            {{1, 2}, {btf, 3}},   // pos (1,2)
+            {{0, 1}, {bft, 1}},   // pos (0,1)
+            {{2, 1}, {shunt, 6}}, // pos (2,1) - same position as first
+            {{1, 0}, {btf, 2}},   // pos (1,0)
+            {{2, 2}, {btt, 7}},   // pos (2,2)
         };
 
         // Expected sorted order: by row first, then by column
@@ -457,20 +458,20 @@ TEST_CASE("Test counting_sort_element") {
         }
 
         // Verify specific elements are preserved correctly
-        CHECK(vec[0].element.element_type == YBusElementType::bff);
+        CHECK(vec[0].element.element_type == bff);
         CHECK(vec[0].element.idx == 0);
-        CHECK(vec[1].element.element_type == YBusElementType::bft);
+        CHECK(vec[1].element.element_type == bft);
         CHECK(vec[1].element.idx == 1);
     }
 
     SUBCASE("Test with single bus") {
-        std::vector<YBusElementMap> vec = {{{0, 0}, {YBusElementType::shunt, 10}}};
+        std::vector<YBusElementMap> vec = {{{0, 0}, {shunt, 10}}};
 
         counting_sort_element(vec, 1);
 
         CHECK(vec.size() == 1);
         CHECK(vec[0].pos == std::make_pair(0, 0));
-        CHECK(vec[0].element.element_type == YBusElementType::shunt);
+        CHECK(vec[0].element.element_type == shunt);
         CHECK(vec[0].element.idx == 10);
     }
 
@@ -482,9 +483,9 @@ TEST_CASE("Test counting_sort_element") {
 
     SUBCASE("Test stability - elements with same position maintain relative order") {
         std::vector<YBusElementMap> vec = {
-            {{1, 1}, {YBusElementType::bff, 100}},
-            {{1, 1}, {YBusElementType::bft, 200}},
-            {{1, 1}, {YBusElementType::shunt, 300}},
+            {{1, 1}, {bff, 100}},
+            {{1, 1}, {bft, 200}},
+            {{1, 1}, {shunt, 300}},
         };
 
         counting_sort_element(vec, 2);
@@ -508,7 +509,7 @@ TEST_CASE("Test counting_sort_element") {
         for (Idx row = n_bus - 1; row != static_cast<Idx>(-1); --row) {
             for (Idx col = n_bus - 1; col != static_cast<Idx>(-1); --col) {
                 if ((row + col) % 3 == 0) { // Sparse pattern
-                    vec.push_back({{row, col}, {YBusElementType::bff, row * n_bus + col}});
+                    vec.push_back({{row, col}, {bff, row * n_bus + col}});
                 }
             }
         }
@@ -520,24 +521,22 @@ TEST_CASE("Test counting_sort_element") {
 
         // Verify sorted order
         for (size_t i = 1; i < vec.size(); ++i) {
-            auto prev_pos = vec[i - 1].pos;
-            auto curr_pos = vec[i].pos;
+            auto [prev_row, prev_col] = vec[i - 1].pos;
+            auto [curr_row, curr_col] = vec[i].pos;
 
             // Check row-major order
-            if (prev_pos.first == curr_pos.first) {
-                CHECK(prev_pos.second <= curr_pos.second); // Same row, column should be non-decreasing
+            if (prev_row == curr_row) {
+                CHECK(prev_col <= curr_col); // Same row, column should be non-decreasing
             } else {
-                CHECK(prev_pos.first < curr_pos.first); // Different row, previous row should be smaller
+                CHECK(prev_row < curr_row); // Different row, previous row should be smaller
             }
         }
     }
 
     SUBCASE("Test all YBusElementType values") {
         std::vector<YBusElementMap> vec = {
-            {{1, 1}, {YBusElementType::fill_in_tf, 6}}, {{0, 1}, {YBusElementType::bft, 1}},
-            {{1, 0}, {YBusElementType::btf, 2}},        {{0, 0}, {YBusElementType::bff, 0}},
-            {{1, 1}, {YBusElementType::btt, 3}},        {{2, 2}, {YBusElementType::shunt, 4}},
-            {{1, 2}, {YBusElementType::fill_in_ft, 5}},
+            {{1, 1}, {fill_in_tf, 6}}, {{0, 1}, {bft, 1}},   {{1, 0}, {btf, 2}},        {{0, 0}, {bff, 0}},
+            {{1, 1}, {btt, 3}},        {{2, 2}, {shunt, 4}}, {{1, 2}, {fill_in_ft, 5}},
         };
 
         counting_sort_element(vec, 3);

--- a/tests/cpp_unit_tests/test_y_bus.cpp
+++ b/tests/cpp_unit_tests/test_y_bus.cpp
@@ -552,7 +552,4 @@ TEST_CASE("Test counting_sort_element") {
     }
 }
 
-// TODO:
-// - test counting_sort_element() ✓ DONE
-
 } // namespace power_grid_model


### PR DESCRIPTION
In two places in code, the explicit copying could've been avoided by swapping:

- [x] y_bus element counting sort
- [x] index_mappign