### PR TITLE
Dependencies: Drop NumPy 1.x support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 requires-python = ">=3.11"
-dependencies = ["numpy>=1.21.0"]
+dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Rationale of this change

As recommended by the [SPEC (Scientific Python Ecosystem Coordination)](https://scientific-python.org/), and as communicated in [this announcement](https://lists.lfenergy.org/g/powergridmodel/message/34), the Power Grid Model has been [scheduled to drop support for NumPy 1.x on 1-Oct-2025](https://github.com/PowerGridModel/power-grid-model/issues/654) (see also [SPEC 0's drop schedule for 2025-Q3](https://scientific-python.org/specs/spec-0000/#2025---quarter-3)).

## Consequences of this change

Starting with the release associated with this PR, newer releases of [power-grid-model](https://github.com/PowerGridModel/power-grid-model) and dependent libraries ([power-grid-model-io](https://github.com/PowerGridModel/power-grid-model-io) and [power-grid-model-ds](https://github.com/PowerGridModel/power-grid-model-ds)) will no longer have active backwards compatibility for NumPy 1.x. In particular, we may do a change that breaks compatibility with NumPy 1.x at any date after the active support is dropped. Please upgrade to NumPy 2.x as soon as possible to stay up to date with new features, as well as important security updates and bug fixes.

## Closes issues

Closes #654 

## Relates to

* https://github.com/PowerGridModel/power-grid-model-io/pull/335
* https://github.com/PowerGridModel/power-grid-model-ds/pull/93