### PR TITLE
Throw errors when the matrix is scalar sparse

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -251,8 +251,10 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
         capturing::into_the_void(data, block_perm_array); // prevent compiler from complaining about unused variables
         if constexpr (!is_block) {
             throw SparseMatrixError{};
-        } else if (has_pivot_perturbation_) {
-            throw SparseMatrixError{};
+        } else {
+            if (has_pivot_perturbation_) {
+                throw SparseMatrixError{};
+            }
         }
     }
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -251,8 +251,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
         capturing::into_the_void(data, block_perm_array); // prevent compiler from complaining about unused variables
         if constexpr (!is_block) {
             throw SparseMatrixError{};
-        }
-        if (has_pivot_perturbation_) {
+        } else if (has_pivot_perturbation_) {
             throw SparseMatrixError{};
         }
     }

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -234,7 +234,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
 
     // solve with existing pre-factorization
     void
-    solve_with_prefactorized_matrix(std::vector<Tensor> const& data,        // pre-factoirzed data, const ref
+    solve_with_prefactorized_matrix(std::vector<Tensor> const& data,        // pre-factorized data, const ref
                                     BlockPermArray const& block_perm_array, // pre-calculated permutation, const ref
                                     std::vector<RHSVector> const& rhs, std::vector<XVector>& x) {
         if (has_pivot_perturbation_) {
@@ -398,7 +398,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
                 //       A(l_row, u_col) = A(l_row, u_col) - l * U(pivot_row_col, u_col),
                 //          for u_col > pivot_row_col
                 // it can create fill-ins, but the fill-ins are pre-allocated
-                // it is garanteed to have an entry at (l_row, u_col), if (pivot_row_col, u_col) is non-zero
+                // it is guaranteed to have an entry at (l_row, u_col), if (pivot_row_col, u_col) is non-zero
                 // starting A index from (l_row, pivot_row_col)
                 Idx a_idx = l_idx;
                 // loop all columns in the right of (pivot_row_col, pivot_row_col), at pivot_row
@@ -442,7 +442,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
     std::optional<std::vector<RHSVector>> residual_;
     std::optional<std::vector<RHSVector>> rhs_;
 
-    void solve_with_refinement(std::vector<Tensor> const& data,        // pre-factoirzed data, const ref
+    void solve_with_refinement(std::vector<Tensor> const& data,        // pre-factorized data, const ref
                                BlockPermArray const& block_perm_array, // pre-calculated permutation, const ref
                                std::vector<RHSVector> const& rhs, std::vector<XVector>& x) {
         // initialize refinement
@@ -585,7 +585,7 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
         original_matrix_.reset();
     }
 
-    void solve_once(std::vector<Tensor> const& data,        // pre-factoirzed data, const ref
+    void solve_once(std::vector<Tensor> const& data,        // pre-factorized data, const ref
                     BlockPermArray const& block_perm_array, // pre-calculated permutation, const ref
                     std::vector<RHSVector> const& rhs, std::vector<XVector>& x) const {
         // local reference

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp
@@ -249,6 +249,9 @@ template <class Tensor, class RHSVector, class XVector> class SparseLUSolver {
         BlockPermArray const& block_perm_array // pre-calculated permutation, const ref
     ) const {
         capturing::into_the_void(data, block_perm_array); // prevent compiler from complaining about unused variables
+        if constexpr (!is_block) {
+            throw SparseMatrixError{};
+        }
         if (has_pivot_perturbation_) {
             throw SparseMatrixError{};
         }

--- a/tests/cpp_unit_tests/test_sparse_lu_solver.cpp
+++ b/tests/cpp_unit_tests/test_sparse_lu_solver.cpp
@@ -84,6 +84,12 @@ TEST_CASE("Test Sparse LU solver") {
             solver.solve_with_prefactorized_matrix((std::vector<double> const&)data, block_perm, rhs, x);
             check_result(x, x_ref);
         }
+        // our use case only need selective inversion for block sparse matrices
+        SUBCASE("Selective inversion error with scalar sparse matrix") {
+            solver.prefactorize(data, block_perm);
+            CHECK_THROWS_AS(solver.inplace_selective_inverse_with_prefactorized_matrix(data, block_perm),
+                            SparseMatrixError);
+        }
 
         SUBCASE("Data is prefactorized by solve") {
             auto prefactorized_data = data;


### PR DESCRIPTION

Context:
Relates to https://github.com/PowerGridModel/power-grid-model/issues/78. Selective inverse is a component for the Uncertainty Quantification of State Estimation. We add a check for scalar sparse matrix in selective inverse, as well as a corresponding unit test.

Motivation:
Our state estimation and its uncertainty quantification methods only involve block sparse matrices. Therefore, we do not need selective inverse for scalar sparse matrices.

Changes proposed in this PR include
1. Throw error when a scalar sparse matrix is received in selective inverse, in [sparse_lu_solver.hpp](https://github.com/PowerGridModel/power-grid-model/blob/main/power_grid_model_c/power_grid_model/include/power_grid_model/math_solver/sparse_lu_solver.hpp);
2. Add a unit test for rejecting selective inversion when the matrix is scalar sparse, in [test_sparse_lu_solver.cpp](https://github.com/PowerGridModel/power-grid-model/blob/b54dd572c06773076062cf6dfc9f912c438fe940/tests/cpp_unit_tests/test_sparse_lu_solver.cpp#L4).

