### PR TITLE
[BUG] add cassert in common include

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/common/common.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <complex>
 #include <concepts>


### PR DESCRIPTION
The header include order of the core has a problem with `cassert`. When building benchmark target in release in macOS, it fails to load `assert` macro.

Now the inclusion is added in the common.