### PR TITLE
Nightly: fix apple clang reproducible build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -353,10 +353,11 @@
     },
     {
       "name": "ci-apple-clang-reproducible",
-      "inherits": "ci-clang-reproducible",
+      "inherits": ["apple-clang-base", "release"],
       "environment": {
         "SOURCE_DATE_EPOCH": "1",
         "DSYMUTIL": "",
+        "REPRODUCIBILITY_COMMON_FLAGS": "$penv{REPRODUCIBILITY_COMMON_FLAGS} -frandom-seed=0 -Wdate-time",
         "REPRODUCIBILITY_LINKER_FLAGS": "-Wl,-no_uuid -Wl,-S"
       }
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -359,6 +359,9 @@
         "DSYMUTIL": "",
         "REPRODUCIBILITY_COMMON_FLAGS": "$penv{REPRODUCIBILITY_COMMON_FLAGS} -frandom-seed=0 -Wdate-time",
         "REPRODUCIBILITY_LINKER_FLAGS": "-Wl,-no_uuid -Wl,-S"
+      },
+      "cacheVariables": {
+        "PGM_ENABLE_DEV_BUILD": "OFF"
       }
     }
   ],


### PR DESCRIPTION
Fix the reproducible build for Apple Clang (failure introduced in #1481 )

NOTE: the MSVC reproducible build may still fail. This is potentially intermittent (as it has been before)

* [x] Test running in https://github.com/PowerGridModel/power-grid-model/actions/runs/29988816918