### PR TITLE
Docs: remove deprecated eqnarray

### DIFF
--- a/docs/algorithms/pf-algorithms.md
+++ b/docs/algorithms/pf-algorithms.md
@@ -22,7 +22,7 @@ Where $I_N$ is the $N$ vector of source currents injected into each bus and $U_N
 The complex power delivered to bus $k$ is:
 
 $$
-S_{k} =  P_k + jQ_k & = U_{k} I_{k}^{*}
+S_{k} = P_k + jQ_k = U_{k} I_{k}^{*}
 $$
 
 Power flow equations are based on solving the nodal equations above to obtain the voltage magnitude and voltage angle at

--- a/docs/algorithms/pf-algorithms.md
+++ b/docs/algorithms/pf-algorithms.md
@@ -15,18 +15,14 @@ For a summary and guidance on choosing the right algorithm, see
 The nodal equations of a power system network can be written as:
 
 $$
-    \begin{eqnarray}
-        I_N    & = Y_{bus}U_N
-    \end{eqnarray}
+I_N = Y_{bus}U_N
 $$
 
 Where $I_N$ is the $N$ vector of source currents injected into each bus and $U_N$ is the $N$ vector of bus voltages.
 The complex power delivered to bus $k$ is:
 
 $$
-    \begin{eqnarray}
-        S_{k}    & =  P_k + jQ_k & = U_{k} I_{k}^{*}
-    \end{eqnarray}
+S_{k} =  P_k + jQ_k & = U_{k} I_{k}^{*}
 $$
 
 Power flow equations are based on solving the nodal equations above to obtain the voltage magnitude and voltage angle at
@@ -47,9 +43,7 @@ This is the traditional method for power flow calculations.
 This method uses a Taylor series, ignoring the higher order terms, to solve the nonlinear set of equations iteratively:
 
 $$
-    \begin{eqnarray}
-        f(x)    & =  y
-    \end{eqnarray}
+f(x) =  y
 $$
 
 Where:
@@ -101,19 +95,17 @@ As can be seen in the equations above $\delta_1$ and $V_1$ are omitted, because 
 In each iteration $i$ the following equation is solved:
 
 $$
-    \begin{eqnarray}
-        J(i) \Delta x(i)    & =  \Delta y(i)
-    \end{eqnarray}
+J(i) \Delta x(i) =  \Delta y(i)
 $$
 
 Where
 
 $$
-    \begin{eqnarray}
-        \Delta x(i)    & =  x(i+1) - x(i)
-        \quad\text{and}\quad
-        \Delta y(i)    & =  y - f(x(i))
-    \end{eqnarray}
+\begin{aligned}
+    \Delta x(i)    & =  x(i+1) - x(i)
+    \quad\text{and}\quad
+    \Delta y(i)    & =  y - f(x(i))
+\end{aligned}
 $$
 
 $J$ is the [Jacobian](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant), a matrix with all partial

--- a/docs/algorithms/sc-algorithms.md
+++ b/docs/algorithms/sc-algorithms.md
@@ -15,7 +15,7 @@ In the short circuit calculation, the following equations are solved with border
 constraints.
 
 $$
-I_N & = Y_{bus}U_N
+I_N = Y_{bus}U_N
 $$
 
 This gives the initial symmetrical short circuit current ($I_k^{\prime\prime}$) for a fault.

--- a/docs/algorithms/sc-algorithms.md
+++ b/docs/algorithms/sc-algorithms.md
@@ -14,7 +14,9 @@ For a summary and guidance, see [Calculations](../user_manual/calculations.md#sh
 In the short circuit calculation, the following equations are solved with border conditions of faults added as
 constraints.
 
-$$ \begin{eqnarray} I_N & = Y_{bus}U_N \end{eqnarray} $$
+$$
+I_N & = Y_{bus}U_N
+$$
 
 This gives the initial symmetrical short circuit current ($I_k^{\prime\prime}$) for a fault.
 This quantity is then used to derive almost all further calculations of short circuit studies applications.

--- a/docs/algorithms/se-algorithms.md
+++ b/docs/algorithms/se-algorithms.md
@@ -32,9 +32,7 @@ The goal of WLS state estimation is to evaluate the state variable with the high
 measurement input, by solving:
 
 $$
-  \begin{eqnarray}
-    \min r(\underline{U}) = \dfrac{1}{2} (f(\underline{U}) - \underline{z})^H W (f(\underline{U}) - \underline{z})
-  \end{eqnarray}
+\min r(\underline{U}) = \dfrac{1}{2} (f(\underline{U}) - \underline{z})^H W (f(\underline{U}) - \underline{z})
 $$
 
 Where:
@@ -82,9 +80,7 @@ For example, there can be multiple voltage sensors on the same bus.
 The measurement data can be merged into one virtual measurement using a Kalman filter:
 
 $$
-    \begin{eqnarray}
-            z = \dfrac{\sum_{k=1}^{N_{sensor}} z_k \sigma_k^{-2}}{\sum_{k=1}^{N_{sensor}} \sigma_k^{-2}}
-    \end{eqnarray}
+z = \dfrac{\sum_{k=1}^{N_{sensor}} z_k \sigma_k^{-2}}{\sum_{k=1}^{N_{sensor}} \sigma_k^{-2}}
 $$
 
 Where $z_k$ and $\sigma_k$ are the measured value and standard deviation of individual measurements.
@@ -92,13 +88,13 @@ Where $z_k$ and $\sigma_k$ are the measured value and standard deviation of indi
 Multiple appliance measurements (power measurements) on one bus are aggregated as the total injection at the bus:
 
 $$
-    \begin{eqnarray}
-            \underline{S} = \sum_{k=1}^{N_{appliance}} \underline{S}_k
-            \quad\text{and}\quad
-            \sigma_P^2 = \sum_{k=1}^{N_{appliance}} \sigma_{P,k}^2
-            \quad\text{and}\quad
-            \sigma_Q^2 = \sum_{k=1}^{N_{appliance}} \sigma_{Q,k}^2
-    \end{eqnarray}
+\begin{aligned}
+    \underline{S} = \sum_{k=1}^{N_{appliance}} \underline{S}_k
+    \quad\text{and}\quad
+    \sigma_P^2 = \sum_{k=1}^{N_{appliance}} \sigma_{P,k}^2
+    \quad\text{and}\quad
+    \sigma_Q^2 = \sum_{k=1}^{N_{appliance}} \sigma_{Q,k}^2
+\end{aligned}
 $$
 
 Where $S_k$ and $\sigma_{P,k}$ and $\sigma_{Q,k}$ are the measured value and the standard deviation of the individual
@@ -150,26 +146,14 @@ The following illustrates how this works for `sym_current_sensor`s in symmetric 
 See also [the full mathematical workout](https://github.com/PowerGridModel/power-grid-model/issues/547).
 
 $$
-   \begin{eqnarray}
-        & \mathrm{Re}\left\{I\right\} = I \cos\theta
-   \end{eqnarray}
-$$
-$$
-   \begin{eqnarray}
-        & \mathrm{Im}\left\{I\right\} = I \sin\theta
-   \end{eqnarray}
-$$
-$$
-   \begin{eqnarray}
-        & \text{Var}\left(\mathrm{Re}\left\{I\right\}\right) =
-            \sigma_i^2 \cos^2\theta + I^2 \sigma_{\theta}^2\sin^2\theta
-   \end{eqnarray}
-$$
-$$
-   \begin{eqnarray}
-        & \text{Var}\left(\mathrm{Im}\left\{I\right\}\right) =
-            \sigma_i^2 \sin^2\theta + I^2 \sigma_{\theta}^2\cos^2\theta
-   \end{eqnarray}
+\begin{aligned}
+    & \mathrm{Re}\left\{I\right\} = I \cos\theta \\
+    & \mathrm{Im}\left\{I\right\} = I \sin\theta \\
+    & \text{Var}\left(\mathrm{Re}\left\{I\right\}\right) =
+        \sigma_i^2 \cos^2\theta + I^2 \sigma_{\theta}^2\sin^2\theta \\
+    & \text{Var}\left(\mathrm{Im}\left\{I\right\}\right) =
+        \sigma_i^2 \sin^2\theta + I^2 \sigma_{\theta}^2\cos^2\theta
+\end{aligned}
 $$
 
 ## Iterative linear state estimation
@@ -188,9 +172,7 @@ Therefore, traditional measurements are linearized prior to running the algorith
   $\theta_i$ is the intrinsic transformer phase shift:
 
 $$
-    \begin{eqnarray}
-            \underline{U}_i = U_i \cdot e^{j \theta_i}
-    \end{eqnarray}
+\underline{U}_i = U_i \cdot e^{j \theta_i}
 $$
 
 - Branch current with global angle: The global angle current measurement captures the phase offset relative to the same
@@ -201,9 +183,7 @@ $$
   angle).
 
 $$
-    \begin{eqnarray}
-            \underline{I} = I_i \cdot e^{j \theta_i}
-    \end{eqnarray}
+\underline{I} = I_i \cdot e^{j \theta_i}
 $$
 
 - Branch current with local angle: Sometimes, (accurate) voltage measurements are not available for a branch, which
@@ -217,10 +197,8 @@ $$
   Given the measured (linearized) voltage phasor, the current phasor is calculated as follows:
 
 $$
-    \begin{equation}
-        \underline{I} = \underline{I}_{\text{local}}^{*} \frac{\underline{U}}{|\underline{U}|}
-        = \underline{I}_{\text{local}}^{*} \cdot e^{j \theta}
-    \end{equation}
+\underline{I} = \underline{I}_{\text{local}}^{*} \frac{\underline{U}}{|\underline{U}|}
+    = \underline{I}_{\text{local}}^{*} \cdot e^{j \theta}
 $$
 
 where $\underline{U}$ is either measured voltage magnitude at the bus or assumed unity magnitude, with the intrinsic
@@ -232,9 +210,7 @@ $\theta$ is the phase angle of the voltage.
   Given the measured (linearized) voltage phasor, the current phasor is calculated as follows:
 
 $$
-    \begin{eqnarray}
-            \underline{I} = (\underline{S}/\underline{U})^*
-    \end{eqnarray}
+\underline{I} = (\underline{S}/\underline{U})^*
 $$
 
 - Bus power injection: Similar as above, to translate the power flow to a complex current phasor, if the bus voltage is
@@ -242,9 +218,7 @@ $$
   The current phasor is calculated as follows:
 
 $$
-    \begin{eqnarray}
-            \underline{I} = (\underline{S}/\underline{U})^*
-    \end{eqnarray}
+\underline{I} = (\underline{S}/\underline{U})^*
 $$
 
 The aggregated apparent power flow is considered as a single measurement, with variance

--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -197,7 +197,7 @@ Output:
 Power flowing through a branch is calculated by voltage and current for any type of calculations in the following way:
 
 $$
-\underline{S_{branch-side}} = \sqrt{3} \cdot \underline{U_{LL-side-node}} \cdot \underline{I_{branch-side}}
+\underline{S_{branch-side}} = \sqrt{3} \cdot \underline{U_{LL-side-node}} \cdot \underline{I_{branch-side}}^*
 $$
 
 These quantities are in complex form.

--- a/docs/user_manual/calculations.md
+++ b/docs/user_manual/calculations.md
@@ -85,17 +85,13 @@ Due to the relative nature of `u_angle` (relevant only in systems with at least 
 conditions should be met:
 
 $$
-    \begin{eqnarray}
-        n_{measurements}    & >= & n_{unknowns}
-    \end{eqnarray}
+n_{measurements} >= n_{unknowns}
 $$
 
 Where
 
 $$
-    \begin{eqnarray}
-        n_{unknowns}    & = & 2 & \cdot & n_{nodes} - 1
-    \end{eqnarray}
+n_{unknowns} = 2 \cdot n_{nodes} - 1
 $$
 
 The number of measurements can be found by taking the sum of the following:
@@ -201,9 +197,7 @@ Output:
 Power flowing through a branch is calculated by voltage and current for any type of calculations in the following way:
 
 $$
-    \begin{eqnarray}
-        \underline{S_{branch-side}} = \sqrt{3} \cdot \underline{U_{LL-side-node}} \cdot \underline{I_{branch-side}}
-    \end{eqnarray}
+\underline{S_{branch-side}} = \sqrt{3} \cdot \underline{U_{LL-side-node}} \cdot \underline{I_{branch-side}}
 $$
 
 These quantities are in complex form.

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -151,8 +151,8 @@ scenarios within a batch are not three-phase faults (i.e. `fault_type` is not `F
 
 $$
 \begin{aligned}
-   & Z_{\text{series}} = r + \mathrm{j}x \\
-   & Y_{\text{shunt}} = 2 \pi fc (\tan \delta +\mathrm{j})
+   Z_{\text{series}} &= r + \mathrm{j}x \\
+   Y_{\text{shunt}} &= 2 \pi fc (\tan \delta +\mathrm{j})
 \end{aligned}
 $$
 
@@ -172,9 +172,7 @@ There is no additional attribute for `link`.
 `link` is modeled by a constant admittance $Y_{\text{series}}$, where
 
 $$
-   \begin{eqnarray}
-      Y_{\text{series}} = (1 + \mathrm{j}) \cdot 10^6 \,\mathrm{p.u.}
-    \end{eqnarray}
+Y_{\text{series}} = (1 + \mathrm{j}) \cdot 10^6 \,\mathrm{p.u.}
 $$
 
 ### Transformer
@@ -238,18 +236,18 @@ for detailed explanation.
 
 $$
 \begin{aligned}
-   & |Z_{\text{series}}| = u_k p.u. \\
-   & \mathrm{Re}(Z_{\text{series}}) = \frac{p_k}{s_n} p.u. \\
-   & \mathrm{Im}(Z_{\text{series}}) = \sqrt{|Z_{\text{series}}|^2-\mathrm{Re}(Z_{\text{series}})^2} \\
+    |Z_{\text{series}}| &= u_k p.u. \\
+    \mathrm{Re}(Z_{\text{series}}) &= \frac{p_k}{s_n} p.u. \\
+    \mathrm{Im}(Z_{\text{series}}) &= \sqrt{|Z_{\text{series}}|^2-\mathrm{Re}(Z_{\text{series}})^2} \\
 \end{aligned}
 $$
 and $Y_{\text{shunt}}$ can be computed as
 
 $$
 \begin{aligned}
-   & |Y_{\text{shunt}}| = i_0 p.u. \\
-   & \mathrm{Re}(Y_{\text{shunt}}) = \frac{p_0}{s_n} p.u. \\
-   & \mathrm{Im}(Y_{\text{shunt}}) = -\sqrt{|Y_{\text{shunt}}|^2-\mathrm{Re}(Y_{\text{shunt}})^2} \\
+    |Y_{\text{shunt}}| &= i_0 p.u. \\
+    \mathrm{Re}(Y_{\text{shunt}}) &= \frac{p_0}{s_n} p.u. \\
+    \mathrm{Im}(Y_{\text{shunt}}) &= -\sqrt{|Y_{\text{shunt}}|^2-\mathrm{Re}(Y_{\text{shunt}})^2} \\
 \end{aligned}
 $$
 
@@ -307,9 +305,9 @@ Asymmetric calculation is not supported for `generic_branch`.
 
 $$
 \begin{aligned}
-   & Y_{\text{series}} = \frac{1}{r + \mathrm{j}x} \\
-   & Y_{\text{shunt}} =  g + \mathrm{j}b \\
-   & N = k \cdot e^{\mathrm{j} \theta}
+    Y_{\text{series}} &= \frac{1}{r + \mathrm{j}x} \\
+    Y_{\text{shunt}} &=  g + \mathrm{j}b \\
+    N &= k \cdot e^{\mathrm{j} \theta}
 \end{aligned}
 $$
 
@@ -629,9 +627,9 @@ Its value can be computed using following equations:
 
 $$
 \begin{aligned}
-      & z_{\text{source}} = \frac{1}{s_k} p.u. \\
-      & x_1 = \frac{z_{\text{source}}}{\sqrt{1+ \left(\frac{r}{x}\right)^2}} p.u. \\
-      & r_1 = x_1 \cdot \left(\frac{r}{x}\right) p.u.
+    z_{\text{source}} &= \frac{1}{s_k} p.u. \\
+    x_1 &= \frac{z_{\text{source}}}{\sqrt{1+ \left(\frac{r}{x}\right)^2}} p.u. \\
+    r_1 &= x_1 \cdot \left(\frac{r}{x}\right) p.u.
 \end{aligned}
 $$
 
@@ -641,9 +639,9 @@ where $\frac{r}{x}$ indicates `rx_ratio` as input.
 
 $$
 \begin{aligned}
-      & z_{\text{source,0}} = z_{\text{source}} \cdot \frac{z_0}{z_1} \\
-      & x_0 = \frac{z_{\text{source,0}}}{\sqrt{1 + \left(\frac{r}{x}\right)^2}} \\
-      & r_0 = x_0 \cdot \left(\frac{r}{x}\right)
+    z_{\text{source,0}} &= z_{\text{source}} \cdot \frac{z_0}{z_1} \\
+    x_0 &= \frac{z_{\text{source,0}}}{\sqrt{1 + \left(\frac{r}{x}\right)^2}} \\
+    r_0 &= x_0 \cdot \left(\frac{r}{x}\right)
 \end{aligned}
 $$
 
@@ -688,25 +686,19 @@ The injection of each ZIP model type can be computed as follows:
 * for a constant impedance (Z) load/generator,
 
 $$
-   \begin{eqnarray}
-        S = S_{\text{specified}} \cdot \bar{u}^2
-   \end{eqnarray}
+S = S_{\text{specified}} \cdot \bar{u}^2
 $$
 
 * for a constant current (I) load/generator,
 
 $$
-   \begin{eqnarray}
-        S = S_{\text{specified}} \cdot \bar{u}
-   \end{eqnarray}
+S = S_{\text{specified}} \cdot \bar{u}
 $$
 
 * for a constant power (P) load/generator:,
 
 $$
-   \begin{eqnarray}
-        S = S_{\text{specified}}
-   \end{eqnarray}
+S = S_{\text{specified}}
 $$
 
 where $\bar{u}$ is the calculated node voltage.
@@ -814,8 +806,8 @@ For other calculation types, sensor output is undefined.
 
 $$
 \begin{aligned}
-      & u_{\text{residual}} = u_{\text{measured}} - u_{\text{state}} \\
-      & \theta_{\text{residual}} = \theta_{\text{measured}} - \theta_{\text{state}} \pmod{2 \pi}
+    u_{\text{residual}} &= u_{\text{measured}} - u_{\text{state}} \\
+    \theta_{\text{residual}} &= \theta_{\text{measured}} - \theta_{\text{state}} \pmod{2 \pi}
 \end{aligned}
 $$
 
@@ -929,8 +921,8 @@ For other calculation types, sensor output is undefined.
 
 $$
 \begin{aligned}
-      & p_{\text{residual}} = p_{\text{measured}} - p_{\text{state}} \\
-         & q_{\text{residual}} = q_{\text{measured}} - q_{\text{state}}
+    p_{\text{residual}} &= p_{\text{measured}} - p_{\text{state}} \\
+    q_{\text{residual}} &= q_{\text{measured}} - q_{\text{state}}
 \end{aligned}
 $$
 
@@ -1024,9 +1016,7 @@ Global angle current measurements require at least one voltage angle measurement
 As a sign convention, the angle is the phase shift of the current relative to the reference angle, i.e.,
 
 $$
-   \begin{eqnarray}
-      \underline{I} = \text{i}_{\text{measured}} \cdot e^{j \text{i}_{\text{angle,measured}}} \text{ .}
-   \end{eqnarray}
+\underline{I} = \text{i}_{\text{measured}} \cdot e^{j \text{i}_{\text{angle,measured}}} \text{ .}
 $$
 
 ##### Local angle current sensors
@@ -1054,10 +1044,10 @@ As a result, the local angle current sensors have a different sign convention fr
 
 $$
 \begin{aligned}
-      & i_{\text{residual}}
-            = i_{\text{measured}} - i_{\text{state}} \\
-      & i_{\text{angle},\text{residual}}
-            = i_{\text{angle},\text{measured}} - i_{\text{angle},\text{state}} \pmod{2 \pi}
+    i_{\text{residual}}
+            &= i_{\text{measured}} - i_{\text{state}} \\
+    i_{\text{angle},\text{residual}}
+            &= i_{\text{angle},\text{measured}} - i_{\text{angle},\text{state}} \pmod{2 \pi}
 \end{aligned}
 $$
 
@@ -1200,10 +1190,8 @@ Instead, it regulates the tap position of the regulated object until the voltage
 voltage band:
 
 $$
-   \begin{eqnarray}
-      U_{\text{control}} \in
-         \left[U_{\text{set}} - \frac{U_{\text{band}}}{2}, U_{\text{set}} + \frac{U_{\text{band}}}{2}\right]
-   \end{eqnarray}
+U_{\text{control}} \in
+    \left[U_{\text{set}} - \frac{U_{\text{band}}}{2}, U_{\text{set}} + \frac{U_{\text{band}}}{2}\right]
 $$
 
 ##### Line drop compensation
@@ -1224,8 +1212,8 @@ drop compensation.
 
 $$
 \begin{aligned}
-   & Z_{\text{compensation}} = r_{\text{compensation}} + \mathrm{j} x_{\text{compensation}} \\
-   & U_{\text{control}} = \left|\underline{U}_{\text{node}} - \underline{I}_{\text{transformer,out}}
+    Z_{\text{compensation}} &= r_{\text{compensation}} + \mathrm{j} x_{\text{compensation}} \\
+    U_{\text{control}} &= \left|\underline{U}_{\text{node}} - \underline{I}_{\text{transformer,out}}
                               \cdot \underline{Z}_{\text{compensation}}\right|
                         = \left|\underline{U}_{\text{node}} + \underline{I}_{\text{transformer}}
                               \cdot \underline{Z}_{\text{compensation}}\right|
@@ -1304,9 +1292,9 @@ The voltage regulator controls the generator to behave as a **PV node** in power
 
 $$
 \begin{aligned}
-   & P_{\text{gen}} = P_{\text{specified}} \\
-   & |U_{\text{node}}| = U_{\text{ref}} \\
-   & Q_{\text{gen}} = \text{calculated to satisfy } U_{\text{ref}}
+    P_{\text{gen}} &= P_{\text{specified}} \\
+    \left|U_{\text{node}}\right| &= U_{\text{ref}} \\
+    Q_{\text{gen}} &= \text{calculated to satisfy } U_{\text{ref}}
 \end{aligned}
 $$
 
@@ -1321,9 +1309,9 @@ node becomes a PQ node:
 
 $$
 \begin{aligned}
-   & P_{\text{gen}} = P_{\text{specified}} \\
-   & Q_{\text{gen}} = Q_{\text{min}} \text{ or } Q_{\text{max}} \\
-   & |U_{\text{node}}| = \text{calculated from power flow}
+    P_{\text{gen}} &= P_{\text{specified}} \\
+    Q_{\text{gen}} &= Q_{\text{min}} \text{ or } Q_{\text{max}} \\
+    \left|U_{\text{node}}\right| &= \text{calculated from power flow}
 \end{aligned}
 $$
 


### PR DESCRIPTION
Fixes #1278
Follow-up to #1288

As mentioned in https://github.com/PowerGridModel/power-grid-model/pull/1288#issuecomment-3858902730, `eqnarray` is deprecated. One consequence is that equations did not render correctly in VSCode Markdown Preview.

This PR removes the deprecated use of `eqnarray`, `align` and `align*`, as well as resolves some minor stylistic issues. As proposed in that same comment:

* single equations guarded by `\begin{eqnarray} ... \end{eqnarray}` are replaced with their unguarded versions
* guards to multi-line equation arrays like `\begin{eqnarray} ... \end{eqnarray}` and equivalent are replaced with an `\begin{aligned} ... \end{aligned}` guard

## To test

Go over all documentation files and check that all equations render correctly

* [x] VS Code Markdown Preview
* [x] Readthedocs local
* [x] Readthedocs remote