### PR TITLE
Documentation: explicitly describe sym vs asym calculations

### DIFF
--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -240,7 +240,7 @@ The option affects which attributes are required and how results are exposed.
 ```{note}
 For short-circuit calculations, a three-phase `fault_type` is calculated with a symmetric calculation, while any other
 `fault_type` (e.g. single- or two-phase faults) automatically triggers the asymmetric calculation.
-Outputs for short circuit calculations are always giving asymmetric output, independent of the fault type present.
+Outputs for short circuit calculations always give asymmetric output, independent of the fault type present.
 ```
 
 ### Power flow algorithms


### PR DESCRIPTION
After fixing https://github.com/PowerGridModel/power-grid-model/pull/1189 and https://github.com/PowerGridModel/power-grid-model/pull/1197 we concluded there is not enough documentation regarding symmetric and asymmetric calculations.

This PR will fix that
