### PR TITLE
CI performance: improve clang-format command

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run clang-format
         run: |
-          find . -regex '.*\.\(h\|c\|cpp\|hpp\|cc\|cxx\)' -exec uv run clang-format -style=file -i {} \;
+          git ls-files -z -- *.h *.c *.cpp *.hpp *.cc *.cxx | xargs -0 -r uv run clang-format -style=file -i
 
       - name: Run cmake-linter
         run: |

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run clang-format
         run: |
-          git ls-files -z -- *.h *.c *.cpp *.hpp *.cc *.cxx | xargs -0 -r uv run clang-format -style=file -i
+          git ls-files -z -- '*.h' '*.c' '*.cpp' '*.hpp' '*.cc' '*.cxx' | xargs -0 -r uv run clang-format -style=file -i
 
       - name: Run cmake-linter
         run: |


### PR DESCRIPTION
Recently, the Check Code Quality workflow has taken well over 10 minutes. It was found that the `clang-format` command is the issue. This should not be a bottleneck, as `clang-format` is usually very fast. My expectation is that the bottleneck is the `find` command.

* [x] proof that this branch fixes it:
  * [x] Last nightly: https://github.com/PowerGridModel/power-grid-model/actions/runs/28072315043/job/83109257442 (9m 57s for the `Run clang-format` step)
  * [x] This branch: https://github.com/PowerGridModel/power-grid-model/actions/runs/28080006051/job/83132592549 (2s for the `Run clang-format` step)