### PR TITLE
Reproducible build: Address fail at action 665

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -267,6 +267,7 @@
       },
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF",
         "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /NOCOFFGRPINFO"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -267,7 +267,7 @@
       },
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
-        "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /LTCG /NOCOFFGRPINFO"
+        "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /NOCOFFGRPINFO"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -268,7 +268,7 @@
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF",
-        "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /NOCOFFGRPINFO"
+        "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /LTCG /NOCOFFGRPINFO"
       }
     },
     {


### PR DESCRIPTION
Manual run: 
https://github.com/PowerGridModel/power-grid-model/actions/runs/26764227321
https://github.com/PowerGridModel/power-grid-model/actions/runs/26802385103

We added /LTCG in https://github.com/PowerGridModel/power-grid-model/pull/1407. This option replaces the default fast linking code generation. However LTCG itself is not deterministic. Searched around and maybe this option works to disable this optimization. Although i am still not sure if this makes the optimization deterministic enough or not. Hence we might bump into similar issues later. 

<img width="2635" height="220" alt="image" src="https://github.com/user-attachments/assets/7bb56224-e4d0-45a9-8d9c-64a2a96aea91" />
