### PR TITLE
Feature: add community.md to readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,7 +36,7 @@ build:
       # download support and contribution
       - git clone https://github.com/PowerGridModel/.github.git --depth 1 --branch main pgm_org_github
       - mkdir -p docs/release_and_support
-      - mv pgm_org_github/RELEASE.md pgm_org_github/SUPPORT.md pgm_org_github/SECURITY.md pgm_org_github/CITATION.md docs/release_and_support/
+      - mv pgm_org_github/RELEASE.md pgm_org_github/SUPPORT.md pgm_org_github/COMMUNITY.md pgm_org_github/SECURITY.md pgm_org_github/CITATION.md docs/release_and_support/
       - mkdir -p docs/contribution
       - mv pgm_org_github/GOVERNANCE.md pgm_org_github/CONTRIBUTING.md pgm_org_github/CODE_OF_CONDUCT.md docs/contribution/
       # fix links

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,7 @@ contribution/GOVERNANCE.md
 :maxdepth: 2
 release_and_support/RELEASE.md
 release_and_support/SUPPORT.md
+release_and_support/COMMUNITY.md
 release_and_support/SECURITY.md
 release_and_support/CITATION.md
 ```


### PR DESCRIPTION
To add the new community.md file to PGM's readthedocs, after https://github.com/PowerGridModel/.github/pull/67 is merged.

After merging the above mentioned PR GitHub Actions should be re-run