### PR TITLE
Type hinting: Fix + add overloads in multiple often-used functions

### DIFF
--- a/src/power_grid_model/_core/data_types.py
+++ b/src/power_grid_model/_core/data_types.py
@@ -13,7 +13,7 @@ from typing import TypeAlias, TypedDict, TypeVar
 
 import numpy as np
 
-from power_grid_model._core.dataset_definitions import ComponentTypeVar
+from power_grid_model._core.dataset_definitions import ComponentType, ComponentTypeVar
 
 SingleArray: TypeAlias = np.ndarray
 
@@ -28,7 +28,8 @@ SingleColumnarData = dict[AttributeType, SingleColumn]
 _SingleComponentData = TypeVar("_SingleComponentData", SingleArray, SingleColumnarData)  # deduction helper
 SingleComponentData = SingleArray | SingleColumnarData
 
-
+SingleRowBasedDataset = dict[ComponentTypeVar, SingleArray]
+SingleColumnarDataset = dict[ComponentTypeVar, SingleColumnarData]
 SingleDataset = dict[ComponentTypeVar, _SingleComponentData]
 
 BatchList = list[SingleDataset]
@@ -112,6 +113,16 @@ Dataset = dict[ComponentTypeVar, _ComponentData]
 
 
 DenseBatchData = DenseBatchArray | DenseBatchColumnarData
+
+# overloads that only match on latest PGM type
+SingleRowBasedOutputDataset = dict[ComponentType, SingleArray]
+SingleColumnarOutputDataset = dict[ComponentType, SingleColumnarData]
+SingleOutputDataset = dict[ComponentType, SingleComponentData]
+DenseBatchRowBasedOutputDataset = dict[ComponentType, DenseBatchArray]
+DenseBatchColumnarOutputDataset = dict[ComponentType, DenseBatchColumnarData]
+DenseBatchOutputDataset = dict[ComponentType, DenseBatchData]
+OutputDataset = dict[ComponentType, ComponentData]
+
 
 NominalValue = int
 

--- a/src/power_grid_model/_core/power_grid_dataset.py
+++ b/src/power_grid_model/_core/power_grid_dataset.py
@@ -37,7 +37,7 @@ from power_grid_model._core.power_grid_core import (
     power_grid_core as pgc,
 )
 from power_grid_model._core.power_grid_meta import ComponentMetaData, DatasetMetaData, power_grid_meta_data
-from power_grid_model._core.typing import ComponentAttributeMapping, _ComponentAttributeMappingDict
+from power_grid_model._core.typing import ComponentAttributeMapping, ComponentAttributeMappingDict
 from power_grid_model._core.utils import (
     get_dataset_type,
     is_columnar,
@@ -426,11 +426,11 @@ class CWritableDataset:
         """
         return self._data[component]
 
-    def get_data_filter(self) -> _ComponentAttributeMappingDict:
+    def get_data_filter(self) -> ComponentAttributeMappingDict:
         """Gets the data filter requested
 
         Returns:
-            _ComponentAttributeMappingDict: data filter
+            ComponentAttributeMappingDict: data filter
         """
         return self._data_filter
 

--- a/src/power_grid_model/_core/power_grid_meta.py
+++ b/src/power_grid_model/_core/power_grid_meta.py
@@ -176,20 +176,20 @@ The data types for all dataset types and components used by the Power Grid Model
 def initialize_array(
     data_type: DatasetTypeLike,
     component_type: ComponentTypeLike,
-    shape: int,
+    shape: int | tuple[int],
     empty: bool = False,
 ) -> SingleArray: ...
 @overload
 def initialize_array(
     data_type: DatasetTypeLike,
     component_type: ComponentTypeLike,
-    shape: tuple,
+    shape: tuple[int, int],
     empty: bool = False,
 ) -> DenseBatchArray: ...
 def initialize_array(
     data_type: DatasetTypeLike,
     component_type: ComponentTypeLike,
-    shape: tuple | int,
+    shape: int | tuple[int] | tuple[int, int],
     empty: bool = False,
 ) -> SingleArray | DenseBatchArray:
     """

--- a/src/power_grid_model/_core/power_grid_meta.py
+++ b/src/power_grid_model/_core/power_grid_meta.py
@@ -8,7 +8,7 @@ Load meta data from C core and define numpy structured array
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 
@@ -172,6 +172,20 @@ The data types for all dataset types and components used by the Power Grid Model
 """
 
 
+@overload
+def initialize_array(
+    data_type: DatasetTypeLike,
+    component_type: ComponentTypeLike,
+    shape: int,
+    empty: bool = False,
+) -> SingleArray: ...
+@overload
+def initialize_array(
+    data_type: DatasetTypeLike,
+    component_type: ComponentTypeLike,
+    shape: tuple,
+    empty: bool = False,
+) -> DenseBatchArray: ...
 def initialize_array(
     data_type: DatasetTypeLike,
     component_type: ComponentTypeLike,

--- a/src/power_grid_model/_core/power_grid_model.py
+++ b/src/power_grid_model/_core/power_grid_model.py
@@ -21,12 +21,14 @@ from power_grid_model._core.data_handling import (
 from power_grid_model._core.data_types import (
     BatchDataset,
     Dataset,
-    DenseBatchArray,
-    DenseBatchColumnarData,
-    SingleArray,
-    SingleColumnarData,
-    SingleComponentData,
+    DenseBatchColumnarOutputDataset,
+    DenseBatchOutputDataset,
+    DenseBatchRowBasedOutputDataset,
+    SingleColumnarOutputDataset,
     SingleDataset,
+    SingleOutputDataset,
+    SingleRowBasedDataset,
+    SingleRowBasedOutputDataset,
 )
 from power_grid_model._core.dataset_definitions import (
     ComponentType,
@@ -325,7 +327,7 @@ class PowerGridModel:
         decode_error: bool = True,
         tap_changing_strategy: TapChangingStrategy | str = TapChangingStrategy.disabled,
         experimental_features: _ExperimentalFeatures | str = _ExperimentalFeatures.disabled,
-    ):
+    ) -> Dataset:
         calculation_type = CalculationType.power_flow
         options = self._options(
             calculation_type=calculation_type,
@@ -361,7 +363,7 @@ class PowerGridModel:
         continue_on_batch_error: bool = False,
         decode_error: bool = True,
         experimental_features: _ExperimentalFeatures | str = _ExperimentalFeatures.disabled,
-    ) -> dict[ComponentType, np.ndarray]:
+    ) -> Dataset:
         calculation_type = CalculationType.state_estimation
         options = self._options(
             calculation_type=calculation_type,
@@ -394,7 +396,7 @@ class PowerGridModel:
         decode_error: bool = True,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str = ShortCircuitVoltageScaling.maximum,
         experimental_features: _ExperimentalFeatures | str = _ExperimentalFeatures.disabled,
-    ) -> dict[ComponentType, np.ndarray]:
+    ) -> Dataset:
         calculation_type = CalculationType.short_circuit
         symmetric = False
 
@@ -421,92 +423,110 @@ class PowerGridModel:
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> dict[ComponentType, SingleArray]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> SingleRowBasedDataset: ...
     @overload
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> dict[ComponentType, SingleColumnarData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> SingleRowBasedDataset: ...
     @overload
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> dict[ComponentType, SingleComponentData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> SingleColumnarOutputDataset: ...
     @overload
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> dict[ComponentType, DenseBatchArray]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> SingleOutputDataset: ...
     @overload
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> dict[ComponentType, DenseBatchColumnarData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> DenseBatchRowBasedOutputDataset: ...
     @overload
     def calculate_power_flow(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-        tap_changing_strategy: TapChangingStrategy | str,
-    ) -> BatchDataset: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> DenseBatchColumnarOutputDataset: ...
+    @overload
+    def calculate_power_flow(
+        self,
+        *,
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+        tap_changing_strategy: TapChangingStrategy | str = ...,
+    ) -> DenseBatchOutputDataset: ...
     def calculate_power_flow(  # noqa: PLR0913
         self,
         *,
@@ -610,86 +630,90 @@ class PowerGridModel:
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> dict[ComponentType, SingleArray]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> SingleRowBasedOutputDataset: ...
     @overload
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> dict[ComponentType, SingleColumnarData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> SingleColumnarOutputDataset: ...
     @overload
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> dict[ComponentType, SingleComponentData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> SingleOutputDataset: ...
     @overload
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> dict[ComponentType, DenseBatchArray]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> DenseBatchRowBasedOutputDataset: ...
     @overload
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> dict[ComponentType, DenseBatchColumnarData]: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> DenseBatchColumnarOutputDataset: ...
     @overload
     def calculate_state_estimation(
         self,
         *,
-        symmetric: bool,
-        error_tolerance: float,
-        max_iterations: int,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
-    ) -> BatchDataset: ...
+        symmetric: bool = ...,
+        error_tolerance: float = ...,
+        max_iterations: int = ...,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
+    ) -> DenseBatchOutputDataset: ...
     def calculate_state_estimation(  # noqa: PLR0913
         self,
         *,
@@ -788,74 +812,78 @@ class PowerGridModel:
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> dict[ComponentType, SingleArray]: ...
+    ) -> SingleRowBasedDataset: ...
     @overload
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> dict[ComponentType, SingleColumnarData]: ...
+    ) -> SingleColumnarOutputDataset: ...
     @overload
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: None,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: None = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> dict[ComponentType, SingleComponentData]: ...
+    ) -> SingleOutputDataset: ...
     @overload
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar],
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> dict[ComponentType, DenseBatchArray]: ...
+    ) -> DenseBatchRowBasedOutputDataset: ...
     @overload
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: ComponentAttributeFilterOptions,
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: ComponentAttributeFilterOptions = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> dict[ComponentType, DenseBatchColumnarData]: ...
+    ) -> DenseBatchColumnarOutputDataset: ...
     @overload
     def calculate_short_circuit(
         self,
         *,
-        calculation_method: CalculationMethod | str,
-        update_data: BatchDataset,
-        threading: int,
-        output_component_types: dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions],
-        continue_on_batch_error: bool,
-        decode_error: bool,
+        calculation_method: CalculationMethod | str = ...,
+        update_data: BatchDataset = ...,
+        threading: int = ...,
+        output_component_types: dict[
+            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
+        ] = ...,
+        continue_on_batch_error: bool = ...,
+        decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
-    ) -> BatchDataset: ...
+    ) -> DenseBatchOutputDataset: ...
     def calculate_short_circuit(  # noqa: PLR0913
         self,
         *,

--- a/src/power_grid_model/_core/power_grid_model.py
+++ b/src/power_grid_model/_core/power_grid_model.py
@@ -49,7 +49,7 @@ from power_grid_model._core.error_handling import PowerGridBatchError, assert_no
 from power_grid_model._core.index_integer import IdNp, IdxNp
 from power_grid_model._core.options import Options
 from power_grid_model._core.power_grid_core import ConstDatasetPtr, IDPtr, IdxPtr, ModelPtr, power_grid_core as pgc
-from power_grid_model._core.typing import ComponentAttributeMapping
+from power_grid_model._core.typing import ComponentAttributeMapping, ComponentAttributeMappingDict
 
 
 class PowerGridModel:
@@ -473,9 +473,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: None = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
         tap_changing_strategy: TapChangingStrategy | str = ...,
@@ -520,9 +518,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: BatchDataset = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
         tap_changing_strategy: TapChangingStrategy | str = ...,
@@ -586,7 +582,7 @@ class PowerGridModel:
                 - None: Row based data for all component types.
                 - set[ComponentTypeVar] or list[ComponentTypeVar]: Row based data for the specified component types.
                 - ComponentAttributeFilterOptions: Columnar data for all component types.
-                - dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]:
+                - ComponentAttributeMappingDict:
                     key: ComponentType
                     value:
                         - None: Row based data for the specified component types.
@@ -664,9 +660,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: None = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
     ) -> SingleOutputDataset: ...
@@ -708,9 +702,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: BatchDataset = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
     ) -> DenseBatchOutputDataset: ...
@@ -769,7 +761,7 @@ class PowerGridModel:
                 - None: Row based data for all component types.
                 - set[ComponentTypeVar] or list[ComponentTypeVar]: Row based data for the specified component types.
                 - ComponentAttributeFilterOptions: Columnar data for all component types.
-                - dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]:
+                - ComponentAttributeMappingDict:
                     key: ComponentType
                     value:
                         - None: Row based data for the specified component types.
@@ -839,9 +831,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: None = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
@@ -877,9 +867,7 @@ class PowerGridModel:
         calculation_method: CalculationMethod | str = ...,
         update_data: BatchDataset = ...,
         threading: int = ...,
-        output_component_types: dict[
-            ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions
-        ] = ...,
+        output_component_types: ComponentAttributeMappingDict = ...,
         continue_on_batch_error: bool = ...,
         decode_error: bool = ...,
         short_circuit_voltage_scaling: ShortCircuitVoltageScaling | str,
@@ -929,7 +917,7 @@ class PowerGridModel:
                 - None: Row based data for all component types.
                 - set[ComponentTypeVar] or list[ComponentTypeVar]: Row based data for the specified component types.
                 - ComponentAttributeFilterOptions: Columnar data for all component types.
-                - dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]:
+                - ComponentAttributeMappingDict:
                     key: ComponentType
                     value:
                         - None: Row based data for the specified component types.

--- a/src/power_grid_model/_core/typing.py
+++ b/src/power_grid_model/_core/typing.py
@@ -9,12 +9,12 @@ Type hints for for library-internal use.
 from power_grid_model._core.dataset_definitions import ComponentType, ComponentTypeVar
 from power_grid_model._core.enum import ComponentAttributeFilterOptions
 
-_ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]
+ComponentAttributeMappingDict = dict[ComponentType, set[str] | list[str] | None | ComponentAttributeFilterOptions]
 
 ComponentAttributeMapping = (
     set[ComponentTypeVar]
     | list[ComponentTypeVar]
     | ComponentAttributeFilterOptions
     | None
-    | _ComponentAttributeMappingDict
+    | ComponentAttributeMappingDict
 )

--- a/src/power_grid_model/_core/utils.py
+++ b/src/power_grid_model/_core/utils.py
@@ -41,7 +41,7 @@ from power_grid_model._core.enum import ComponentAttributeFilterOptions
 from power_grid_model._core.error_handling import VALIDATOR_MSG
 from power_grid_model._core.errors import PowerGridError
 from power_grid_model._core.power_grid_meta import initialize_array, power_grid_meta_data
-from power_grid_model._core.typing import ComponentAttributeMapping, _ComponentAttributeMappingDict
+from power_grid_model._core.typing import ComponentAttributeMapping, ComponentAttributeMappingDict
 
 SINGLE_DATASET_NDIM = 1
 BATCH_DATASET_NDIM = 2
@@ -455,7 +455,7 @@ def process_data_filter(
     dataset_type: DatasetType,
     data_filter: ComponentAttributeMapping,
     available_components: list[ComponentType],
-) -> _ComponentAttributeMappingDict:
+) -> ComponentAttributeMappingDict:
     """Checks valid type for data_filter. Also checks for any invalid component names and attribute names.
 
     Args:
@@ -464,10 +464,10 @@ def process_data_filter(
         available_components (list[ComponentType]):  all components available in model instance or data
 
     Returns:
-        _ComponentAttributeMappingDict: processed data_filter in a dictionary
+        ComponentAttributeMappingDict: processed data_filter in a dictionary
     """
     if data_filter is None:
-        processed_data_filter: _ComponentAttributeMappingDict = {ComponentType[k]: None for k in available_components}
+        processed_data_filter: ComponentAttributeMappingDict = {ComponentType[k]: None for k in available_components}
     elif isinstance(data_filter, ComponentAttributeFilterOptions):
         processed_data_filter = {ComponentType[k]: data_filter for k in available_components}
     elif isinstance(data_filter, (list, set)):
@@ -485,14 +485,14 @@ def process_data_filter(
 
 
 def validate_data_filter(
-    data_filter: _ComponentAttributeMappingDict,
+    data_filter: ComponentAttributeMappingDict,
     dataset_type: DatasetType,
     available_components: list[ComponentType],
 ) -> None:
     """Raise error if some specified components or attributes are unknown.
 
     Args:
-        data_filter (_ComponentAttributeMappingDict): Processed component to attribtue dictionary
+        data_filter (ComponentAttributeMappingDict): Processed component to attribtue dictionary
         dataset_type (DatasetType):  Type of dataset
         available_components (list[ComponentType]):  all components available in model instance or data
 

--- a/tests/unit/test_power_grid_model.py
+++ b/tests/unit/test_power_grid_model.py
@@ -15,6 +15,7 @@ from power_grid_model import (
     initialize_array,
 )
 from power_grid_model._core.utils import compatibility_convert_row_columnar_dataset
+from power_grid_model.data_types import BatchDataset
 from power_grid_model.errors import InvalidCalculationMethod, IterationDiverge, PowerGridBatchError, PowerGridError
 from power_grid_model.utils import get_dataset_scenario
 from power_grid_model.validation import assert_valid_input_data
@@ -182,7 +183,7 @@ def test_get_indexer(model: PowerGridModel):
     np.testing.assert_allclose(expected_indexer, indexer)
 
 
-def test_batch_power_flow(model: PowerGridModel, update_batch, sym_output_batch):
+def test_batch_power_flow(model: PowerGridModel, update_batch: BatchDataset, sym_output_batch):
     result = model.calculate_power_flow(update_data=update_batch)
     compare_result(result, sym_output_batch, rtol=0.0, atol=1e-8)
 


### PR DESCRIPTION
* [x] Fix: `PowerGridModel.calculate*` functions had the output type still specified to row-based data sets. It did not provide the correct output type hint for columnar or mixed output data
* [x] Quality of life improvements:
  * [x] `initialize_array` now provides type type hinting specific to whether single or batch data was requested. This is the biggest quality of life improvement
  * [x] `PowerGridModel.calculate*` functions are now type-hint whether they return a single output dataset or a batch output dataset
  * [x] `create_output_data` now provides specific output 

## Example

### `initialize_array`

#### Before
```py
node_input: ComponentData = initialize_array(DatasetType.input, ComponentType.node, 1)
line_update: ComponentData = initialize_array(DatasetType.input, ComponentType.line, (3, 4))

# nodes: SingleArray = node_input      # mypy error
nodes = cast(SingleArray, node_input)  # ugly
lines = cast(SingleArray, line_update) # oops, but allowed
```

#### After
```py
node_input: SingleArray = initialize_array(DatasetType.input, ComponentType.node, 1)
line_update: BatchArray = initialize_array(DatasetType.input, ComponentType.line, (3, 4))

# no need for casting here
# less error-prone
```

### `PowerGridModel.calculate*`

#### Before
```py
model = PowerGridModel(...)
result = model.calculate_power_flow()  # type hints SingleRowBasedDataset

update_batch: BatchDataset
result = model.calculate_power_flow(update_data=update_batch)  # type hints DenseBatchRowBasedOutputDataset
```