### PR TITLE
CI: remove pre-commit before run pull request

### DIFF
--- a/.github/workflows/refresh-lock-and-linter-dependencies.yml
+++ b/.github/workflows/refresh-lock-and-linter-dependencies.yml
@@ -85,6 +85,7 @@ jobs:
           source .venv/bin/activate
           pre-commit install
           pre-commit install-hooks
+          pre-commit uninstall
 
       - name: create pull request
         if: ${{ inputs.create-pr || github.event_name == 'schedule' }}


### PR DESCRIPTION
The refresh workflow has a problem. When PR is automatically created, pre-commit kicks in which might give error and block the PR from created. So pre-commit is now removed before PR is created.