### PR TITLE
Clarify columnar data in docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,6 +55,11 @@ node[AttributeType.u_rated] = [10.5e3, 10.5e3]
 
 The code above generates a node input array with two nodes, and assigns the attributes of the nodes to the array.
 A dictionary of such arrays is used for `input_data` and `update_data`.
+This row based format is the most common way to start, but the same dataset can also use a columnar format where each
+component maps to a dictionary of attribute arrays.
+Columnar data can be useful when a component has many optional attributes, for example in large batch calculations.
+See [Dataset Terminology](user_manual/dataset-terminology.md#data-structures) and
+[Native Data Interface](advanced_documentation/native-data-interface.md#columnar-data-format) for details.
 
 ```python
 # line

--- a/docs/user_manual/dataset-terminology.md
+++ b/docs/user_manual/dataset-terminology.md
@@ -91,6 +91,8 @@ graph TD
         flattened over all batches.
   - **{py:class}`ColumnarData <power_grid_model.data_types.ColumnarData>`:** A dictionary of attributes as keys and
     individual numpy arrays as values.
+    This format is described in more detail in
+    [Native Data Interface](../advanced_documentation/native-data-interface.md#columnar-data-format).
     - **{py:class}`SingleColumnarData <power_grid_model.data_types.SingleColumnarData>`:** A dictionary of attributes as
       keys and `SingleColumn` as values in a single dataset.
     - **{py:class}`BatchColumnarData <power_grid_model.data_types.BatchColumnarData>`:** Multiple batches of data can be


### PR DESCRIPTION
Relates to #1382

### Changes proposed in this PR include

- Mention columnar data directly in the quick start after the first row-based `input_data` example
- Link readers to the dataset terminology and native data interface sections where columnar data is explained
- Add a cross-reference from `ColumnarData` in the dataset terminology page to the detailed native data interface section

### Could you please pay extra attention to the points below when reviewing the PR

- Whether the quick start wording introduces columnar data at the right level without distracting from the row-based beginner path

### Checks

- [ ] If changes are related to CI/CD, are they verified via a manual run on this branch?
- [ ] Do you wish to discuss this PR in the bi monthly community meeting?

Validation: checked the new documentation links and anchors locally.
