### PR TITLE
fix: allow zero mutual asym-line values

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -347,30 +347,30 @@ If the neutral values are not provided, the last row and column from the above m
 | name   | data type | unit       | description                       | required                     |  update  | valid values |
 |--------|-----------|------------|-----------------------------------|------------------------------|:--------:|:------------:|
 | `r_aa` | `double`  | ohm (Ω)    | Series serial resistance aa       | &#10004;                     | &#10060; |    `> 0`     |
-| `r_ba` | `double`  | ohm (Ω)    | Series serial resistance ba       | &#10004;                     | &#10060; |    `> 0`     |
+| `r_ba` | `double`  | ohm (Ω)    | Series serial resistance ba       | &#10004;                     | &#10060; |    `>= 0`    |
 | `r_bb` | `double`  | ohm (Ω)    | Series serial resistance bb       | &#10004;                     | &#10060; |    `> 0`     |
-| `r_ca` | `double`  | ohm (Ω)    | Series serial resistance ca       | &#10004;                     | &#10060; |    `> 0`     |
-| `r_cb` | `double`  | ohm (Ω)    | Series serial resistance cb       | &#10004;                     | &#10060; |    `> 0`     |
+| `r_ca` | `double`  | ohm (Ω)    | Series serial resistance ca       | &#10004;                     | &#10060; |    `>= 0`    |
+| `r_cb` | `double`  | ohm (Ω)    | Series serial resistance cb       | &#10004;                     | &#10060; |    `>= 0`    |
 | `r_cc` | `double`  | ohm (Ω)    | Series serial resistance cc       | &#10004;                     | &#10060; |    `> 0`     |
-| `r_na` | `double`  | ohm (Ω)    | Series serial resistance na       | &#10024; for a neutral phase | &#10060; |    `> 0`     |
-| `r_nb` | `double`  | ohm (Ω)    | Series serial resistance nb       | &#10024; for a neutral phase | &#10060; |    `> 0`     |
-| `r_nc` | `double`  | ohm (Ω)    | Series serial resistance nc       | &#10024; for a neutral phase | &#10060; |    `> 0`     |
+| `r_na` | `double`  | ohm (Ω)    | Series serial resistance na       | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
+| `r_nb` | `double`  | ohm (Ω)    | Series serial resistance nb       | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
+| `r_nc` | `double`  | ohm (Ω)    | Series serial resistance nc       | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
 | `r_nn` | `double`  | ohm (Ω)    | Series serial resistance nn       | &#10024; for a neutral phase | &#10060; |    `> 0`     |
 | `x_aa` | `double`  | ohm (Ω)    | Series serial reactance aa        | &#10004;                     | &#10060; |    `> 0`     |
-| `x_ba` | `double`  | ohm (Ω)    | Series serial reactance ba        | &#10004;                     | &#10060; |    `> 0`     |
+| `x_ba` | `double`  | ohm (Ω)    | Series serial reactance ba        | &#10004;                     | &#10060; |    `>= 0`    |
 | `x_bb` | `double`  | ohm (Ω)    | Series serial reactance bb        | &#10004;                     | &#10060; |    `> 0`     |
-| `x_ca` | `double`  | ohm (Ω)    | Series serial reactance ca        | &#10004;                     | &#10060; |    `> 0`     |
-| `x_cb` | `double`  | ohm (Ω)    | Series serial reactance cb        | &#10004;                     | &#10060; |    `> 0`     |
+| `x_ca` | `double`  | ohm (Ω)    | Series serial reactance ca        | &#10004;                     | &#10060; |    `>= 0`    |
+| `x_cb` | `double`  | ohm (Ω)    | Series serial reactance cb        | &#10004;                     | &#10060; |    `>= 0`    |
 | `x_cc` | `double`  | ohm (Ω)    | Series serial reactance cc        | &#10004;                     | &#10060; |    `> 0`     |
-| `x_na` | `double`  | ohm (Ω)    | Series serial reactance na        | &#10024; for a neutral phase | &#10060; |    `> 0`     |
-| `x_nb` | `double`  | ohm (Ω)    | Series serial reactance nb        | &#10024; for a neutral phase | &#10060; |    `> 0`     |
-| `x_nc` | `double`  | ohm (Ω)    | Series serial reactance nc        | &#10024; for a neutral phase | &#10060; |    `> 0`     |
+| `x_na` | `double`  | ohm (Ω)    | Series serial reactance na        | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
+| `x_nb` | `double`  | ohm (Ω)    | Series serial reactance nb        | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
+| `x_nc` | `double`  | ohm (Ω)    | Series serial reactance nc        | &#10024; for a neutral phase | &#10060; |    `>= 0`    |
 | `x_nn` | `double`  | ohm (Ω)    | Series serial reactance nn        | &#10024; for a neutral phase | &#10060; |    `> 0`     |
 | `c_aa` | `double`  | farad (F)  | Shunt nodal capacitance matrix aa | &#10024; for a full c matrix | &#10060; |    `> 0`     |
-| `c_ba` | `double`  | farad (F)  | Shunt nodal capacitance matrix ba | &#10024; for a full c matrix | &#10060; |    `> 0`     |
+| `c_ba` | `double`  | farad (F)  | Shunt nodal capacitance matrix ba | &#10024; for a full c matrix | &#10060; |    `>= 0`    |
 | `c_bb` | `double`  | farad (F)  | Shunt nodal capacitance matrix bb | &#10024; for a full c matrix | &#10060; |    `> 0`     |
-| `c_ca` | `double`  | farad (F)  | Shunt nodal capacitance matrix ca | &#10024; for a full c matrix | &#10060; |    `> 0`     |
-| `c_cb` | `double`  | farad (F)  | Shunt nodal capacitance matrix cb | &#10024; for a full c matrix | &#10060; |    `> 0`     |
+| `c_ca` | `double`  | farad (F)  | Shunt nodal capacitance matrix ca | &#10024; for a full c matrix | &#10060; |    `>= 0`    |
+| `c_cb` | `double`  | farad (F)  | Shunt nodal capacitance matrix cb | &#10024; for a full c matrix | &#10060; |    `>= 0`    |
 | `c_cc` | `double`  | farad (F)  | Shunt nodal capacitance matrix cc | &#10024; for a full c matrix | &#10060; |    `> 0`     |
 | `c0`   | `double`  | farad (F)  | zero-sequence shunt capacitance   | &#10024; without a c matrix  | &#10060; |    `> 0`     |
 | `c1`   | `double`  | farad (F)  | Series shunt capacitance          | &#10024; without a c matrix  | &#10060; |    `> 0`     |

--- a/src/power_grid_model/validation/_validation.py
+++ b/src/power_grid_model/validation/_validation.py
@@ -643,19 +643,21 @@ def validate_line(data: SingleDataset) -> list[ValidationError]:
 def validate_asym_line(data: SingleDataset) -> list[ValidationError]:
     errors = validate_branch(data, CT.asym_line)
     errors += _all_greater_than_zero(data, CT.asym_line, AT.i_n)
-    required_fields = [
+    required_positive_fields = [
         AT.r_aa,
-        AT.r_ba,
         AT.r_bb,
-        AT.r_ca,
-        AT.r_cb,
         AT.r_cc,
         AT.x_aa,
-        AT.x_ba,
         AT.x_bb,
+        AT.x_cc,
+    ]
+    required_non_negative_fields = [
+        AT.r_ba,
+        AT.r_ca,
+        AT.r_cb,
+        AT.x_ba,
         AT.x_ca,
         AT.x_cb,
-        AT.x_cc,
     ]
     optional_r_matrix_fields = [
         AT.r_na,
@@ -669,19 +671,32 @@ def validate_asym_line(data: SingleDataset) -> list[ValidationError]:
         AT.x_nc,
         AT.x_nn,
     ]
-    required_c_matrix_fields = [
+    required_positive_c_matrix_fields = [
         AT.c_aa,
-        AT.c_ba,
         AT.c_bb,
-        AT.c_ca,
-        AT.c_cb,
         AT.c_cc,
     ]
+    required_non_negative_c_matrix_fields = [
+        AT.c_ba,
+        AT.c_ca,
+        AT.c_cb,
+    ]
+    required_c_matrix_fields = required_positive_c_matrix_fields + required_non_negative_c_matrix_fields
     c_fields = [AT.c0, AT.c1]
     for field in (
-        required_fields + optional_r_matrix_fields + optional_x_matrix_fields + required_c_matrix_fields + c_fields
+        required_positive_fields
+        + [AT.r_nn, AT.x_nn]
+        + required_positive_c_matrix_fields
+        + c_fields
     ):
         errors += _all_greater_than_zero(data, CT.asym_line, field)
+
+    for field in (
+        required_non_negative_fields
+        + [AT.r_na, AT.r_nb, AT.r_nc, AT.x_na, AT.x_nb, AT.x_nc]
+        + required_non_negative_c_matrix_fields
+    ):
+        errors += _all_greater_than_or_equal_to_zero(data, CT.asym_line, field)
 
     errors += _no_strict_subset_missing(data, optional_r_matrix_fields + optional_x_matrix_fields, CT.asym_line)
     errors += _no_strict_subset_missing(data, required_c_matrix_fields, CT.asym_line)

--- a/tests/unit/validation/test_input_validation.py
+++ b/tests/unit/validation/test_input_validation.py
@@ -1111,30 +1111,30 @@ def test_asym_line_input_data(input_data):
     validation_errors = validate_input_data(input_data, symmetric=True)
     assert validation_errors is not None
     assert NotGreaterThanError(CT.asym_line, AT.r_aa, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_ba, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_ba, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.r_bb, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_ca, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_cb, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_ca, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_cb, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.r_cc, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_na, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_nb, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.r_nc, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_na, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_nb, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.r_nc, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.r_nn, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.x_aa, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_ba, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_ba, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.x_bb, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_ca, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_cb, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_ca, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_cb, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.x_cc, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_na, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_nb, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.x_nc, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_na, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_nb, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.x_nc, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.x_nn, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.c_aa, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.c_ba, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.c_ba, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.c_bb, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.c_ca, [55], 0) in validation_errors
-    assert NotGreaterThanError(CT.asym_line, AT.c_cb, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.c_ca, [55], 0) in validation_errors
+    assert NotGreaterOrEqualError(CT.asym_line, AT.c_cb, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.c_cc, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.c0, [55], 0) in validation_errors
     assert NotGreaterThanError(CT.asym_line, AT.c1, [55], 0) in validation_errors
@@ -1187,6 +1187,33 @@ def test_asym_line_input_data(input_data):
         )
         in validation_errors
     )
+
+
+def test_asym_line_input_data__zero_mutual_impedances_are_valid():
+    node = initialize_array(DatasetType.input, CT.node, 2)
+    node[AT.id] = [1, 2]
+    node[AT.u_rated] = [10.5e3, 10.5e3]
+
+    asym_line = initialize_array(DatasetType.input, CT.asym_line, 1)
+    asym_line[AT.id] = [3]
+    asym_line[AT.from_node] = [1]
+    asym_line[AT.to_node] = [2]
+    asym_line[AT.from_status] = [1]
+    asym_line[AT.to_status] = [1]
+    asym_line[AT.i_n] = [50]
+
+    for field in [AT.r_aa, AT.r_bb, AT.r_cc, AT.r_nn, AT.x_aa, AT.x_bb, AT.x_cc, AT.x_nn]:
+        asym_line[field] = [1]
+    for field in [AT.r_ba, AT.r_ca, AT.r_cb, AT.r_na, AT.r_nb, AT.r_nc]:
+        asym_line[field] = [0]
+    for field in [AT.x_ba, AT.x_ca, AT.x_cb, AT.x_na, AT.x_nb, AT.x_nc]:
+        asym_line[field] = [0]
+    for field in [AT.c_aa, AT.c_bb, AT.c_cc]:
+        asym_line[field] = [1e-9]
+    for field in [AT.c_ba, AT.c_ca, AT.c_cb]:
+        asym_line[field] = [0]
+
+    assert_valid_input_data({CT.node: node, CT.asym_line: asym_line})
 
 
 @pytest.mark.parametrize("component_type", CT)


### PR DESCRIPTION
## Summary

- allow zero-valued mutual asym-line resistance/reactance entries while keeping self terms strictly positive
- allow zero-valued mutual asym-line capacitance matrix entries while keeping diagonal capacitance and `c0`/`c1` strictly positive
- update the asym-line component docs and validation tests for the new `>= 0` mutual-field contract

Closes #1460

## Validation

- `python -m py_compile src/power_grid_model/validation/_validation.py tests/unit/validation/test_input_validation.py`
- `git diff --check`
- AST parse of the changed Python files

I also attempted the focused pytest path locally, but this checkout needs the compiled `power_grid_model_c.dll`. A direct source run failed at import with the missing shared library, and an editable install did not get past build dependency setup on this machine after several minutes without output.