### PR TITLE
Temporarily skip clang-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
   reuse-compliance:
     uses: "./.github/workflows/reuse-compliance.yml"
 
-  clang-tidy:
-    uses: "./.github/workflows/clang-tidy.yml"
-    with:
-      target: "all"
+  # clang-tidy:
+  #   uses: "./.github/workflows/clang-tidy.yml"
+  #   with:
+  #     target: "all"
 
   ci-passed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Latest clang-tidy is failing. 

At most one of https://github.com/PowerGridModel/power-grid-model/pull/1541 and https://github.com/PowerGridModel/power-grid-model/pull/1542 can be merged.