### PR TITLE
GitHub Actions: bump macos runner images to macos-26 (arm-based)

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -138,7 +138,7 @@ jobs:
           install\${{ env.PRESET }}\bin\power_grid_model_package_test; if(!$?) { Exit $LASTEXITCODE }
 
   build-cpp-test-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix:
         build-option: [debug, release]
@@ -177,7 +177,7 @@ jobs:
             os: ubuntu-24.04-arm
             cibw_build: "*_aarch64"
           - platform: macos
-            os: macos-15
+            os: macos-26
             cibw_build: "*"
           - platform: windows
             os: windows-latest
@@ -198,7 +198,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Set up XCode
-        if: matrix.os == 'macos-15'
+        if: matrix.os == 'macos-26'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -179,12 +179,12 @@ jobs:
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
             cibw_build: "*_aarch64"
-          - platform: macos-aarch64
+          - platform: macos-arm64
             os: macos-26
-            cibw_build: "*"
+            cibw_build: "*_arm64"
           - platform: macos-x64
             os: macos-26-intel
-            cibw_build: "*"
+            cibw_build: "*_x86_64"
           - platform: windows
             os: windows-latest
             cibw_build: "*"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -138,10 +138,13 @@ jobs:
           install\${{ env.PRESET }}\bin\power_grid_model_package_test; if(!$?) { Exit $LASTEXITCODE }
 
   build-cpp-test-macos:
-    runs-on: macos-26
     strategy:
       matrix:
         build-option: [debug, release]
+        os: [macos-26, macos-26-intel]
+
+    runs-on: ${{ matrix.os }}
+  
     env:
       CMAKE_PREFIX_PATH: /usr/local
       PRESET: ci-clang-${{ matrix.build-option }}
@@ -176,8 +179,11 @@ jobs:
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
             cibw_build: "*_aarch64"
-          - platform: macos
+          - platform: macos-arm64
             os: macos-26
+            cibw_build: "*"
+          - platform: macos-x64
+            os: macos-26-intel
             cibw_build: "*"
           - platform: windows
             os: windows-latest
@@ -198,7 +204,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Set up XCode
-        if: matrix.os == 'macos-26'
+        if: matrix.os == 'macos-26' || matrix.os == 'macos-26-intel'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -171,7 +171,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        platform: [linux-x64, linux-aarch64, macos-aarch64, macos-x64, windows]
+        platform: [linux-x64, linux-aarch64, macos-arm64, macos-x64, windows]
         include:
           - platform: linux-x64
             os: ubuntu-24.04

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -171,7 +171,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        platform: [linux-x64, linux-aarch64, macos, windows]
+        platform: [linux-x64, linux-aarch64, macos-aarch64, macos-x64, windows]
         include:
           - platform: linux-x64
             os: ubuntu-24.04
@@ -179,7 +179,7 @@ jobs:
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
             cibw_build: "*_aarch64"
-          - platform: macos-arm64
+          - platform: macos-aarch64
             os: macos-26
             cibw_build: "*"
           - platform: macos-x64

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -21,9 +21,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         compiler: [gcc, clang]
-        include:
-          - compiler: gcc
-          - compiler: clang
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -126,7 +126,11 @@ jobs:
           Write-Host "Builds are identical"
 
   check-reproducibility-c-macos:
-    runs-on: macos-26
+    strategy:
+      matrix:
+        os: [macos-26, macos-26-intel]
+
+    runs-on: ${{ matrix.os }}
     env:
       CMAKE_PREFIX_PATH: /usr/local
       PRESET: ci-apple-clang-reproducible

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -126,7 +126,7 @@ jobs:
           Write-Host "Builds are identical"
 
   check-reproducibility-c-macos:
-    runs-on: macos-latest
+    runs-on: macos-26
     env:
       CMAKE_PREFIX_PATH: /usr/local
       PRESET: ci-apple-clang-reproducible

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-name: Build and Test C++ and Python
+name: Check build reproducibility
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -17,15 +17,15 @@ concurrency:
 
 jobs:
   check-power-grid-model-c-linux:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         compiler: [gcc, clang]
         include:
-          - c_compiler: gcc-14
-            cxx_compiler: g++-14
-          - c_compiler: clang-18
-            cxx_compiler: clang++-18
+          - compiler: gcc
+          - compiler: clang
+
+    runs-on: ${{ matrix.os }}
 
     env:
       CMAKE_PREFIX_PATH: /home/linuxbrew/.linuxbrew

--- a/docs/advanced_documentation/build-guide.md
+++ b/docs/advanced_documentation/build-guide.md
@@ -73,7 +73,7 @@ These are handled automatically in CI. For local development, use your system's 
 
 #### macOS
 
-* Apple Clang >= 17.0:
+* Apple Clang >= 21.0:
   * Latest XCode release tested in CI.
 
 ```{note}


### PR DESCRIPTION
`macos-26` has been in GA for a couple months now. Let's bump.

~NOTE: `macos-xx` points to ARM by default. If we want to remain on intel cores, we should explicitly specify `macos-26-intel`, but I do not see any reason to do so.~ EDIT: i apparently missed the actual change.

This also comes with a more recent Apple Clang (21, to be specific).