### PR TITLE
Deserializer: fix deep nesting errors

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/auxiliary/serialization/deserializer.hpp
@@ -119,6 +119,7 @@ struct JsonSAXVisitor {
     static bool binary(json::binary_t const& /* val */) { return true; }
 
     bool start_object(size_t /* elements */) {
+        check_depth();
         data_buffers.emplace();
         return true;
     }
@@ -140,6 +141,7 @@ struct JsonSAXVisitor {
         return true;
     }
     bool start_array(size_t /* elements */) {
+        check_depth();
         data_buffers.emplace();
         return true;
     }
@@ -162,6 +164,12 @@ struct JsonSAXVisitor {
                             ? std::format("{}...[truncated]", last_token.substr(0, max_error_message_token_length))
                             : last_token,
                         ex.what())};
+    }
+
+    void check_depth() const {
+        if (data_buffers.size() > 10) {
+            throw SerializationError{"Json depth exceeds the limit of 10!\n"};
+        }
     }
 
     std::stack<JsonMapArrayData> data_buffers;

--- a/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
+++ b/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
@@ -757,10 +757,8 @@ true}]}]})";
 
     SUBCASE("Deeply nested msgpack") {
         constexpr std::string_view msgpack_invalid =
-            "\x81\xa4"
-            "data"
-            "\x91\x91\x91\x91\x91\x91\x91\x91\x91\x91\x91\x90"sv;
-  
+            "\x{81}\x{a4}data\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{91}\x{90}"sv;
+
         std::vector<NodeInput> node(1);
 
         auto const run = [&]() {

--- a/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
+++ b/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
@@ -749,6 +749,11 @@ true}]}]})";
             check_error(json_invalid, std::format("Last token: {}. Exception message:", full_token_string));
         }
     }
+
+    SUBCASE("Deeply nested json") {
+        constexpr std::string_view json_invalid = R"({"data":[[[[[[[[[[[[]]]]]]]]]]]]})";
+        check_error(json_invalid, "Json depth exceeds the limit of 10!\n");
+    }
 }
 
 } // namespace power_grid_model::meta_data

--- a/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
+++ b/tests/cpp_unit_tests/auxiliary/test_deserializer.cpp
@@ -754,6 +754,23 @@ true}]}]})";
         constexpr std::string_view json_invalid = R"({"data":[[[[[[[[[[[[]]]]]]]]]]]]})";
         check_error(json_invalid, "Json depth exceeds the limit of 10!\n");
     }
+
+    SUBCASE("Deeply nested msgpack") {
+        constexpr std::string_view msgpack_invalid =
+            "\x81\xa4"
+            "data"
+            "\x91\x91\x91\x91\x91\x91\x91\x91\x91\x91\x91\x90"sv;
+  
+        std::vector<NodeInput> node(1);
+
+        auto const run = [&]() {
+            Deserializer deserializer{from_msgpack, msgpack_invalid, meta_data_gen::meta_data};
+            deserializer.get_dataset_info().set_buffer("node", nullptr, node.data());
+            deserializer.parse();
+        };
+
+        CHECK_THROWS_WITH_AS(run(), doctest::Contains("Map expected."), std::exception);
+    }
 }
 
 } // namespace power_grid_model::meta_data


### PR DESCRIPTION
This fixes CVE-2026-76912. For further reading, please visit https://github.com/PowerGridModel/power-grid-model/security/advisories/GHSA-jch4-ggwc-h4q5 .