### PR TITLE
Reproducible build: Failing again at action 667 and 669 nightly

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
       "binaryDir": "${sourceDir}/cpp_build/${presetName}",
       "installDir": "${sourceDir}/install/${presetName}",
       "cacheVariables": {
-        "PGM_ENABLE_DEV_BUILD": "ON"
+        "PGM_ENABLE_DEV_BUILD": "ON",
+        "PGM_MSVC_REPRODUCIBLE_BUILD": "OFF"
       },
       "environment": {
         "PLATFORM_C_FLAGS": "",
@@ -267,6 +268,7 @@
       },
       "cacheVariables": {
         "PGM_ENABLE_DEV_BUILD": "OFF",
+        "PGM_MSVC_REPRODUCIBLE_BUILD": "ON",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF",
         "CMAKE_SHARED_LINKER_FLAGS": "/debug:None /Brepro /INCREMENTAL:NO /LTCG /NOCOFFGRPINFO"
       }

--- a/power_grid_model_c/power_grid_model_c/CMakeLists.txt
+++ b/power_grid_model_c/power_grid_model_c/CMakeLists.txt
@@ -31,7 +31,10 @@ file(
 
 target_link_libraries(power_grid_model_c PRIVATE power_grid_model)
 
-target_compile_definitions(power_grid_model_c PRIVATE PGM_VERSION="${PGM_VERSION}")
+target_compile_definitions(
+    power_grid_model_c
+    PRIVATE PGM_VERSION="${PGM_VERSION}"
+)
 
 target_sources(
     power_grid_model_c
@@ -44,12 +47,17 @@ target_sources(
 
 set_target_properties(
     power_grid_model_c
-    PROPERTIES
-        VERSION ${PGM_VERSION}
-        SOVERSION ${PGM_VERSION_MAJOR}
-        INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
-        INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
+    PROPERTIES VERSION ${PGM_VERSION} SOVERSION ${PGM_VERSION_MAJOR}
 )
+
+if(NOT PGM_MSVC_REPRODUCIBLE_BUILD)
+    set_target_properties(
+        power_grid_model_c
+        PROPERTIES
+            INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
+            INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
+    )
+endif()
 
 install(
     TARGETS power_grid_model_c


### PR DESCRIPTION
The reproducibility build has still not been fixed. I suspect these options would reenable the interprocedural optimisation. Hence disabling it specifically for reproducible builds

Failed at nightly-s 667, 669, 673, 674

Manual runs:
https://github.com/PowerGridModel/power-grid-model/actions/runs/26874783996
https://github.com/PowerGridModel/power-grid-model/actions/runs/26873653208