### PR TITLE
Pin to earlier pgm dep

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -63,7 +63,7 @@ jobs:
       
       - name: Install pgm-build-deps
         run: |
-          uv tool install pgm-build-deps
+          uv tool install pgm-build-deps@2026.08.10.64
           pgm-build-setup-ga-ci
 
       - name: Set build target in case of workflow dispatch


### PR DESCRIPTION
Clang-tidy is failing. Pin to earlier pgm dep version to avoid disabling clang-tidy all together.

At most one of https://github.com/PowerGridModel/power-grid-model/pull/1541 and https://github.com/PowerGridModel/power-grid-model/pull/1542 can be merged.