### PR TITLE
Bug: Update to correct last commit SHA

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Set PyPI Version
-        uses: PowerGridModel/pgm-version-bump@17f01ca0e845c35804c8c3c2490f61d14a77ede2 # v0.1.1
+        uses: PowerGridModel/pgm-version-bump@b75ff549cae00be1ca859d181dbc460f69003643 # v0.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
After https://github.com/PowerGridModel/power-grid-model/pull/1372, we realized we pinned to the commit SHA of some of our dependency repos after main PGM was done, which caused CI to fail because for instance https://github.com/PowerGridModel/pgm-version-bump doesn't release, so its new SHA wasn't automatically updated.

This PR is attempt to hot fix it.

This PR can be merged after CI runs successfully.