### PR TITLE
Node injection sensor deprecation: future behavior if experimental

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model.hpp
@@ -111,6 +111,10 @@ class MainModel {
         impl().check_no_experimental_features_used(options, batch_dataset);
     }
 
+    void check_no_future_deprecations(Options const& options, ConstDataset const* batch_dataset) const {
+        impl().check_no_future_deprecations(options, batch_dataset);
+    }
+
   private:
     Impl& impl() {
         assert(impl_ != nullptr);

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -409,6 +409,18 @@ class MainModelImpl {
         }
     }
 
+    void check_no_future_deprecations(Options const& /*options*/, ConstDataset const* /*batch_dataset*/) const {
+        ModelType::run_functor_with_all_component_types_return_void([this]<typename CT>() {
+            if constexpr (requires(CT c) { c.get_terminal_type(); }) {
+                if (std::ranges::any_of(state_.components.template citer<CT>(), [](auto const& sensor) {
+                        return sensor.get_terminal_type() == MeasuredTerminalType::node;
+                    })) {
+                    throw InvalidMeasuredTerminalType{MeasuredTerminalType::node, CT::name};
+                }
+            }
+        });
+    }
+
   private:
     template <solver_output_type SolverOutputType>
     void output_result(MathOutput<std::vector<SolverOutputType>> const& math_output, MutableDataset const& result_data,

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -413,8 +413,8 @@ class MainModelImpl {
         ModelType::run_functor_with_all_component_types_return_void([this]<typename CT>() {
             // only flow sensors have get_terminal_type() so we can filter on it
             if constexpr (requires(CT c) {
-                { c.get_terminal_type() } -> std::same_as<MeasuredTerminalType>;
-            }) {
+                              { c.get_terminal_type() } -> std::same_as<MeasuredTerminalType>;
+                          }) {
                 if (std::ranges::any_of(state_.components.template citer<CT>(), [](auto const& sensor) {
                         return sensor.get_terminal_type() == MeasuredTerminalType::node;
                     })) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -412,7 +412,9 @@ class MainModelImpl {
     void check_no_future_deprecations(Options const& /*options*/, ConstDataset const* /*batch_dataset*/) const {
         ModelType::run_functor_with_all_component_types_return_void([this]<typename CT>() {
             // only flow sensors have get_terminal_type() so we can filter on it
-            if constexpr (requires(CT c) { { c.get_terminal_type() } -> std::same_as<MeasuredTerminalType>; }) {
+            if constexpr (requires(CT c) {
+                { c.get_terminal_type() } -> std::same_as<MeasuredTerminalType>;
+            }) {
                 if (std::ranges::any_of(state_.components.template citer<CT>(), [](auto const& sensor) {
                         return sensor.get_terminal_type() == MeasuredTerminalType::node;
                     })) {

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_model_impl.hpp
@@ -411,7 +411,8 @@ class MainModelImpl {
 
     void check_no_future_deprecations(Options const& /*options*/, ConstDataset const* /*batch_dataset*/) const {
         ModelType::run_functor_with_all_component_types_return_void([this]<typename CT>() {
-            if constexpr (requires(CT c) { c.get_terminal_type(); }) {
+            // only flow sensors have get_terminal_type() so we can filter on it
+            if constexpr (requires(CT c) { { c.get_terminal_type() } -> std::same_as<MeasuredTerminalType>; }) {
                 if (std::ranges::any_of(state_.components.template citer<CT>(), [](auto const& sensor) {
                         return sensor.get_terminal_type() == MeasuredTerminalType::node;
                     })) {

--- a/power_grid_model_c/power_grid_model_c/CMakeLists.txt
+++ b/power_grid_model_c/power_grid_model_c/CMakeLists.txt
@@ -31,7 +31,10 @@ file(
 
 target_link_libraries(power_grid_model_c PRIVATE power_grid_model)
 
-target_compile_definitions(power_grid_model_c PRIVATE PGM_VERSION="${PGM_VERSION}")
+target_compile_definitions(
+    power_grid_model_c
+    PRIVATE PGM_VERSION="${PGM_VERSION}"
+)
 
 target_sources(
     power_grid_model_c

--- a/power_grid_model_c/power_grid_model_c/src/model.cpp
+++ b/power_grid_model_c/power_grid_model_c/src/model.cpp
@@ -83,6 +83,28 @@ void check_no_experimental_features_used(MainModel const& model, MainModel::Opti
     model.check_no_experimental_features_used(opt, batch_dataset);
 }
 
+void check_no_future_deprecations(MainModel const& model, MainModel::Options const& opt,
+                                  ConstDataset const* batch_dataset) {
+    // optionally add deprecation checks here
+    using namespace std::string_literals;
+
+    model.check_no_future_deprecations(opt, batch_dataset);
+}
+
+void check_experimental_support(Idx experimental_features, MainModel const& model, MainModel::Options const& opt,
+                                ConstDataset const* batch_dataset) {
+    switch (experimental_features) {
+    case PGM_experimental_features_disabled:
+        check_no_experimental_features_used(model, opt, batch_dataset);
+        break;
+    case PGM_experimental_features_enabled:
+        check_no_future_deprecations(model, opt, batch_dataset);
+        break;
+    default:
+        throw MissingCaseForEnumError{"calculate_impl", experimental_features};
+    }
+}
+
 void check_calculate_valid_options(PGM_Options const& opt) {
     if (opt.tap_changing_strategy != PGM_tap_changing_strategy_disabled && opt.calculation_type != PGM_power_flow) {
         // illegal combination of options
@@ -315,9 +337,7 @@ void calculate_impl(MainModel& model, PGM_Options const& options, MutableDataset
     check_calculate_valid_options(options);
     auto const extracted_options = extract_calculation_options(options);
 
-    if (options.experimental_features == PGM_experimental_features_disabled) {
-        check_no_experimental_features_used(model, extracted_options, batch_dataset);
-    }
+    check_experimental_support(options.experimental_features, model, extracted_options, batch_dataset);
 
     calculate_multi_dimensional_impl(model, extracted_options, output_dataset, batch_dataset);
 }

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/input.json
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/input.json
@@ -1,0 +1,58 @@
+{
+  "version": "1.0",
+  "type": "input",
+  "is_batch": false,
+  "attributes": {},
+  "data": {
+    "node": [
+      {
+        "id": 1,
+        "u_rated": 100.0
+      },
+      {
+        "id": 2,
+        "u_rated": 100.0
+      }
+    ],
+    "line": [
+      {
+        "id": 4,
+        "from_node": 1,
+        "to_node": 2,
+        "from_status": 1,
+        "to_status": 1,
+        "r1": 0.1,
+        "x1": 0.0,
+        "c1": 0.0,
+        "tan1": 0.0,
+        "i_n": 1000.0
+      }
+    ],
+    "source": [
+      {
+        "id": 6,
+        "node": 1,
+        "status": 1,
+        "u_ref": 1.0
+      }
+    ],
+    "sym_voltage_sensor": [
+      {
+        "id": 101,
+        "measured_object": 1,
+        "u_measured": 100.0,
+        "u_sigma": 1.0
+      }
+    ],
+    "sym_power_sensor": [
+      {
+        "id": 401,
+        "measured_object": 2,
+        "measured_terminal_type": 9,
+        "p_measured": 100e3,
+        "q_measured": 100e3,
+        "power_sigma": 1e3
+      }
+    ]
+  }
+}

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/input.json.license
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/input.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/params.json
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/params.json
@@ -1,0 +1,10 @@
+{
+  "calculation_method": ["iterative_linear", "newton_raphson"],
+  "rtol": 1e-8,
+  "atol": 1e-8,
+  "experimental_features": "enabled",
+  "raises": {
+    "raises": "InvalidMeasuredObject",
+    "reason": "Node injection sensors are no longer supported starting with version 2.0."
+  }
+}

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/params.json.license
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/params.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/sym_output.json
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/sym_output.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "type": "sym_output",
+  "is_batch": false,
+  "attributes": {},
+  "data": {}
+}

--- a/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/sym_output.json.license
+++ b/tests/data/state_estimation/node-injection-sensor-and-zero-injection-deprecated/sym_output.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
Part of #1334 

Add future behavior for deprecation of node injection sensor as an experimental feature.
This is a step towards introducing a feature toggle for merging nodes on links, but it **does not yet introduce** the feature toggle.