### PR TITLE
Sonar issues: fix reliability issues

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/topology.hpp
@@ -344,48 +344,6 @@ class Topology {
         return fill_in;
     }
 
-    // TODO(mgovers): remove this before merge!!!!!
-    void reproduce_issue() {
-        std::vector<int> v1{1, 2, 3, 4, 5};
-        std::vector<int> v2{6, 7, 8, 9, 10};
-        std::string dummy;
-
-        // Versions with modifying: should raise sonar cloud warnings
-        for (auto const& t : std::views::zip(v1, v2)) {
-            get<0>(t) = get<1>(t);              // Compiles
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-        for (auto&& t : std::views::zip(v1, v2)) {
-            get<0>(t) = get<1>(t);              // Compiles
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-        for (auto const& [t1, t2] : std::views::zip(v1, v2)) {
-            t1 = t2;                     // Compiles
-            dummy += std::to_string(t1); // Compiles and warns
-        }
-        for (auto&& [t1, t2] : std::views::zip(v1, v2)) {
-            t1 = t2;                     // Compiles
-            dummy += std::to_string(t1); // Compiles and warns
-        }
-        // Versions with modifying that do not compile
-        for (auto const& t : std::views::zip(v1, v2) | std::views::as_const) {
-            // get<0>(t) = get<1>(t); // Does not compile
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-        for (auto&& t : std::views::zip(v1, v2) | std::views::as_const) {
-            // get<0>(t) = get<1>(t); // Does not compile
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-        for (auto const& t : std::views::zip(std::as_const(v1), std::as_const(v2))) {
-            // get<0>(t) = get<1>(t); // Does not compile
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-        for (auto&& t : std::views::zip(std::as_const(v1), std::as_const(v2))) {
-            // get<0>(t) = get<1>(t); // Does not compile
-            dummy += std::to_string(get<0>(t)); // Compiles and warns
-        }
-    }
-
     void couple_branch() {
         auto const get_group_pos_if = []([[maybe_unused]] Idx math_group, IntS status, Idx2D const& math_idx) {
             if (status == 0) {


### PR DESCRIPTION
* [x] reproduce reliability issues ([9012de5](https://github.com/PowerGridModel/power-grid-model/pull/1257/commits/9012de5c3293af09dad9bb61d1b97f2e8925e3c9))
* [x] fix them

The reliability issue is the following (https://sonarcloud.io/project/issues?impactSoftwareQualities=RELIABILITY&issueStatuses=OPEN%2CCONFIRMED&id=PowerGridModel_power-grid-model&open=AZr-F7--gi65kzaSIM-Y&tab=code)

> Pipe the range initialization into "std::views::as_const" to prevent modifications of the range underlying data (a "const &" for variable is not enough).
>

> std::views::as_const provides a constant view over a range. Using it removes the possibility of inadvertently modifying the underlying data of a range. This function is especially useful because in C++ const only applies to the top-level element, it is not deep-const.
> 
> One common misunderstanding of how const works is when iterating on ranges whose element type is a pair/tuple of references. Even if the iteration variable is const-qualified, it is possible to modify the range’s underlying data through this variable:
> 
> ```cpp
> void example() {
>   std::vector<int> v1 = createVector1();
>   std::vector<int> v2 = createVector2();
> 
>   for (auto const&t : std::views::zip(v1, v2)) {
>     get<0>(t) = get<1>(t); // Modifies data in v1
>   }
> ```
> 
> In this example, zip returns a view of std::tuple<int&, int&>, and even if p is const-qualified, it is still possible to change the underlying data via p, because the references inside the tuple never become const.
> 
> On the other hand, if the example is rewritten this way:
> 
> ```cpp
> void example() {
>   std::vector<int> v1 = createVector1();
>   std::vector<int> v2 = createVector2();
> 
>   for (auto const &t : std::views::zip(v1, v2) | std::views::as_const) {
>     get<0>(t) = get<1>(t); // Does not compile
>   }
> ```
> 
> The view is now over elements of type std::tuple<int const&, int const&> and can no longer be used to modify the data in v1 or v2.
> 
> This rule raises an issue when iterating with a range-based for loop over a range whose elements are tuples or pairs containing non-constant references, and the iteration variable is a reference to a constant.
> 
> This situation can easily happen when using std::views::zip, std::views::enumerate, std::flat_map…​

However, not all our compilers support `std::views::as_const` yet, so I will try to resolve it using `std::as_const` instead (see if that solves the issue)
```cpp
void example() {
  std::vector<int> v1 = createVector1();
  std::vector<int> v2 = createVector2();

  for (auto const &t : std::views::zip(std::as_const(v1), std::as_const(v2))) {
    get<0>(t) = get<1>(t); // Does not compile
  }
```