### PR TITLE
Add homepage to metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
-homepage = "https://lfenergy.org/projects/power-grid-model/"
 
 [dependency-groups]
 
@@ -72,7 +71,7 @@ doc = [
 ]
 
 [project.urls]
-Home-page = "https://lfenergy.org/projects/power-grid-model/"
+homepage = "https://lfenergy.org/projects/power-grid-model/"
 GitHub = "https://github.com/PowerGridModel/power-grid-model"
 Documentation = "https://power-grid-model.readthedocs.io/en/stable/"
 Mailing-list = "https://lists.lfenergy.org/g/powergridmodel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
+homepage = "https://lfenergy.org/projects/power-grid-model/"
 
 [dependency-groups]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ doc = [
 ]
 
 [project.urls]
-homepage = "https://lfenergy.org/projects/power-grid-model/"
+Homepage = "https://lfenergy.org/projects/power-grid-model/"
 GitHub = "https://github.com/PowerGridModel/power-grid-model"
 Documentation = "https://power-grid-model.readthedocs.io/en/stable/"
 Mailing-list = "https://lists.lfenergy.org/g/powergridmodel"


### PR DESCRIPTION
Our page: https://pypistats.com/packages/power-grid-model
Comparison: https://pypistats.com/packages/numpy

Adding homepage seems like an easy win

https://pypistats.com/guide

> Metadata (0–22/25)
Equal points for each of: summary, author, license, homepage, and latest version. Well-maintained packages tend to have complete metadata.

Okay to close if not appropriate. 