### PR TITLE
Improvement: avoid string lookup when getting scenario from batch dataset

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/dataset.hpp
@@ -485,8 +485,6 @@ template <dataset_type_tag dataset_type_> class Dataset {
     Dataset get_individual_scenario(Idx scenario) const
         requires(!is_indptr_mutable_v<dataset_type>)
     {
-        using AdvanceablePtr = std::conditional_t<is_data_mutable_v<dataset_type>, char*, char const*>;
-
         assert(0 <= scenario && scenario < batch_size());
 
         Dataset result{*this};
@@ -503,8 +501,7 @@ template <dataset_type_tag dataset_type_> class Dataset {
             if (is_columnar(buffer)) {
                 buffer.data = nullptr;
                 for (auto& attribute_buffer : buffer.attributes) {
-                    attribute_buffer.data = static_cast<Data*>(static_cast<AdvanceablePtr>(attribute_buffer.data) +
-                                                               attribute_buffer.meta_attribute->size * offset);
+                    attribute_buffer.data = attribute_buffer.meta_attribute->advance_ptr(attribute_buffer.data, offset);
                 }
             } else {
                 buffer.data = component_info.component->advance_ptr(buffer.data, offset);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/meta_data.hpp
@@ -108,6 +108,13 @@ struct MetaAttribute {
         using CharType = std::conditional_t<std::is_const_v<T>, char const*, char*>;
         return *reinterpret_cast<T*>(reinterpret_cast<CharType>(ptr) + offset);
     }
+
+    RawDataPtr advance_ptr(RawDataPtr ptr, Idx difference) const {
+        return reinterpret_cast<char*>(ptr) + difference * size;
+    }
+    RawDataConstPtr advance_ptr(RawDataConstPtr ptr, Idx difference) const {
+        return reinterpret_cast<char const*>(ptr) + difference * size;
+    }
 };
 
 // meta component


### PR DESCRIPTION
The current implementation of getting scenario from a batch dataset involves string lookups. This is not needed and also executed in tight loops.

The PR directly manipulates the internal data to avoid string lookup.