### PR TITLE
Performance: reduce copying during batch error handling

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/job_dispatch.hpp
@@ -184,7 +184,7 @@ class JobDispatch {
     }
 
     static void handle_batch_exceptions(std::vector<std::string> const& exceptions) {
-        std::stringstream combined_error_message;
+        std::ostringstream combined_error_message;
         IdxVector failed_scenarios;
         std::vector<std::string> err_msgs;
         for (Idx batch = 0; batch < static_cast<Idx>(exceptions.size()); ++batch) {


### PR DESCRIPTION
A serious performance regression was introduced in #1018 (Release [`v1.11.33`](https://github.com/PowerGridModel/power-grid-model/releases/tag/v1.11.33)) to batch error handling that caused the combined batch error message to be copied completely for every scenario, resulting in a quadratic blowup in the amount of failing scenarios.

This fixes that.