### PR TITLE
Remove Redundant Overload

### DIFF
--- a/src/power_grid_model/_core/power_grid_model.py
+++ b/src/power_grid_model/_core/power_grid_model.py
@@ -478,20 +478,6 @@ class PowerGridModel:
         error_tolerance: float = ...,
         max_iterations: int = ...,
         calculation_method: CalculationMethod | str = ...,
-        threading: int = ...,
-        output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,
-        continue_on_batch_error: bool = ...,
-        decode_error: bool = ...,
-        tap_changing_strategy: TapChangingStrategy | str = ...,
-    ) -> SingleRowBasedDataset: ...
-    @overload
-    def calculate_power_flow(
-        self,
-        *,
-        symmetric: bool = ...,
-        error_tolerance: float = ...,
-        max_iterations: int = ...,
-        calculation_method: CalculationMethod | str = ...,
         update_data: None = ...,
         threading: int = ...,
         output_component_types: None | set[ComponentTypeVar] | list[ComponentTypeVar] = ...,


### PR DESCRIPTION
The `calculate_power_flow()` overloads at line 473 and 487 both are similar except that the second one has argument `update_data: None = ...,`, while the first one omits it. However, the `update_data: None = ...,` covers the case of not passing the `update_data` at all.


Reference to the comment https://github.com/PowerGridModel/power-grid-model/pull/1178#discussion_r3411489945
- [x] IDE Autocomplete working
- [x] mypy run passed