### PR TITLE
Fix/result production performance

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/math_output_queries.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/math_output_queries.hpp
@@ -20,11 +20,11 @@
 namespace power_grid_model::main_core {
 
 template <typename Component, solver_output_type SolverOutputType>
-constexpr auto get_component_output(MathOutput<std::vector<SolverOutputType>> const& math_output,
-                                    Idx2D const& math_id) {
+constexpr auto const& get_component_output(MathOutput<std::vector<SolverOutputType>> const& math_output,
+                                           Idx2D const& math_id) {
     auto const& solver_output = math_output.solver_output[math_id.group];
 
-    auto const& component_type_output = [&solver_output] {
+    auto const& component_type_output = [&solver_output]() -> auto const& {
         if constexpr (std::derived_from<Component, Branch> || std::derived_from<Component, Branch3>) {
             return solver_output.branch;
         } else if constexpr (std::same_as<Component, Source> && requires { solver_output.source; }) {


### PR DESCRIPTION
While looking into something else entirely, I got curious about where the time actually goes when a
batch calculation writes out its results. I assumed it would be spread fairly evenly over writing
the node, branch and appliance records. It wasn't. Nearly all of it sat in one loop, and at a rate
that didn't add up: adding a single complex number onto a node was costing something like sixty
times more than computing and writing that same appliance's entire output record.

That seemed odd enough to chase down. It turned out to be two separate things, one big and one
small.

## The big one: the whole result vector gets copied for every single value read

`get_component_output()` returns one element out of one of the solver's result containers. It picks
which container using a small lambda:

```cpp
auto const& component_type_output = [&solver_output] {
    ...
    return solver_output.load_gen;   // a std::vector
}();
return component_type_output[math_id.pos];
```

The lambda has no explicit return type, so `auto` deduction drops the reference and that `return`
copy-constructs the entire vector. The `auto const&` on the outside then binds to the copy and
extends its lifetime, which looks like it is avoiding a copy but isn't — the copy has already
happened.

So every call allocates, copies the whole container, reads one element out of the copy, and throws
it away. Its only caller runs once per appliance while totalling injections onto nodes, so with N
appliances each scenario performs N copies of an N-element vector. Quadratic, where plain indexing
was obviously the intent.

The fix is just to write the return type out — `auto const&` on the lambda and on the function. What
comes back is then a reference into `math_output.solver_output[group]`, which the caller owns and
which outlives the call.

Since the waste grew with the square of the appliance count, larger models were quietly paying much
more than the grid I measured on.

## The small one: a heap allocation per node, per scenario

With that out of the way, what remained was the step that builds the per-node output vectors. Each
node gets a vector holding one value per user node — but a node only ever holds more than one when
links have merged several nodes into one. In a grid without links, every single one of them holds
exactly one number.

So the code was asking the allocator for room to store one complex number, once per node, for every
scenario. In the benchmark grid that is 2605 allocate-and-free pairs per scenario, roughly 2.6
million across a 1000-scenario batch. The ~37 ns per node I measured is a malloc, not arithmetic.

`boost::container::small_vector<ComplexValue<sym>, 1>` keeps room for one value inside the object
itself and only goes to the heap beyond that. That's why the inline size is 1: it covers the
ordinary node exactly, and merged nodes still work, they just allocate as before. Boost is already a
required dependency here (`supernodes.hpp` and `topology.hpp` use Boost.Graph) and `small_vector` is
header-only.

## Why I believe this is safe

The second change alters a member's type, so that's the one worth being suspicious of. I tried
fairly hard to prove it wrong before accepting it.

There is exactly one place in the tree that constructs this member. Everywhere else only indexes
into it, and `[i]` behaves identically for a `std::vector` and a `small_vector`. Worth mentioning
that three unrelated things in this codebase are called `bus_injection`, and most of the search hits
belong to `SolverOutput`, which this doesn't touch at all.

The same function has a second branch for short-circuit output, and that specialisation of the
struct has no `bus_injection` member in the first place, so there is nothing there to affect.

And if I had missed a site somewhere, it would not quietly do the wrong thing: `small_vector` has no
converting constructor from `std::vector`, so anything left over would be a hard compile error
rather than a silent conversion. I checked that directly instead of assuming it. The project builds
with warnings as errors, so there was nowhere for a missed site to hide.

The case I was most worried about is a node holding more than one value, since that is where the
inline capacity spills to the heap. The `handling-of-links` validation cases cover exactly that, and
they pass unchanged.

The first change I'd argue is safe more simply: the same element is read either way, just without
the copy wrapped around it.

## Numbers

`tests/benchmark_cpp`, radial grid, 2605 nodes, batch of 1000 scenarios, symmetric Newton-Raphson,
MSVC `/O2`. Clean builds of `main` and of this branch with no measuring code in either, medians of
four runs:

| | median | min | max |
|---|---:|---:|---:|
| `main` | 3.636 s | 3.392 s | 3.742 s |
| this branch | **2.232 s** | 2.181 s | 2.293 s |

That's **1.63x faster, 38.6 % less total time**.

I also ran a separate build with temporary timers inside result production to confirm the saving
really came from these two places rather than from something else moving. Those timers are not part
of this PR. They attribute 1.33 s to these two steps against the 1.40 s measured end to end, and a
neighbouring step that neither change touches stayed flat across both, so I don't think this is just
the machine having a good day.

## Testing

All ten C++ test suites pass, 177415 assertions, built with warnings as errors. That includes the
validation data set and the link cases mentioned above.
`tests/cpp_unit_tests/main_core/test_topological_node_output.cpp` covers this code directly and
passes unchanged.

Happy to split this into two PRs if you'd prefer them reviewed separately — the first commit is a
bug fix and the second is an optimisation, and they're independent.

## Note for maintainers

This needs a label to satisfy `check-pr-labels`, and I can't add one myself. The first commit is a
`bug`, the second an `improvement`.

Assisted-by: Claude (Anthropic)