### PR TITLE
OpenSSF gold badge: UBSan hardening in CMakePresets.json

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -138,7 +138,7 @@ jobs:
   
     env:
       CMAKE_PREFIX_PATH: /usr/local
-      PRESET: ci-clang-${{ matrix.build-option }}
+      PRESET: ci-apple-clang-${{ matrix.build-option }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -148,6 +148,9 @@
     {
       "name": "msvc-debug",
       "displayName": "Debug (MSVC)",
+      "environment": {
+        "SANITIZER_FLAGS": "/RTC1"
+      },
       "inherits": ["msvc-base", "debug"]
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
         "REPRODUCIBILITY_LINKER_FLAGS": "",
         "CFLAGS": "$penv{CFLAGS} $env{PLATFORM_C_FLAGS} $env{COMPILER_C_FLAGS} $env{COVERAGE_FLAGS} $env{SANITIZER_FLAGS} $env{REPRODUCIBILITY_COMMON_FLAGS}",
         "CXXFLAGS": "$penv{CXXFLAGS} $env{PLATFORM_CXX_FLAGS} $env{COMPILER_CXX_FLAGS} $env{COVERAGE_FLAGS} $env{SANITIZER_FLAGS} $env{REPRODUCIBILITY_COMMON_FLAGS}",
-        "LDFLAGS": "$env{PLATFORM_LINKER_FLAGS} $env{SANITIZER_FLAGS} $env{REPRODUCIBILITY_LINKER_FLAGS} $env{REPRODUCIBILITY_LINKER_FLAGS}"
+        "LDFLAGS": "$env{PLATFORM_LINKER_FLAGS} $env{SANITIZER_FLAGS} $env{SANITIZER_LINKER_FLAGS} $env{REPRODUCIBILITY_LINKER_FLAGS} $env{REPRODUCIBILITY_LINKER_FLAGS}"
       },
       "architecture": {
         "value": "x64",
@@ -169,21 +169,51 @@
       "inherits": ["clang-cl-base", "relwithdebinfo"]
     },
     {
-      "name": "clang-base",
+      "name": "clang-linux-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "environment": {
+        "SANITIZER_LINKER_FLAGS": "-lubsan"
+      },
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": "unix-sanitizer",
+      "hidden": true
+    },
+    {
+      "name": "apple-clang-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
       },
       "inherits": "unix-sanitizer",
       "hidden": true
     },
     {
       "name": "clang-debug",
-      "inherits": ["debug", "clang-base"]
+      "inherits": ["debug", "clang-linux-base"]
     },
     {
       "name": "clang-release",
-      "inherits": ["relwithdebinfo", "clang-base"]
+      "inherits": ["relwithdebinfo", "clang-linux-base"]
+    },
+    {
+      "name": "apple-clang-debug",
+      "inherits": ["debug", "apple-clang-base"]
+    },
+    {
+      "name": "apple-clang-release",
+      "inherits": ["relwithdebinfo", "apple-clang-base"]
     },
     {
       "name": "clang-tidy-debug",
@@ -206,13 +236,19 @@
     {
       "name": "gcc-base",
       "environment": {
-        "COMPILER_CXX_FLAGS": "$env{COMPILER_C_FLAGS} -Wno-maybe-uninitialized"
+        "COMPILER_CXX_FLAGS": "$env{COMPILER_C_FLAGS} -Wno-maybe-uninitialized",
+        "SANITIZER_LINKER_FLAGS": "-static-libubsan"
       },
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++"
       },
       "inherits": "unix-sanitizer",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
       "hidden": true
     },
     {
@@ -230,6 +266,17 @@
     {
       "name": "ci-clang-release",
       "inherits": "clang-release",
+      "cacheVariables": {
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
+      }
+    },
+    {
+      "name": "ci-apple-clang-debug",
+      "inherits": ["apple-clang-debug", "unix-coverage"]
+    },
+    {
+      "name": "ci-apple-clang-release",
+      "inherits": "apple-clang-release",
       "cacheVariables": {
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "TRUE"
       }
@@ -253,7 +300,7 @@
     },
     {
       "name": "ci-sonar",
-      "inherits": ["clang-base", "debug", "unix-coverage"]
+      "inherits": ["clang-linux-base", "debug", "unix-coverage"]
     },
     {
       "name": "ci-clang-tidy-debug",
@@ -296,7 +343,7 @@
     },
     {
       "name": "ci-clang-reproducible",
-      "inherits": ["clang-base", "release"],
+      "inherits": ["clang-linux-base", "release"],
       "environment": {
         "REPRODUCIBILITY_COMMON_FLAGS": "$penv{REPRODUCIBILITY_COMMON_FLAGS} -frandom-seed=0 -Wdate-time"
       },
@@ -340,6 +387,14 @@
       "configurePreset": "clang-release"
     },
     {
+      "name": "apple-clang-debug",
+      "configurePreset": "apple-clang-debug"
+    },
+    {
+      "name": "apple-clang-release",
+      "configurePreset": "apple-clang-release"
+    },
+    {
       "name": "clang-tidy-debug",
       "configurePreset": "clang-tidy-debug"
     },
@@ -370,6 +425,14 @@
     {
       "name": "ci-clang-release",
       "configurePreset": "ci-clang-release"
+    },
+    {
+      "name": "ci-apple-clang-debug",
+      "configurePreset": "ci-apple-clang-debug"
+    },
+    {
+      "name": "ci-apple-clang-release",
+      "configurePreset": "ci-apple-clang-release"
     },
     {
       "name": "ci-gcc-debug",
@@ -438,6 +501,14 @@
       "configurePreset": "clang-release"
     },
     {
+      "name": "apple-clang-debug",
+      "configurePreset": "apple-clang-debug"
+    },
+    {
+      "name": "apple-clang-release",
+      "configurePreset": "apple-clang-release"
+    },
+    {
       "name": "clang-tidy-debug",
       "configurePreset": "clang-tidy-debug"
     },
@@ -468,6 +539,14 @@
     {
       "name": "ci-clang-release",
       "configurePreset": "ci-clang-release"
+    },
+    {
+      "name": "ci-apple-clang-debug",
+      "configurePreset": "ci-apple-clang-debug"
+    },
+    {
+      "name": "ci-apple-clang-release",
+      "configurePreset": "ci-apple-clang-release"
     },
     {
       "name": "ci-gcc-debug",
@@ -624,6 +703,23 @@
         {
           "type": "test",
           "name": "clang-release"
+        }
+      ]
+    },
+    {
+      "name": "apple-clang-release",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "apple-clang-release"
+        },
+        {
+          "type": "build",
+          "name": "apple-clang-release"
+        },
+        {
+          "type": "test",
+          "name": "apple-clang-release"
         }
       ]
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -120,7 +120,7 @@
     {
       "name": "unix-sanitizer",
       "environment": {
-        "SANITIZER_FLAGS": "-fsanitize=address"
+        "SANITIZER_FLAGS": "-fstack-protector -fsanitize=address,pointer-compare,undefined -fno-sanitize-recover"
       },
       "inherits": "unix-base",
       "hidden": true

--- a/tests/package_tests/CMakePresets.json
+++ b/tests/package_tests/CMakePresets.json
@@ -118,6 +118,16 @@
       "hidden": true
     },
     {
+      "name": "apple-clang-base",
+      "inherits": ["clang-base"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "hidden": true
+    },
+    {
       "name": "gcc-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc",
@@ -132,6 +142,14 @@
     {
       "name": "ci-clang-release",
       "inherits": ["unix-sanitizer", "clang-base", "release"]
+    },
+    {
+      "name": "ci-apple-clang-debug",
+      "inherits": ["unix-sanitizer", "apple-clang-base", "debug"]
+    },
+    {
+      "name": "ci-apple-clang-release",
+      "inherits": ["unix-sanitizer", "apple-clang-base", "release"]
     },
     {
       "name": "ci-gcc-debug",
@@ -170,6 +188,14 @@
     {
       "name": "ci-clang-release",
       "configurePreset": "ci-clang-release"
+    },
+    {
+      "name": "ci-apple-clang-debug",
+      "configurePreset": "ci-apple-clang-debug"
+    },
+    {
+      "name": "ci-apple-clang-release",
+      "configurePreset": "ci-apple-clang-release"
     },
     {
       "name": "ci-gcc-debug",


### PR DESCRIPTION
This replaces the always-on hardening proposed in #1241 as that requires more discussions.

In the meantime, we can already get the benefits of getting hardening in the C/C++ tests.

## Testing

To test that it works, you can create

```cpp
TEST_CASE("Test UBSan") {
    int k = 0x7fffffff;
    k += 1;
    CHECK(k == 0x00000000); // overflow has occurred
}
```

If UBSan is correctly enabled, you should get something along the lines of
```cpp
ctest]     Start 64: Counting Iterator
[ctest] 1/1 Test #64: Counting Iterator ................Subprocess aborted***Exception:   0.07 sec
[ctest] tests/cpp_unit_tests/common/test_counting_iterator.cpp:15:7: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
[ctest] SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/cpp_unit_tests/common/test_counting_iterator.cpp:15:7 
```