### PR TITLE
fix 2 blocker-level sonar cloud issues

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
@@ -45,6 +45,13 @@ using nlohmann::json;
 struct JsonMapArrayData {
     size_t size{};
     msgpack::sbuffer buffer;
+
+    JsonMapArrayData() = default;
+    JsonMapArrayData(JsonMapArrayData const&) = delete;
+    JsonMapArrayData& operator=(JsonMapArrayData const&) = delete;
+    JsonMapArrayData(JsonMapArrayData&&) noexcept = default;
+    JsonMapArrayData& operator=(JsonMapArrayData&&) noexcept = default;
+    ~JsonMapArrayData() = default;
 };
 
 struct JsonSAXVisitor {
@@ -420,7 +427,7 @@ class Deserializer {
     Deserializer(Deserializer const&) = delete;
     Deserializer& operator=(Deserializer const&) = delete;
     // movable
-    Deserializer(Deserializer&&) = default;
+    Deserializer(Deserializer&&) noexcept = default;
     Deserializer& operator=(Deserializer&&) noexcept = default;
 
     // destructor


### PR DESCRIPTION
During reviewing of #1207, I found out that there were some previously accepted Sonar Cloud issues that were marked severity level `Blocker` that were very easy to fix (missing `noexcept` for `move` operations), so I went ahead and did just that.