### PR TITLE
Move release step outside to ci

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -8,19 +8,10 @@ name: Build and Test C++ and Python
 on:
   # run pipeline from another workflow
   workflow_call:
-    inputs:
-      create_release:
-        type: boolean
-        description: Create a (pre-)release when CI passes
-        required: true
+
   # run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-      create_release:
-        type: boolean
-        description: Create a (pre-)release when CI passes
-        default: false
-        required: true
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-main
@@ -288,59 +279,3 @@ jobs:
 
       - name: Test
         run: pytest
-
-  github-release:
-    name: Create and release assets to GitHub
-    needs:
-      [
-        build-cpp-test-linux,
-        build-cpp-test-windows,
-        build-cpp-test-macos,
-        build-and-test-python,
-        build-and-test-conda,
-      ]
-    if: (inputs.create_release)
-    runs-on: ubuntu-latest
-    environment: release
-
-    steps:
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: version
-          path: .
-
-      - name: Combine wheelhouses
-        run: mv wheelhouse-*/* wheelhouse
-
-      - name: List assets
-        run: ls ./wheelhouse/ -al
-
-      - name: Get tag
-        id: tag
-        run: echo "tag=v$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Display tag
-        run: echo "${{ steps.tag.outputs.tag }}"
-      
-      - name: generate GitHub App token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: generate-token
-        with:
-          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          files: |
-            ./wheelhouse/*
-          tag_name: ${{ steps.tag.outputs.tag }}
-          prerelease: ${{ github.ref != 'refs/heads/main'}}
-          generate_release_notes: true
-          target_commitish: ${{ github.sha }}
-          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,9 @@ jobs:
     # true if the event that triggered this workflow is "workflow_dispatch" and inputs.create_release is true
     # true if the event that triggered this workflow is "push" on main
     # otherwise false
-    # TODO uncomment this once test is done
-    # if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
+    if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
     runs-on: ubuntu-latest
-    # TODO uncomment this once test is done
-    # environment: release
+    environment: release
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,11 @@ jobs:
     # true if the event that triggered this workflow is "workflow_dispatch" and inputs.create_release is true
     # true if the event that triggered this workflow is "push" on main
     # otherwise false
-    if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
+    # TODO uncomment this once test is done
+    # if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
     runs-on: ubuntu-latest
-    environment: release
+    # TODO uncomment this once test is done
+    # environment: release
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,60 @@ jobs:
   build-test-release:
     name: build-test-release
     uses: "./.github/workflows/build-test-release.yml"
+  
+  github-release:
+    name: Create and release assets to GitHub
+    needs: build-test-release
+    
+    # true if the event that triggered this workflow is "workflow_dispatch" and inputs.create_release is true
+    # true if the event that triggered this workflow is "push" on main
+    # otherwise false
+    if: (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: release
 
-    with:
-      # create_release becomes true if the event that triggered this workflow is "workflow_dispatch" and inputs.create_release is true
-      # create_release becomes true if the event that triggered this workflow is "push" on main
-      # otherwise create_release becomes false
-      create_release: ${{ (github.event_name == 'workflow_dispatch' && inputs.create_release) || github.event_name == 'push'}}
+    steps:
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: version
+          path: .
+
+      - name: Combine wheelhouses
+        run: mv wheelhouse-*/* wheelhouse
+
+      - name: List assets
+        run: ls ./wheelhouse/ -al
+
+      - name: Get tag
+        id: tag
+        run: echo "tag=v$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Display tag
+        run: echo "${{ steps.tag.outputs.tag }}"
+      
+      - name: generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          files: |
+            ./wheelhouse/*
+          tag_name: ${{ steps.tag.outputs.tag }}
+          prerelease: ${{ github.ref != 'refs/heads/main'}}
+          generate_release_notes: true
+          target_commitish: ${{ github.sha }}
+          token: ${{ steps.generate-token.outputs.token }}
+
 
   check-code-quality:
     uses: "./.github/workflows/check-code-quality.yml"
@@ -78,7 +126,7 @@ jobs:
     permissions:
       id-token: write # Required for Trusted Publishing
     environment: release
-    needs: build-test-release
+    needs: github-release
     if: (github.event_name == 'workflow_dispatch') || github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
#1445 does not work.

https://github.com/PowerGridModel/power-grid-model/actions/runs/28044882907/job/83026915088

Environment secrets cannot be easily used in reusable workflow.
https://github.com/actions/runner/issues/1490

We need to factor the github release step out. This PR does the minimum adjustment to make it working. The whole CI pipelines need more attention to refactor in a logical way.