### PR TITLE
Docs: explain how to model grid component types not provided by PGM

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ user_manual/data-model
 user_manual/dataset-terminology
 user_manual/components
 user_manual/calculations
+user_manual/non-pgm-components
 user_manual/performance-guide
 user_manual/data-validator
 user_manual/model-validation

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: MPL-2.0
 
 # Components
 
+```{note}
+This document is about components supported by PGM.
+For documentation on modeling grid components not listed here, please refer to [Grid Modeling](./non-pgm-components.md).
+```
+
 The attributes of components are listed below.
 
 ## Base
@@ -166,6 +171,9 @@ It has a very high admittance (small impedance) which is set to a fixed per-unit
 10kV network).
 Therefore, it is chosen by design that no sensors can be coupled to a `link`.
 There is no additional attribute for `link`.
+
+It is explicitly allowed to connect a link between nodes with different voltage levels to allow modeling
+[ideal transformers](./non-pgm-components.md#ideal-transformer).
 
 #### Electric Model
 
@@ -1321,3 +1329,9 @@ $$
 
 In this case, `limit_violated` will indicate which limit was exceeded, and the actual voltage at the node may differ
 from `u_ref`.
+
+## Other components
+
+The list of components explicitly supported by the power-grid-model is a subset of all possible power system components.
+If you did not find the component you're trying to model, you may find what you are looking for
+in [Grid Modeling](./non-pgm-components.md).

--- a/docs/user_manual/non-pgm-components.md
+++ b/docs/user_manual/non-pgm-components.md
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Grid Component Modeling
+
+```{note}
+This document is about components not explicitly supported by PGM that can still be modeled using PGM components.
+For documentation on the components supported by PGM, please refer to [Components](./components.md).
+```
+
+The power grid consists of many different component types and the list is ever-increasing.
+As a result, it would be an impossible task to make the list of components supported by PGM exhaustive.
+Moreover, many grid component types share electrical attributes, so that one such grid component may be modeled as
+another.
+This document contains a non-exhaustive list of such modeling examples.
+New contributions and ideas for modeling grid components are very welcome!
+
+## Ideal transformer
+
+An ideal transformer can be modeled as a [link](./components.md#link). <!-- markdownlint-disable-line descriptive-link-text line-length -->
+To this end, it is explicitly allowed to place a link between two different voltage levels.
+Trivially, no additional electrical parameters need to be specified.
+
+```{note}
+The [transformer](./components.md#transformer) component as provided by the PGM models a real transformer in the grid,
+i.e., with finite impedance.
+This directly conflicts with the properties of an ideal transformer, so the PGM
+[transformer](./components.md#transformer) cannot be used to model ideal transformers.
+```
+
+## Grounding transformer
+
+A grounding transformer (a.k.a. earthing transformer) can be modeled as a [shunt](./components.md#shunt) with only
+zero-sequence parameters (and positive-sequence parameters set to $0$).
+In particular, a grounding transformer with resistance $r$ and reactance $x$ can be modeled as follows.
+
+$$
+\begin{aligned}
+g_1 &= 0 \\
+b_1 &= 0 \\
+g_0 &= \Re\left\{\frac{1}{r + j x}\right\} \\
+b_0 &= \Im\left\{\frac{1}{r + j x}\right\}
+\end{aligned}
+$$
+
+## Choke coil
+
+A choke coil (a.k.a. reactance coil) can be modeled as a [line](./components.md#line) with its shunt parameters
+(`c1`, `tan1`, `c0`, `tan0`) set to $0$.
+
+```{note}
+A choke coil can also be modeled using a [generic branch](./components.md#generic-branch).
+However, at the time of writing (June 2026; see
+[PGM issue #739](https://github.com/PowerGridModel/power-grid-model/issues/739)), this component does not yet support
+zero-sequence parameters. As a result, asymmetric calculations are not supported, and this model currently only works
+for symmetric calculations.
+```
+
+## Cable
+
+A cable is equivalent to a line.


### PR DESCRIPTION
This documents how to model some of the component types not explicitly provided by PGM:

* [x] Ideal transformer (modeled as link)
* [x] Grounding transformer/earthing transformer (modeled as shunt)
* [x] Choke coil/reactance coil (modeled as line, explicitly referring to #739 regarding as to why the recommendation is to model it as line and not as generic branch)
* [x] Cable (trivially modeled as line)

## Potential extensions

If you want me to, I can also add other components to the list (many of which can be directly taken from PGM-IO: https://github.com/PowerGridModel/power-grid-model-io/blob/main/src/power_grid_model_io/config/excel/vision_en.yaml):

* [ ] Phase shifter transformer (#188)
* [ ] Transformer loads (modeled using a transformer, a node and a load/gen)
* [ ] Synchronous generators (identical to `sym_gen`)
* [ ] Wind turbines (trivially modeled as `sym_gen`)
* [ ] PVs (trivially modeled as `sym_gen`)
* [ ] Capacitor (modeled as shunt)
* [ ] Reactor (modeled as shunt)
* [ ] Single-phase loads (#489 , but notice https://github.com/PowerGridModel/power-grid-model/issues/489#issuecomment-2751247228 which states that this modeling will not work for state estimation, so that would require an explicit `{warning}` statement)
* [ ] Ideal source (this would put the handling on the user-side, rather than internally in PGM as per #733)
* [ ] Compound load (modeled as 3 separate loads representing the individual ZIP components, rather than to implement it internally in PGM as per #168)

or i can create a follow-up ticket with this