### PR TITLE
Validation tests: allow different atols per calculation method

### DIFF
--- a/tests/cpp_validation_tests/test_validation.cpp
+++ b/tests/cpp_validation_tests/test_validation.cpp
@@ -512,6 +512,15 @@ std::optional<CaseParam> construct_case(std::filesystem::path const& case_dir, j
         }
     }
 
+    if (calculation_method_params.contains("atol")) {
+        json const& j_extra_atol = calculation_method_params.at("atol");
+        if (j_extra_atol.type() != json::value_t::object) {
+            param.atol = {{"default", j_extra_atol.get<double>()}};
+        } else {
+            j_extra_atol.get_to(param.atol);
+        }
+    }
+
     if (calculation_method_params.contains("raises")) {
         if (json const& raises = calculation_method_params.at("raises"); raises.contains("raises")) {
             param.raises = raises.at("raises").get<std::string>();


### PR DESCRIPTION
This is a quick PR that allows specifying different `atol`s per calculation method on the validation tests via the `extra_params`.

Note: The use case of this is [b55a78c](https://github.com/PowerGridModel/power-grid-model/pull/1137/commits/b55a78c2bb11e8972b97e866a0388a36d939d3aa) on https://github.com/PowerGridModel/power-grid-model/pull/1137.