### PR TITLE
Document performance scalability

### DIFF
--- a/docs/user_manual/performance-guide.md
+++ b/docs/user_manual/performance-guide.md
@@ -22,6 +22,10 @@ This guide focuses on system-level performance optimization (batching, caching, 
 For algorithm-level details such as calculation method selection, see the [Calculations](calculations.md) documentation.
 ```
 
+## Scalability
+
+PGM scales linearly with respect to the problem size.
+
 ## Data validity
 
 Many of our optimizations assume input data validity and rely on the fact that the provided grid is reasonably close to


### PR DESCRIPTION
## Summary

- Add a dedicated scalability section to the performance guide.
- State the qualitative scalability conclusion requested in #1096, without reintroducing the superseded quantitative analysis.

## Validation

- `npx --no-install markdownlint docs/user_manual/performance-guide.md`
- `.venv\Scripts\reuse.exe lint`
- `git diff --check upstream/main...HEAD`
- `sphinx-build -W --keep-going -b html docs docs\_build\html` was attempted locally; the build could not complete because the generated Doxygen XML file `docs/doxygen/build/xml/index.xml` is absent in the local environment. The hosted documentation check will provide full Sphinx validation.

## AI assistance

OpenAI Codex assisted with repository navigation, scope verification, drafting, and validation. I reviewed and understand the change and remain responsible for the contribution.

Assisted-by: OpenAI Codex

Closes #1096