### PR TITLE
Branch into itself: make validator + docs accept branches into itself

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -84,7 +84,7 @@ The `p` and `q` output of injection follows the `generator` reference direction 
 * type name: `branch`
 * base: [base](#base)
 
-`branch` is the abstract base type for the component which connects two *different* nodes.
+`branch` is the abstract base type for the component which connects two (possibly identical) nodes.
 For each branch two switches are always defined at from- and to-side of the branch.
 In reality such switches may not exist.
 For example, a cable usually permanently connects two joints.
@@ -460,7 +460,7 @@ Where $Z_{\text{i,j}}$ denotes the row and column of the $Z_{\text{series}}$ mat
 * type name: `branch3`
 * base: [base](#base)
 
-`branch3` is the abstract base type for the component which connects three *different* nodes.
+`branch3` is the abstract base type for the component which connects three (possibly identical) nodes.
 For each branch3 three switches are always defined at side 1, 2, or 3 of the branch.
 In reality such switches may not exist.
 

--- a/src/power_grid_model/validation/_validation.py
+++ b/src/power_grid_model/validation/_validation.py
@@ -626,7 +626,6 @@ def validate_branch(data: SingleDataset, component: CT) -> list[ValidationError]
     errors = validate_base(data, component)
     errors += _all_valid_ids(data, component, AT.from_node, CT.node)
     errors += _all_valid_ids(data, component, AT.to_node, CT.node)
-    errors += _all_not_two_values_equal(data, component, AT.to_node, AT.from_node)
     errors += _all_boolean(data, component, AT.from_status)
     errors += _all_boolean(data, component, AT.to_status)
     return errors


### PR DESCRIPTION
Closes #1418 

* [x] Depends on #1448 , `do-not-merge` label added to reflect this
  * (yes, it is technically independent from it but it if we first review the validation cases, we have evidence that it also works as intended before we officially make it GA)