### PR TITLE
Reproducible build: fix MSVC build reproducibility

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,7 +32,7 @@
     {
       "name": "release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Release"
       },
       "hidden": true
     },
@@ -40,6 +40,13 @@
       "name": "debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "hidden": true
+    },
+    {
+      "name": "relwithdebinfo",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },
       "hidden": true
     },
@@ -145,7 +152,7 @@
     {
       "name": "msvc-release",
       "displayName": "Release (MSVC)",
-      "inherits": ["msvc-base", "release"]
+      "inherits": ["msvc-base", "relwithdebinfo"]
     },
     {
       "name": "clang-cl-debug",
@@ -155,7 +162,7 @@
     {
       "name": "clang-cl-release",
       "displayName": "Release (Clang CL)",
-      "inherits": ["clang-cl-base", "release"]
+      "inherits": ["clang-cl-base", "relwithdebinfo"]
     },
     {
       "name": "clang-base",
@@ -172,7 +179,7 @@
     },
     {
       "name": "clang-release",
-      "inherits": ["release", "clang-base"]
+      "inherits": ["relwithdebinfo", "clang-base"]
     },
     {
       "name": "clang-tidy-debug",
@@ -180,7 +187,7 @@
     },
     {
       "name": "clang-tidy-release",
-      "inherits": ["release", "clang-tidy-unix-base"]
+      "inherits": ["relwithdebinfo", "clang-tidy-unix-base"]
     },
     {
       "name": "clang-tidy-windows-debug",
@@ -190,7 +197,7 @@
     {
       "name": "clang-tidy-windows-release",
       "displayName": "Release (Clang CL + Clang Tidy)",
-      "inherits": ["release", "clang-tidy-windows-base"]
+      "inherits": ["relwithdebinfo", "clang-tidy-windows-base"]
     },
     {
       "name": "gcc-base",
@@ -210,7 +217,7 @@
     },
     {
       "name": "gcc-release",
-      "inherits": ["release", "gcc-base"]
+      "inherits": ["relwithdebinfo", "gcc-base"]
     },
     {
       "name": "ci-clang-debug",
@@ -254,18 +261,18 @@
     },
     {
       "name": "ci-msvc-reproducible",
-      "inherits": "msvc-release",
+      "inherits": ["msvc-base", "release"],
       "environment": {
         "REPRODUCIBILITY_COMMON_FLAGS": "/d1nodatetime /experimental:deterministic"
       },
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
-        "CMAKE_SHARED_LINKER_FLAGS": "/Brepro /INCREMENTAL:NO"
+        "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /LTCG /NOCOFFGRPINFO"
       }
     },
     {
       "name": "ci-clang-cl-reproducible",
-      "inherits": "clang-cl-release",
+      "inherits": ["clang-cl-base", "release"],
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
         "CMAKE_SHARED_LINKER_FLAGS": "/Brepro /INCREMENTAL:NO"
@@ -273,7 +280,7 @@
     },
     {
       "name": "ci-gcc-reproducible",
-      "inherits": "gcc-release",
+      "inherits": ["gcc-base", "release"],
       "environment": {
         "REPRODUCIBILITY_COMMON_FLAGS": "$penv{REPRODUCIBILITY_COMMON_FLAGS} -frandom-seed=0 -Wdate-time"
       },
@@ -283,7 +290,7 @@
     },
     {
       "name": "ci-clang-reproducible",
-      "inherits": "clang-release",
+      "inherits": ["clang-base", "release"],
       "environment": {
         "REPRODUCIBILITY_COMMON_FLAGS": "$penv{REPRODUCIBILITY_COMMON_FLAGS} -frandom-seed=0 -Wdate-time"
       },


### PR DESCRIPTION
The MSVC build reproducibility failed recently (see e.g. https://github.com/PowerGridModel/power-grid-model/actions/runs/26438097171/job/77825539883)

The underlying reason seems to be related to a couple things related to the debug directories: (tested using `dumpbin /HEADERS <first> <second>` and also with a full check using `dumpbin /ALL <first> <second>`)

## Changes in this PR

* For the reproducibile build check, migrated from `RelWithDebInfo` to `Release` to get rid of more debug symbols
  * NOTE: THIS MAY CAUSE `CMakeUserPresets.json` TO BREAK FOR SOME DEVELOPERS
* set `/debug:None` to force `Debug Directories` to be reproducible (creates a `None` string instead)
* set `/NOCOFFGRPINFO` to remove the `COFFGRP` directory from the `Debug Directories`
* set `/LTCG` to disable the default fast linking code generation (which is not fully disabled by disabling incremental build)

## Test case
### First
```
  Debug Directories

        Time Type        Size      RVA  Pointer
    -------- ------- -------- -------- --------
    E39168F9 cv            79 006D2934   6D1934    Format: RSDS, {9310574C-CE7A-FD1A-032B-721FC6B9EABA}, 1, D:\a\power-grid-model\power-grid-model\cpp_build\ci-msvc-reproducible\bin\power_grid_model_c.pdb
    E39168F9 feat          14 006D29B0   6D19B0    Counts: Pre-VC++ 11.00=0, C/C++=46, /GS=46, /sdl=0, guardN=37
    E39168F9 coffgrp      33C 006D29C4   6D19C4    4C544347 (LTCG)
    E39168F9 repro         24 006D2D00   6D1D00    4C 57 10 93 7A CE 1A FD 03 2B 72 1F C6 B9 EA BA 4A 7A A3 30 4A 32 40 08 69 87 BA 73 F9 68 91 E3
```

### Second
```
  Debug Directories

        Time Type        Size      RVA  Pointer
    -------- ------- -------- -------- --------
    63B9CD42 cv            79 006D2934   6D1934    Format: RSDS, {EFB674F5-E861-8C49-023F-F88F6283BE43}, 1, D:\a\power-grid-model\power-grid-model\cpp_build\ci-msvc-reproducible\bin\power_grid_model_c.pdb
    63B9CD42 feat          14 006D29B0   6D19B0    Counts: Pre-VC++ 11.00=0, C/C++=46, /GS=46, /sdl=0, guardN=37
    63B9CD42 coffgrp      33C 006D29C4   6D19C4    4C544347 (LTCG)
    63B9CD42 repro         24 006D2D00   6D1D00    F5 74 B6 EF 61 E8 49 8C 02 3F F8 8F 62 83 BE 43 38 26 9D 50 D9 1F FE D0 12 2D 4E 50 42 CD B9 63
```

## After this PR
```
  Debug Directories

        Time Type        Size      RVA  Pointer
    -------- ------- -------- -------- --------
    B825E477 repro         24 001A4F88   1A3788    1C DE 69 56 F8 9A 0F D4 97 D4 4E 6C 8E FB C9 E8 D5 EE C8 3A 4B 86 E4 CB 3D 0B F0 35 77 E4 25 B8
```

where the pointer and bytes are both consistent across multiple builds

## To test

* [x] re-run the reproducible build action multiple times (once may not be not be sufficient)
  * [x] first: https://github.com/PowerGridModel/power-grid-model/actions/runs/26443450525
  * [x] second: https://github.com/PowerGridModel/power-grid-model/actions/runs/26444002791
* [x] download the MSVC reproducible build artifacts and compare across multiple runs: all are identical (comparing using `dumpbin /ALL <first> <second>`)