### PR TITLE
Remove the voltage overload for branch and appliaces for get_output

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/appliance.hpp
@@ -100,13 +100,6 @@ class Appliance : public Base {
         ComplexValue<asymmetric_t> const iabc{i};
         return get_sc_output(iabc);
     }
-    template <symmetry_tag sym> ApplianceOutput<sym> get_output(ComplexValue<sym> const& u) const {
-        if constexpr (is_symmetric_v<sym>) {
-            return get_output<symmetric_t>(sym_u2si(u));
-        } else {
-            return get_output<asymmetric_t>(asym_u2si(u));
-        }
-    }
     template <symmetry_tag sym>
     ApplianceShortCircuitOutput
     get_sc_output(ApplianceShortCircuitSolverOutput<sym> const& appliance_solver_output) const {
@@ -117,10 +110,6 @@ class Appliance : public Base {
     ID node_;
     bool status_;
     double base_i_;
-
-    // pure virtual functions for translate from u to s/i
-    virtual ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const = 0;
-    virtual ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const = 0;
 
     virtual double injection_direction() const = 0;
 };

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/branch.hpp
@@ -95,19 +95,6 @@ class Branch : public Base {
     virtual bool is_param_mutable() const = 0;
 
     template <symmetry_tag sym>
-    BranchOutput<sym> get_output(ComplexValue<sym> const& u_f, ComplexValue<sym> const& u_t) const {
-        // calculate flow
-        BranchCalcParam<sym> const param = calc_param<sym>();
-        BranchSolverOutput<sym> branch_solver_output{};
-        branch_solver_output.i_f = dot(param.yff(), u_f) + dot(param.yft(), u_t);
-        branch_solver_output.i_t = dot(param.ytf(), u_f) + dot(param.ytt(), u_t);
-        branch_solver_output.s_f = u_f * conj(branch_solver_output.i_f);
-        branch_solver_output.s_t = u_t * conj(branch_solver_output.i_t);
-        // calculate result
-        return get_output<sym>(branch_solver_output);
-    }
-
-    template <symmetry_tag sym>
     BranchOutput<sym> get_output(BranchSolverOutput<sym> const& branch_solver_output) const {
         // result object
         BranchOutput<sym> output{};

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/load_gen.hpp
@@ -137,19 +137,6 @@ class LoadGen final : public std::conditional_t<is_generator_v<appliance_type_>,
         }
         return piecewise_complex_value(s_specified_);
     }
-    template <symmetry_tag calculation_symmetry>
-    ApplianceSolverOutput<calculation_symmetry> u2si(ComplexValue<calculation_symmetry> const& u) const {
-        ApplianceSolverOutput<calculation_symmetry> appliance_solver_output;
-        appliance_solver_output.s = scale_power<calculation_symmetry>(u);
-        appliance_solver_output.i = conj(appliance_solver_output.s / u);
-        return appliance_solver_output;
-    }
-    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const override {
-        return u2si<symmetric_t>(u);
-    }
-    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const override {
-        return u2si<asymmetric_t>(u);
-    }
 
     double injection_direction() const override { return direction_; }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/shunt.hpp
@@ -106,21 +106,6 @@ class Shunt : public Appliance {
         return true;
     }
 
-    template <symmetry_tag sym_calc> ApplianceSolverOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
-        ApplianceSolverOutput<sym_calc> appliance_solver_output;
-        ComplexTensor<sym_calc> const param = calc_param<sym_calc>();
-        // return value should be injection direction, therefore a negative sign for i
-        appliance_solver_output.i = -dot(param, u);
-        appliance_solver_output.s = u * conj(appliance_solver_output.i);
-        return appliance_solver_output;
-    }
-    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
-        return u2si<symmetric_t>(u);
-    }
-    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
-        return u2si<asymmetric_t>(u);
-    }
-
     double injection_direction() const final { return -1.0; }
 };
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/component/source.hpp
@@ -121,23 +121,6 @@ class Source : public Appliance {
     DoubleComplex y1_ref_;
     DoubleComplex y0_ref_;
 
-    template <symmetry_tag sym_calc> ApplianceSolverOutput<sym_calc> u2si(ComplexValue<sym_calc> const& u) const {
-        ApplianceSolverOutput<sym_calc> appliance_solver_output;
-        ComplexValue<sym_calc> const u_ref{u_ref_};
-        SourceCalcParam const source_param = math_param<sym_calc>();
-        ComplexTensor<sym_calc> const y_ref = source_param.template y_ref<sym_calc>();
-        appliance_solver_output.i = dot(y_ref, u_ref - u);
-        appliance_solver_output.s = u * conj(appliance_solver_output.i);
-        return appliance_solver_output;
-    }
-
-    ApplianceSolverOutput<symmetric_t> sym_u2si(ComplexValue<symmetric_t> const& u) const final {
-        return u2si<symmetric_t>(u);
-    }
-    ApplianceSolverOutput<asymmetric_t> asym_u2si(ComplexValue<asymmetric_t> const& u) const final {
-        return u2si<asymmetric_t>(u);
-    }
-
     double injection_direction() const final { return 1.0; }
 };
 

--- a/tests/cpp_unit_tests/test_asym_line.cpp
+++ b/tests/cpp_unit_tests/test_asym_line.cpp
@@ -54,18 +54,10 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
     ComplexTensor<asymmetric_t> const ytt = y_series + 0.5 * y_shunt;
     ComplexTensor<asymmetric_t> const branch_shunt = 0.5 * y_shunt + inv(inv(y_series) + 2.0 * inv(y_shunt));
 
-    double constexpr nominal_current = 216.0;
-    DoubleComplex const u1f = 1.0;
-    DoubleComplex const u1t = 0.9;
     ComplexValue<asymmetric_t> const uaf{1.0};
     ComplexValue<asymmetric_t> const uat{0.9};
 
     // Symmetric results
-    DoubleComplex const i1f = (yff1 * u1f + yft1 * u1t) * base_i;
-    DoubleComplex const i1t = (yft1 * u1f + yff1 * u1t) * base_i;
-    DoubleComplex const s_f = conj(i1f) * u1f * 10e3 * sqrt3;
-    DoubleComplex const s_t = conj(i1t) * u1t * 10e3 * sqrt3;
-    double const loading_sym = std::max(cabs(i1f), cabs(i1t)) / nominal_current;
 
     // Asymmetric results
     ComplexValue<asymmetric_t> const i_f = dot(ytt, uaf) + dot(-y_series, uat);
@@ -84,8 +76,6 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
     ComplexValue<asymmetric_t> const q3pf = base_power<asymmetric_t> * imag(s_f_asym);
     ComplexValue<asymmetric_t> const q3pt = base_power<asymmetric_t> * imag(s_t_asym);
 
-    double const max_i = std::max(max_val(i_from_asym), max_val(i_to_asym));
-    double const loading_asym = max_i / nominal_current;
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
     DoubleComplex const it_sc{2.0, 2.0 * sqrt3};
@@ -164,21 +154,6 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
         CHECK((cabs(param.yft() - 0.0) < numerical_tolerance).all());
     }
 
-    SUBCASE("Symmetric results") {
-        BranchOutput<symmetric_t> const output = branch.get_output<symmetric_t>(1.0, 0.9);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == doctest::Approx(loading_sym));
-        CHECK(output.i_from == doctest::Approx(cabs(i1f)));
-        CHECK(output.i_to == doctest::Approx(cabs(i1t)));
-        CHECK(output.s_from == doctest::Approx(cabs(s_f)));
-        CHECK(output.s_to == doctest::Approx(cabs(s_t)));
-        CHECK(output.p_from == doctest::Approx(real(s_f)));
-        CHECK(output.p_to == doctest::Approx(real(s_t)));
-        CHECK(output.q_from == doctest::Approx(imag(s_f)));
-        CHECK(output.q_to == doctest::Approx(imag(s_t)));
-    }
-
     SUBCASE("Symmetric results with direct power and current output") {
         BranchSolverOutput<symmetric_t> branch_solver_output{};
         branch_solver_output.i_f = 1.0 - 2.0i;
@@ -222,19 +197,6 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
         CHECK(output.i_to(1) == 0.0);
         CHECK(output.i_from_angle(0) == 0.0);
         CHECK(output.i_to_angle(1) == 0.0);
-    }
-
-    SUBCASE("Asymmetric results") {
-        BranchOutput<asymmetric_t> const output = branch.get_output<asymmetric_t>(uaf, uat);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == doctest::Approx(loading_asym));
-        CHECK((cabs(output.i_from - i3pf) < numerical_tolerance).all());
-        CHECK((cabs(output.i_to - i3pt) < numerical_tolerance).all());
-        CHECK((cabs(output.p_from - p3pf) < numerical_tolerance).all());
-        CHECK((cabs(output.p_to - p3pt) < numerical_tolerance).all());
-        CHECK((cabs(output.q_from - q3pf) < numerical_tolerance).all());
-        CHECK((cabs(output.q_to - q3pt) < numerical_tolerance).all());
     }
 
     SUBCASE("Asym short circuit results") {

--- a/tests/cpp_unit_tests/test_asym_line.cpp
+++ b/tests/cpp_unit_tests/test_asym_line.cpp
@@ -62,19 +62,9 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
     // Asymmetric results
     ComplexValue<asymmetric_t> const i_f = dot(ytt, uaf) + dot(-y_series, uat);
     ComplexValue<asymmetric_t> const i_t = dot(-y_series, uaf) + dot(ytt, uat);
-    ComplexValue<asymmetric_t> const i3pf = base_i * cabs(i_f);
-    ComplexValue<asymmetric_t> const i3pt = base_i * cabs(i_t);
 
     ComplexValue<asymmetric_t> const s_f_asym = uaf * conj(i_f);
     ComplexValue<asymmetric_t> const s_t_asym = uat * conj(i_t);
-
-    RealValue<asymmetric_t> const i_from_asym = base_i * cabs(i_f);
-    RealValue<asymmetric_t> const i_to_asym = base_i * cabs(i_t);
-
-    ComplexValue<asymmetric_t> const p3pf = base_power<asymmetric_t> * real(s_f_asym);
-    ComplexValue<asymmetric_t> const p3pt = base_power<asymmetric_t> * real(s_t_asym);
-    ComplexValue<asymmetric_t> const q3pf = base_power<asymmetric_t> * imag(s_f_asym);
-    ComplexValue<asymmetric_t> const q3pt = base_power<asymmetric_t> * imag(s_t_asym);
 
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};

--- a/tests/cpp_unit_tests/test_asym_line.cpp
+++ b/tests/cpp_unit_tests/test_asym_line.cpp
@@ -54,18 +54,6 @@ void execute_subcases(const AsymLineInput& input, const ComplexTensor<asymmetric
     ComplexTensor<asymmetric_t> const ytt = y_series + 0.5 * y_shunt;
     ComplexTensor<asymmetric_t> const branch_shunt = 0.5 * y_shunt + inv(inv(y_series) + 2.0 * inv(y_shunt));
 
-    ComplexValue<asymmetric_t> const uaf{1.0};
-    ComplexValue<asymmetric_t> const uat{0.9};
-
-    // Symmetric results
-
-    // Asymmetric results
-    ComplexValue<asymmetric_t> const i_f = dot(ytt, uaf) + dot(-y_series, uat);
-    ComplexValue<asymmetric_t> const i_t = dot(-y_series, uaf) + dot(ytt, uat);
-
-    ComplexValue<asymmetric_t> const s_f_asym = uaf * conj(i_f);
-    ComplexValue<asymmetric_t> const s_t_asym = uat * conj(i_t);
-
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
     DoubleComplex const it_sc{2.0, 2.0 * sqrt3};

--- a/tests/cpp_unit_tests/test_asym_line.cpp
+++ b/tests/cpp_unit_tests/test_asym_line.cpp
@@ -18,7 +18,6 @@
 
 #include <doctest/doctest.h>
 
-#include <algorithm>
 #include <complex>
 
 namespace power_grid_model {

--- a/tests/cpp_unit_tests/test_line.cpp
+++ b/tests/cpp_unit_tests/test_line.cpp
@@ -185,7 +185,6 @@ TEST_CASE("Test line") {
         CHECK(output.i_to_angle(1) == 0.0);
     }
 
-
     SUBCASE("Asym short circuit results") {
         BranchShortCircuitOutput asym_output = branch.get_sc_output(if_sc_asym, it_sc_asym);
         CHECK(asym_output.id == 1);

--- a/tests/cpp_unit_tests/test_line.cpp
+++ b/tests/cpp_unit_tests/test_line.cpp
@@ -17,7 +17,6 @@
 
 #include <doctest/doctest.h>
 
-#include <algorithm>
 #include <complex>
 
 namespace power_grid_model {

--- a/tests/cpp_unit_tests/test_line.cpp
+++ b/tests/cpp_unit_tests/test_line.cpp
@@ -59,15 +59,8 @@ TEST_CASE("Test line") {
     ComplexTensor<asymmetric_t> const yfta{(2.0 * yft1 + yft0) / 3.0, (yft0 - yft1) / 3.0};
     ComplexTensor<asymmetric_t> const ysa{(2.0 * ys1 + ys0) / 3.0, (ys0 - ys1) / 3.0};
 
-    DoubleComplex const u1f = 1.0;
-    DoubleComplex const u1t = 0.9;
     ComplexValue<asymmetric_t> const uaf{1.0};
     ComplexValue<asymmetric_t> const uat{0.9};
-    DoubleComplex const i1f = (yff1 * u1f + yft1 * u1t) * base_i;
-    DoubleComplex const i1t = (yft1 * u1f + yff1 * u1t) * base_i;
-    DoubleComplex const s_f = conj(i1f) * u1f * 10e3 * sqrt3;
-    DoubleComplex const s_t = conj(i1t) * u1t * 10e3 * sqrt3;
-    double const loading = std::max(cabs(i1f), cabs(i1t)) / 200.0;
 
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
@@ -147,21 +140,6 @@ TEST_CASE("Test line") {
         CHECK((cabs(param.yft() - 0.0) < numerical_tolerance).all());
     }
 
-    SUBCASE("Symmetric results") {
-        BranchOutput<symmetric_t> const output = branch.get_output<symmetric_t>(1.0, 0.9);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == doctest::Approx(loading));
-        CHECK(output.i_from == doctest::Approx(cabs(i1f)));
-        CHECK(output.i_to == doctest::Approx(cabs(i1t)));
-        CHECK(output.s_from == doctest::Approx(cabs(s_f)));
-        CHECK(output.s_to == doctest::Approx(cabs(s_t)));
-        CHECK(output.p_from == doctest::Approx(real(s_f)));
-        CHECK(output.p_to == doctest::Approx(real(s_t)));
-        CHECK(output.q_from == doctest::Approx(imag(s_f)));
-        CHECK(output.q_to == doctest::Approx(imag(s_t)));
-    }
-
     SUBCASE("Symmetric results with direct power and current output") {
         BranchSolverOutput<symmetric_t> branch_solver_output{};
         branch_solver_output.i_f = 1.0 - 2.0i;
@@ -207,20 +185,6 @@ TEST_CASE("Test line") {
         CHECK(output.i_to_angle(1) == 0.0);
     }
 
-    SUBCASE("Asymmetric results") {
-        BranchOutput<asymmetric_t> output = branch.get_output<asymmetric_t>(uaf, uat);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == doctest::Approx(loading));
-        CHECK(output.i_from(0) == doctest::Approx(cabs(i1f)));
-        CHECK(output.i_to(1) == doctest::Approx(cabs(i1t)));
-        CHECK(output.s_from(2) == doctest::Approx(cabs(s_f) / 3.0));
-        CHECK(output.s_to(0) == doctest::Approx(cabs(s_t) / 3.0));
-        CHECK(output.p_from(1) == doctest::Approx(real(s_f) / 3.0));
-        CHECK(output.p_to(2) == doctest::Approx(real(s_t) / 3.0));
-        CHECK(output.q_from(0) == doctest::Approx(imag(s_f) / 3.0));
-        CHECK(output.q_to(1) == doctest::Approx(imag(s_t) / 3.0));
-    }
 
     SUBCASE("Asym short circuit results") {
         BranchShortCircuitOutput asym_output = branch.get_sc_output(if_sc_asym, it_sc_asym);

--- a/tests/cpp_unit_tests/test_link.cpp
+++ b/tests/cpp_unit_tests/test_link.cpp
@@ -30,14 +30,8 @@ TEST_CASE("Test link") {
     Branch& branch = link;
     double const base_i_from = base_power_1p / (10.0e3 / sqrt3);
     double const base_i_to = base_power_1p / (50.0e3 / sqrt3);
-    DoubleComplex const u1f = 1.0;
-    DoubleComplex const u1t = 0.9;
     ComplexValue<asymmetric_t> const uaf{1.0};
     ComplexValue<asymmetric_t> const uat{0.9};
-    DoubleComplex const i1f = (u1f - u1t) * y_link * base_i_from;
-    DoubleComplex const i1t = (u1t - u1f) * y_link * base_i_to;
-    DoubleComplex const s_f = conj(i1f) * u1f * 10e3 * sqrt3;
-    DoubleComplex const s_t = conj(i1t) * u1t * 50e3 * sqrt3;
 
     // Short circuit results
     DoubleComplex const if_sc{1.0, 1.0};
@@ -75,36 +69,6 @@ TEST_CASE("Test link") {
         CHECK(cabs(param.ytt() - 0.0) < numerical_tolerance);
         CHECK(cabs(param.ytf() - 0.0) < numerical_tolerance);
         CHECK(cabs(param.yft() - 0.0) < numerical_tolerance);
-    }
-
-    SUBCASE("Symmetric results") {
-        BranchOutput<symmetric_t> const output = branch.get_output<symmetric_t>(1.0, 0.9);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == 0.0);
-        CHECK(output.i_from == doctest::Approx(cabs(i1f)));
-        CHECK(output.i_to == doctest::Approx(cabs(i1t)));
-        CHECK(output.s_from == doctest::Approx(cabs(s_f)));
-        CHECK(output.s_to == doctest::Approx(cabs(s_t)));
-        CHECK(output.p_from == doctest::Approx(real(s_f)));
-        CHECK(output.p_to == doctest::Approx(real(s_t)));
-        CHECK(output.q_from == doctest::Approx(imag(s_f)));
-        CHECK(output.q_to == doctest::Approx(imag(s_t)));
-    }
-
-    SUBCASE("Asymmetric results") {
-        BranchOutput<asymmetric_t> const output = branch.get_output<asymmetric_t>(uaf, uat);
-        CHECK(output.id == 1);
-        CHECK(output.energized);
-        CHECK(output.loading == 0.0);
-        CHECK(output.i_from(0) == doctest::Approx(cabs(i1f)));
-        CHECK(output.i_to(1) == doctest::Approx(cabs(i1t)));
-        CHECK(output.s_from(2) == doctest::Approx(cabs(s_f) / 3.0));
-        CHECK(output.s_to(0) == doctest::Approx(cabs(s_t) / 3.0));
-        CHECK(output.p_from(1) == doctest::Approx(real(s_f) / 3.0));
-        CHECK(output.p_to(2) == doctest::Approx(real(s_t) / 3.0));
-        CHECK(output.q_from(0) == doctest::Approx(imag(s_f) / 3.0));
-        CHECK(output.q_to(1) == doctest::Approx(imag(s_t) / 3.0));
     }
 
     SUBCASE("Short circuit asym results") {

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -173,7 +173,6 @@ TEST_CASE("Test load generator") {
         CHECK(reverse_result.pf == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
     }
 
-
     SUBCASE("Test asymmetric generator with constant addmittance; s, i as input") {
         GenericLoadGen const& load_gen = asym_gen_y;
         // sym result

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -64,8 +64,6 @@ TEST_CASE("Test load generator") {
 
     double const base_i = base_power_1p / (10e3 / sqrt3);
     ComplexValue<asymmetric_t> const ua{1.1 * std::exp(1.0i * 10.0)};
-    double const s_y = sqrt2 * 3e6 * 1.1 * 1.1;
-    double const s_i = sqrt2 * 3e6 * 1.1;
 
     ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
     appliance_solver_output_sym.i = 1.0 + 2.0i;
@@ -90,34 +88,6 @@ TEST_CASE("Test load generator") {
         CHECK(appliance.status());
         CHECK(appliance.set_status(false));
         CHECK(!appliance.status());
-    }
-
-    SUBCASE("Test symmetric generator with constant power; u as input") {
-        GenericLoadGen const& load_gen = sym_gen_pq;
-        // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.p == doctest::Approx(p_pq));
-        CHECK(sym_result.q == doctest::Approx(q_pq));
-        CHECK(sym_result.s == doctest::Approx(s_pq));
-        CHECK(sym_result.i == doctest::Approx(i_pq));
-        CHECK(sym_result.pf == doctest::Approx(pf));
-        // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p_pq / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(q_pq / 3));
-        CHECK(asym_result.s(2) == doctest::Approx(s_pq / 3));
-        CHECK(asym_result.i(0) == doctest::Approx(i_pq));
-        CHECK(asym_result.pf(1) == doctest::Approx(pf));
-        // test sym power injection
-        ComplexValue<symmetric_t> const s_inj = load_gen.calc_param<symmetric_t>();
-        CHECK(real(s_inj) == doctest::Approx(p_pu));
-        CHECK(imag(s_inj) == doctest::Approx(p_pu));
-        // test asym power injection
-        ComplexValue<asymmetric_t> const s_inj_a = load_gen.calc_param<asymmetric_t>();
-        CHECK(real(s_inj_a(0)) == doctest::Approx(p_pu));
-        CHECK(imag(s_inj_a(1)) == doctest::Approx(p_pu));
     }
 
     SUBCASE("Test symmetric generator with constant power; s,i as input") {
@@ -223,20 +193,6 @@ TEST_CASE("Test load generator") {
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));
         CHECK(asym_result.i(0) == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(asym_result.pf(1) == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
-    }
-
-    SUBCASE("Test update load") {
-        auto changed =
-            sym_gen_pq.update(SymLoadGenUpdate{.id = 1, .status = na_IntS, .p_specified = 1e6, .q_specified = nan});
-        CHECK(!changed.topo);
-        CHECK(!changed.param);
-        ApplianceOutput<symmetric_t> const sym_result = sym_gen_pq.get_output<symmetric_t>(u);
-        CHECK(sym_result.p == doctest::Approx(1e6));
-        CHECK(sym_result.q == doctest::Approx(q_pq));
-        asym_load_pq.set_power(RealValue<asymmetric_t>{nan}, RealValue<asymmetric_t>{1e5});
-        ApplianceOutput<asymmetric_t> const asym_result = asym_load_pq.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p_pq / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(1e5));
     }
 
     SUBCASE("Test set_power - sym") {

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -7,7 +7,6 @@
 
 #include <power_grid_model/auxiliary/input.hpp>
 #include <power_grid_model/auxiliary/output.hpp>
-#include <power_grid_model/auxiliary/update.hpp>
 #include <power_grid_model/calculation_parameters.hpp>
 #include <power_grid_model/common/common.hpp>
 #include <power_grid_model/common/enum.hpp>
@@ -19,7 +18,6 @@
 #include <complex>
 #include <concepts>
 #include <cstddef>
-#include <numbers>
 
 TYPE_TO_STRING_AS("SymGenerator", power_grid_model::SymGenerator);
 TYPE_TO_STRING_AS("AsymGenerator", power_grid_model::AsymGenerator);
@@ -28,7 +26,6 @@ TYPE_TO_STRING_AS("AsymLoad", power_grid_model::AsymLoad);
 
 namespace power_grid_model {
 namespace {
-using std::numbers::sqrt2;
 
 void check_nan_preserving_equality(std::floating_point auto actual, std::floating_point auto expected) {
     if (is_nan(expected)) {

--- a/tests/cpp_unit_tests/test_load_gen.cpp
+++ b/tests/cpp_unit_tests/test_load_gen.cpp
@@ -63,22 +63,9 @@ TEST_CASE("Test load generator") {
     AsymGenerator const asym_gen_y{asym_load_gen_input, 10e3};
 
     double const base_i = base_power_1p / (10e3 / sqrt3);
-    DoubleComplex const u{1.1 * std::exp(1.0i * 10.0)};
     ComplexValue<asymmetric_t> const ua{1.1 * std::exp(1.0i * 10.0)};
-    double const pf = 1 / sqrt2;
-    double const s_pq = sqrt2 * 3e6;
-    double const p_pq = 3e6;
-    double const q_pq = 3e6;
-    double const i_pq = s_pq / (1.1 * 10e3) / sqrt3;
     double const s_y = sqrt2 * 3e6 * 1.1 * 1.1;
-    double const p_y = 3e6 * 1.1 * 1.1;
-    double const q_y = 3e6 * 1.1 * 1.1;
-    double const i_y = s_y / (1.1 * 10e3) / sqrt3;
     double const s_i = sqrt2 * 3e6 * 1.1;
-    double const p_i = 3e6 * 1.1;
-    double const q_i = 3e6 * 1.1;
-    double const i_i = s_i / (1.1 * 10e3) / sqrt3;
-    double const p_pu = 3e6 / base_power_3p;
 
     ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
     appliance_solver_output_sym.i = 1.0 + 2.0i;
@@ -164,33 +151,6 @@ TEST_CASE("Test load generator") {
         CHECK(reverse_result.pf == doctest::Approx(-3.0 / cabs(3.0 + 4.0i)));
     }
 
-    SUBCASE("Test asymmetric load with constant power; u as input") {
-        GenericLoadGen const& load_gen = asym_load_pq;
-        // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.p == doctest::Approx(p_pq));
-        CHECK(sym_result.q == doctest::Approx(q_pq));
-        CHECK(sym_result.s == doctest::Approx(s_pq));
-        CHECK(sym_result.i == doctest::Approx(i_pq));
-        CHECK(sym_result.pf == doctest::Approx(pf));
-        // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p_pq / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(q_pq / 3));
-        CHECK(asym_result.s(2) == doctest::Approx(s_pq / 3));
-        CHECK(asym_result.i(0) == doctest::Approx(i_pq));
-        CHECK(asym_result.pf(1) == doctest::Approx(pf));
-        // test sym power injection
-        ComplexValue<symmetric_t> const s_inj = load_gen.calc_param<symmetric_t>();
-        CHECK(real(s_inj) == doctest::Approx(-p_pu));
-        CHECK(imag(s_inj) == doctest::Approx(-p_pu));
-        ComplexValue<asymmetric_t> const s_inj_a = load_gen.calc_param<asymmetric_t>();
-        CHECK(real(s_inj_a(0)) == doctest::Approx(-p_pu));
-        CHECK(imag(s_inj_a(1)) == doctest::Approx(-p_pu));
-    }
-
     SUBCASE("Test asymmetric load with constant power; s, i as input") {
         GenericLoadGen const& load_gen = asym_load_pq;
         // sym result
@@ -210,26 +170,6 @@ TEST_CASE("Test load generator") {
         CHECK(asym_result.s(2) == doctest::Approx(5.0 * base_power<asymmetric_t>));
         CHECK(asym_result.i(0) == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(asym_result.pf(1) == doctest::Approx(-3.0 / cabs(3.0 + 4.0i)));
-    }
-
-    SUBCASE("Test symmetric load with constant current; u as input") {
-        GenericLoadGen const& load_gen = sym_load_i;
-        // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.p == doctest::Approx(p_i));
-        CHECK(sym_result.q == doctest::Approx(q_i));
-        CHECK(sym_result.s == doctest::Approx(s_i));
-        CHECK(sym_result.i == doctest::Approx(i_i));
-        CHECK(sym_result.pf == doctest::Approx(pf));
-        // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p_i / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(q_i / 3));
-        CHECK(asym_result.s(2) == doctest::Approx(s_i / 3));
-        CHECK(asym_result.i(0) == doctest::Approx(i_i));
-        CHECK(asym_result.pf(1) == doctest::Approx(pf));
     }
 
     SUBCASE("Test symmetric load with constant current; s, i as input") {
@@ -263,25 +203,6 @@ TEST_CASE("Test load generator") {
         CHECK(reverse_result.pf == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
     }
 
-    SUBCASE("Test asymmetric generator with constant addmittance; u as input ") {
-        GenericLoadGen const& load_gen = asym_gen_y;
-        // sym result
-        ApplianceOutput<symmetric_t> const sym_result = load_gen.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.p == doctest::Approx(p_y));
-        CHECK(sym_result.q == doctest::Approx(q_y));
-        CHECK(sym_result.s == doctest::Approx(s_y));
-        CHECK(sym_result.i == doctest::Approx(i_y));
-        CHECK(sym_result.pf == doctest::Approx(pf));
-        // asym result
-        ApplianceOutput<asymmetric_t> const asym_result = load_gen.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p_y / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(q_y / 3));
-        CHECK(asym_result.s(2) == doctest::Approx(s_y / 3));
-        CHECK(asym_result.i(0) == doctest::Approx(i_y));
-        CHECK(asym_result.pf(1) == doctest::Approx(pf));
-    }
 
     SUBCASE("Test asymmetric generator with constant addmittance; s, i as input") {
         GenericLoadGen const& load_gen = asym_gen_y;

--- a/tests/cpp_unit_tests/test_shunt.cpp
+++ b/tests/cpp_unit_tests/test_shunt.cpp
@@ -37,13 +37,7 @@ TEST_CASE("Test shunt") {
     double const base_y = base_power_3p / 10e3 / 10e3;
     DoubleComplex const y1 = (1.0 + 2.0i) / base_y;
     DoubleComplex const y0 = (3.0 + 4.0i) / base_y;
-    DoubleComplex const u{1.0};
     ComplexValue<asymmetric_t> const ua{1.0};
-    double const p = 10e3 * 10e3 * 1.0;
-    double const q = -10e3 * 10e3 * 2.0;
-    double const s = std::sqrt(p * p + q * q);
-    double const i = s / 10e3 / sqrt3;
-    double const pf = p / s;
 
     CHECK(shunt.math_model_type() == ComponentType::shunt);
 
@@ -57,23 +51,6 @@ TEST_CASE("Test shunt") {
         ya = shunt.calc_param<asymmetric_t>(false);
         CHECK(cabs(ya(0, 0)) < numerical_tolerance);
         CHECK(cabs(ya(0, 1)) < numerical_tolerance);
-    }
-
-    SUBCASE("test results; u as input") {
-        ApplianceOutput<symmetric_t> const sym_result = shunt.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.p == doctest::Approx(p));
-        CHECK(sym_result.q == doctest::Approx(q));
-        CHECK(sym_result.s == doctest::Approx(s));
-        CHECK(sym_result.i == doctest::Approx(i));
-        CHECK(sym_result.pf == doctest::Approx(pf));
-        ApplianceOutput<asymmetric_t> asym_result = shunt.get_output<asymmetric_t>(ua);
-        CHECK(asym_result.p(0) == doctest::Approx(p / 3));
-        CHECK(asym_result.q(1) == doctest::Approx(q / 3));
-        CHECK(asym_result.s(2) == doctest::Approx(s / 3));
-        CHECK(asym_result.i(0) == doctest::Approx(i));
-        CHECK(asym_result.pf(1) == doctest::Approx(pf));
     }
 
     SUBCASE("Symmetric test results; s, i as input") {

--- a/tests/cpp_unit_tests/test_source.cpp
+++ b/tests/cpp_unit_tests/test_source.cpp
@@ -49,8 +49,6 @@ TEST_CASE("Test source") {
 
     // calculation
     double const u_input = 1.1;
-    double const u = 0.9;
-    double const i = cabs(y1 * (u_input - u)) * base_power_3p / sqrt3 / un;
 
     // asym
     ComplexTensor<asymmetric_t> const sym_matrix = get_sym_matrix();
@@ -111,13 +109,6 @@ TEST_CASE("Test source") {
         CHECK(cabs(u_ref - 1.1 * std::exp(2.5i)) < numerical_tolerance);
     }
 
-    SUBCASE("test source sym results; u as input") {
-        ApplianceOutput<symmetric_t> const sym_result = source.get_output<symmetric_t>(u);
-        CHECK(sym_result.id == 1);
-        CHECK(sym_result.energized);
-        CHECK(sym_result.i == doctest::Approx(i));
-    }
-
     SUBCASE("test source sym results; s, i as input") {
         ApplianceSolverOutput<symmetric_t> appliance_solver_output_sym;
         appliance_solver_output_sym.i = 1.0 + 2.0i;
@@ -130,14 +121,6 @@ TEST_CASE("Test source") {
         CHECK(sym_result.s == doctest::Approx(cabs(3.0 + 4.0i) * base_power<symmetric_t>));
         CHECK(sym_result.i == doctest::Approx(cabs(1.0 + 2.0i) * base_i));
         CHECK(sym_result.pf == doctest::Approx(3.0 / cabs(3.0 + 4.0i)));
-    }
-
-    SUBCASE("test source asym results; u as input") {
-        ApplianceOutput<asymmetric_t> const asym_result =
-            source.get_output<asymmetric_t>(ComplexValue<asymmetric_t>{u});
-        CHECK(asym_result.id == 1);
-        CHECK(asym_result.energized);
-        CHECK(asym_result.i(0) == doctest::Approx(i));
     }
 
     SUBCASE("test source asym results; s, i as input") {


### PR DESCRIPTION
Prerequisite to do #1156.

Currently `Branch` and `Appliance` has `get_output` overload based on voltages. These were historically used but currently not used in production.

This PR removes all of them and its tests.