### PR TITLE
GitHub Actions: require actions to be pinned to full-length commit SHA

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -31,13 +31,13 @@ jobs:
     name: Build sdist and set version
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set PyPI Version
-        uses: PowerGridModel/pgm-version-bump@main
+        uses: PowerGridModel/pgm-version-bump@17f01ca0e845c35804c8c3c2490f61d14a77ede2 # v0.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -48,13 +48,13 @@ jobs:
           uv build --sdist --no-create-gitignore --out-dir wheelhouse .
 
       - name: Keep version file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: version
           path: VERSION
 
       - name: Keep SDist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheelhouse
           path: ./wheelhouse/*.tar.gz
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        build-option: [ debug, release ]
+        build-option: [debug, release]
         compiler: [gcc, clang]
         include:
           - compiler: gcc
@@ -75,7 +75,7 @@ jobs:
       HOMEBREW_FORCE_BREWED_CURL: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install packages
         run: |
           sudo apt-get update
@@ -86,8 +86,8 @@ jobs:
           sudo ln -s /usr/bin/g++-14 /usr/local/bin/g++
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
       - name: Install pgm-build-dependencies
         run: |
           uv tool install https://github.com/PowerGridModel/pgm-build-dependencies/releases/latest/download/pgm_build_dependencies-0.1.0-py3-none-any.whl
@@ -100,25 +100,25 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        build-option: [ debug, release ]
+        build-option: [debug, release]
         compiler: [msvc, clang-cl]
 
     env:
       PRESET: ${{ matrix.compiler }}-${{ matrix.build-option }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
       - name: Install pgm-build-dependencies
         run: |
           uv tool install https://github.com/PowerGridModel/pgm-build-dependencies/releases/latest/download/pgm_build_dependencies-0.1.0-py3-none-any.whl
           pgm-build-setup-ga-ci
- 
+
       - uses: ./.github/actions/enable-msvc
-    
+
       - name: Build and test
         run: |
           # generate cmake cache
@@ -141,22 +141,22 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        build-option: [ debug, release ]
+        build-option: [debug, release]
     env:
       CMAKE_PREFIX_PATH: /usr/local
       PRESET: ci-clang-${{ matrix.build-option }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
       - name: Install pgm-build-dependencies
         run: |
           uv tool install https://github.com/PowerGridModel/pgm-build-dependencies/releases/latest/download/pgm_build_dependencies-0.1.0-py3-none-any.whl
@@ -168,7 +168,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        platform: [ linux-x64, linux-aarch64, macos, windows ]
+        platform: [linux-x64, linux-aarch64, macos, windows]
         include:
           - platform: linux-x64
             os: ubuntu-24.04
@@ -187,9 +187,9 @@ jobs:
     needs: [acquire-python-version-build-sdist]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: version
           path: .
@@ -199,12 +199,12 @@ jobs:
 
       - name: Set up XCode
         if: matrix.os == 'macos-15'
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         # GitHub Actions specific build parameters
         env:
           # pass GitHub runner info into Linux container
@@ -214,7 +214,7 @@ jobs:
           extras: "uv"
 
       - name: Keep wheel files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheelhouse-${{ matrix.platform }}
           path: ./wheelhouse/*.whl
@@ -238,17 +238,17 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
-          miniforge-version: latest  # use miniforge instead of miniconda
+          miniforge-version: latest # use miniforge instead of miniconda
           activate-environment: conda-pgm-env
           environment-file: .github/conda_pgm_env.yml
           auto-activate-base: false
           channels: conda-forge
           conda-remove-defaults: "true"
-      
+
       - name: List conda
         run: |
           conda info
@@ -265,7 +265,7 @@ jobs:
 
       - name: Build and install cmake target for Windows
         if: matrix.os == 'windows'
-        run: |          
+        run: |
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/ -S .
           cmake --build build/ --verbose -j1
           cmake --install build/ --prefix ${env:CONDA_PREFIX}/Library
@@ -285,7 +285,14 @@ jobs:
 
   github-release:
     name: Create and release assets to GitHub
-    needs: [build-cpp-test-linux, build-cpp-test-windows, build-cpp-test-macos, build-and-test-python, build-and-test-conda]
+    needs:
+      [
+        build-cpp-test-linux,
+        build-cpp-test-windows,
+        build-cpp-test-macos,
+        build-and-test-python,
+        build-and-test-conda,
+      ]
     # always run publish job but fail at the first step if previous jobs have been failed
     if: always()
     runs-on: ubuntu-latest
@@ -299,11 +306,11 @@ jobs:
           echo "Previous jobs have failures!"
           exit 1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: version
           path: .
@@ -322,7 +329,7 @@ jobs:
         run: echo "${{ steps.tag.outputs.tag }}"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: (inputs.create_release)
         with:
           files: |

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -33,7 +33,7 @@ jobs:
       HOMEBREW_FORCE_BREWED_CURL: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install packages
         run: |
           sudo apt-get update
@@ -44,7 +44,7 @@ jobs:
           sudo ln -s /usr/bin/g++-14 /usr/local/bin/g++
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install pgm-build-dependencies
         run: |
@@ -83,10 +83,10 @@ jobs:
       PRESET: ci-${{ matrix.compiler }}-reproducible
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install pgm-build-dependencies
         run: |
@@ -132,15 +132,15 @@ jobs:
       PRESET: ci-apple-clang-reproducible
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install pgm-build-dependencies
         run: |

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install most linters from uv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     uses: "./.github/workflows/build-test-release.yml"
     permissions:
       contents: write
-    with: 
+    with:
       # create_release becomes true if the event that triggered this workflow is "workflow_dispatch" and inputs.create_release is true
       # create_release becomes true if the event that triggered this workflow is "push" on main
       # otherwise create_release becomes false
@@ -57,7 +57,14 @@ jobs:
 
   ci-passed:
     runs-on: ubuntu-latest
-    needs: [ci-started, build-test-release, check-code-quality, reuse-compliance, clang-tidy]
+    needs:
+      [
+        ci-started,
+        build-test-release,
+        check-code-quality,
+        reuse-compliance,
+        clang-tidy,
+      ]
     if: always()
 
     steps:
@@ -71,13 +78,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write  # Required for Trusted Publishing
+      id-token: write # Required for Trusted Publishing
     needs: build-test-release
     if: (github.event_name == 'workflow_dispatch') || github.event_name == 'push'
 
     steps:
       - name: Download assets from GitHub release
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: ${{ github.repository }}
           # download the latest release
@@ -95,9 +102,9 @@ jobs:
 
       - name: List downloaded assets
         run: ls -la assets-to-publish
-      
+
       - name: Upload assets to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           # To test, use the TestPyPI:
           # repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install R
       run: |
         sudo apt-get update && sudo apt-get install -y r-base
     - name: Validate CITATION.cff
-      uses: dieghernan/cff-validator@v4
+      uses: dieghernan/cff-validator@114aae53e1850c3757733beb60036941900e3dc3 # v4

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -48,7 +48,7 @@ jobs:
       HOMEBREW_FORCE_BREWED_CURL: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install packages
         run: |
@@ -59,7 +59,7 @@ jobs:
           sudo ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       
       - name: Install pgm-build-dependencies
         run: |

--- a/.github/workflows/refresh-lock-and-linter-dependencies.yml
+++ b/.github/workflows/refresh-lock-and-linter-dependencies.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: upgrade uv lock
         run: uv lock --upgrade  
@@ -84,7 +84,7 @@ jobs:
           grab_installed_version_npm "markdownlint-cli"
 
       - name: Update .pre-commit-config.yaml
-        uses: cuchi/jinja2-action@v1.3.0
+        uses: cuchi/jinja2-action@8bd801365a8d36a0b20f45ee969161685de7785a # v1.3.0
         with:
           template: .pre-commit-config.yaml.jinja
           output_file: .pre-commit-config.yaml
@@ -109,7 +109,7 @@ jobs:
           pre-commit uninstall
 
       - name: generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
@@ -117,7 +117,7 @@ jobs:
 
       - name: create pull request
         if: ${{ inputs.create-pr || github.event_name == 'schedule' }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "Refresh lock and linter dependencies"
           branch: "dependencies/refresh-lock-and-linter"

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v6
+      uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,9 +28,9 @@ jobs:
       LLVM_COV: llvm-cov-18
       HOMEBREW_FORCE_BREWED_CURL: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install packages
         run: |
           sudo apt-get update
@@ -38,14 +38,14 @@ jobs:
           sudo ln -s /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -s /usr/bin/clang++-18 /usr/local/bin/clang++
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Install pgm-build-dependencies
         run: |
           uv tool install https://github.com/PowerGridModel/pgm-build-dependencies/releases/latest/download/pgm_build_dependencies-0.1.0-py3-none-any.whl
           pgm-build-setup-ga-ci
       - name: Install build-wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
-        
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
+
       - name: Python test and coverage
         run: |
           CC=clang CXX=clang++ uv sync --no-default-groups --group test
@@ -73,7 +73,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args: >
             --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json


### PR DESCRIPTION
This is part of our goal to follow security best practices. See also https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions

Cfr. https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#controlling-access-to-public-actions-and-reusable-workflows :

> Require actions to be pinned to a full-length commit SHA: All actions must be pinned to a full-length commit SHA to be used. This includes actions from your enterprise and actions authored by GitHub. Reusable workflows can still be referenced by tag. For more information, see [Secure use reference](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions).

So we have to pin also the GitHub-owned (`actions/checkout`, ...) and PowerGridModel-owned action (`pgm-version-bump`) before we can enable enforcing.

In addition, uv has migrated to no longer use rolling release tags (e.g. `v7`, `v8`, `v8.0`, ...) and instead requires us to use either the full tag (e.g. `v8.0.0`) or the full-length commit SHA (e.g. `cec208311dfd045dd5311c1add060b2062131d57`, optionally followed by a commented-out version of the tag, e.g. `cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0`). Further reading in https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0 . This also means that we missed the latest version bump of uv. This feels like a good moment to jump, but let's let dependabot handle that, so we can 1. separate concerns, and 2. test whether the dependabot pipeline still works

## Relates to:

* https://github.com/PowerGridModel/power-grid-model/pull/1372
* https://github.com/PowerGridModel/power-grid-model-io/pull/412
* https://github.com/PowerGridModel/power-grid-model-ds/pull/228
* https://github.com/PowerGridModel/pgm-build-dependencies/pull/15
* https://github.com/PowerGridModel/pgm-version-bump/pull/9
* https://github.com/PowerGridModel/power-grid-model-workshop/pull/56
* https://github.com/PowerGridModel/power-grid-model-benchmark/pull/17
* https://github.com/PowerGridModel/homebrew-pgm/pull/1