### PR TITLE
PV node: only support voltage regulators for NRPF

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -455,6 +455,12 @@ class MainModelImpl {
                 is_three_phase ? CalculationSymmetry::symmetric : CalculationSymmetry::asymmetric;
         }
 
+        if (options.calculation_type == CalculationType::power_flow &&
+            options.calculation_method != CalculationMethod::newton_raphson &&
+            state_.components.template size<VoltageRegulator>() > 0) {
+            throw InvalidCalculationMethod{};
+        }
+
         calculation_type_symmetry_func_selector(
             options.calculation_type, options.calculation_symmetry,
             []<calculation_type_tag calculation_type, symmetry_tag sym>(

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/input.json
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/input.json
@@ -1,0 +1,60 @@
+{
+    "version": "1.0",
+    "type": "input",
+    "is_batch": false,
+    "attributes": {},
+    "data": {
+        "node": [
+            {
+                "id": 1,
+                "u_rated": 220e3
+            },
+            {
+                "id": 2,
+                "u_rated": 220e3
+            }
+        ],
+        "line": [
+            {
+                "id": 3,
+                "from_node": 1,
+                "to_node": 2,
+                "from_status": 1,
+                "to_status": 1,
+                "r1": 0.1,
+                "x1": 0.6,
+                "c1": 0.0,
+                "tan1": 0.0
+            }
+        ],
+        "sym_gen": [
+            {
+                "id": 4,
+                "node": 2,
+                "status": 1,
+                "type": 0,
+                "p_specified": 10e6,
+                "q_specified": 0e6
+            }
+        ],
+        "voltage_regulator": [
+            {
+                "id": 5,
+                "regulated_object": 4,
+                "status": 1,
+                "u_ref": 1.05
+            }
+        ],
+        "source": [
+            {
+                "id": 6,
+                "node": 1,
+                "status": 1,
+                "u_ref": 1.05,
+                "sk": 1e40,
+                "rx_ratio": 0.1,
+                "z01_ratio": 1.0
+            }
+        ]
+    }
+}

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/input.json.license
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/input.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/params.json
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/params.json
@@ -1,0 +1,9 @@
+{
+  "calculation_method": ["linear", "iterative_linear", "iterative_current", "linear_current"],
+  "rtol": 1e-5,
+  "atol": 1e-5,
+  "xfail": {
+    "raises": "InvalidCalculationMethod",
+    "reason": "The calculation method is invalid for this calculation!"
+  }
+}

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/params.json.license
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/params.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/sym_output.json
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/sym_output.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0",
+  "type": "sym_output",
+  "is_batch": false,
+  "attributes": {},
+  "data": {
+    "node": [
+      {
+        "id": 1
+      },
+      {
+        "id": 2
+      }
+    ],
+    "line": [
+      {
+        "id": 3
+      }
+    ],
+    "sym_gen": [
+      {
+        "id": 4
+      }
+    ],
+    "voltage_regulator": [
+      {
+        "id": 5
+      }
+    ],
+    "source": [
+      {
+        "id": 6
+      }
+    ]
+  }
+}

--- a/tests/data/power_flow/pv-node/pv-node-calc-methods/sym_output.json.license
+++ b/tests/data/power_flow/pv-node/pv-node-calc-methods/sym_output.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
**Follow‑up PR for issue:** #185 and PR #1220
Throw an exception when voltage regulators are present and the calculation method is not NR.
