### PR TITLE
Node injection sensor deprecation: suppress deprecation warnings in data validator + tests

### DIFF
--- a/src/power_grid_model/validation/_validation.py
+++ b/src/power_grid_model/validation/_validation.py
@@ -10,6 +10,7 @@ Although all functions are 'public', you probably only need validate_input_data(
 """
 
 import copy
+import warnings
 from collections.abc import Sized as ABCSized
 from itertools import chain
 from typing import Literal
@@ -1303,13 +1304,15 @@ def validate_generic_power_sensor(data: SingleDataset, component: CT) -> list[Va
         ref_components=CT.three_winding_transformer,
         measured_terminal_type=MeasuredTerminalType.branch3_3,
     )
-    errors += _all_valid_ids(
-        data,
-        component,
-        field=AT.measured_object,
-        ref_components=CT.node,
-        measured_terminal_type=MeasuredTerminalType.node,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        errors += _all_valid_ids(
+            data,
+            component,
+            field=AT.measured_object,
+            ref_components=CT.node,
+            measured_terminal_type=MeasuredTerminalType.node,
+        )
     if component in (CT.sym_power_sensor, CT.asym_power_sensor):
         errors += _valid_p_q_sigma(data, component)
 

--- a/tests/unit/validation/test_validation_functions.py
+++ b/tests/unit/validation/test_validation_functions.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import copy
+import warnings
 from itertools import product
 from typing import cast
 from unittest.mock import ANY, MagicMock, patch
@@ -869,6 +870,12 @@ def test_validate_generic_power_sensor__all_terminal_types(
     )
 
 
+def _deprecated_measured_terminal_type_node():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return MeasuredTerminalType.node
+
+
 @pytest.mark.parametrize(
     ("ref_component", "measured_terminal_type"),
     [
@@ -887,7 +894,7 @@ def test_validate_generic_power_sensor__all_terminal_types(
         (CT.three_winding_transformer, MeasuredTerminalType.branch3_1),
         (CT.three_winding_transformer, MeasuredTerminalType.branch3_2),
         (CT.three_winding_transformer, MeasuredTerminalType.branch3_3),
-        (CT.node, MeasuredTerminalType.node),
+        (CT.node, _deprecated_measured_terminal_type_node()),
     ],
 )
 @patch("power_grid_model.validation._validation.validate_base", new=MagicMock())
@@ -957,7 +964,7 @@ def test_validate_generic_current_sensor__all_terminal_types(
         (MeasuredTerminalType.shunt, False),
         (MeasuredTerminalType.load, False),
         (MeasuredTerminalType.generator, False),
-        (MeasuredTerminalType.node, False),
+        (_deprecated_measured_terminal_type_node(), False),
     ],
 )
 @patch("power_grid_model.validation._validation._all_greater_than_zero", new=MagicMock(return_value=[]))


### PR DESCRIPTION
Relates to #1334 

In #1384, node injection sensor types were marked as deprecated. However, this caused users to get deprecation warnings if they run the data validator, even if they themselves did not use node injection sensors, because the data validator internally checks for `MeasuredTerminalType.node`. Similarly, running `pytest` also resulted in a multitude of deprecation warnings.

This PR fixes both.