### PR TITLE
Merge links into nodes: Fix performance regression topological node output

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topological_node_output.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/topological_node_output.hpp
@@ -162,6 +162,10 @@ template <symmetry_tag sym, typename LinkSolver>
     requires std::invocable<LinkSolver, std::vector<BranchIdx>, ComplexVector>
 ComplexValueVector<sym> compute_link_solver(LinkSolver link_solver,
                                             SuperNodeSolverInput<sym> const& super_node_solver_input) {
+    if (std::ranges::empty(super_node_solver_input.links)) {
+        return {};
+    }
+
     if constexpr (is_symmetric_v<sym>) {
         return link_solver(super_node_solver_input.links | std::ranges::to<std::vector>(),
                            super_node_solver_input.get_total_injection_per_node());
@@ -199,18 +203,15 @@ template <symmetry_tag sym, typename BranchSolverOutputType>
               std::same_as<BranchSolverOutputType,
                            BranchShortCircuitSolverOutput<decode_symmetry_v<BranchSolverOutputType>>>)
 std::vector<BranchSolverOutputType> get_link_output(ComplexValueVector<sym> const& link_solver_result) {
-    std::vector<BranchSolverOutputType> link_output;
-    link_output.reserve(link_solver_result.size());
-
-    for (auto const& result : link_solver_result) {
-        if constexpr (std::same_as<BranchSolverOutputType,
-                                   BranchSolverOutput<decode_symmetry_v<BranchSolverOutputType>>>) {
-            link_output.emplace_back(BranchSolverOutputType{.s_f = result, .s_t = -result});
-        } else {
-            link_output.emplace_back(BranchSolverOutputType{.i_f = result, .i_t = -result});
-        }
-    }
-    return link_output;
+    return link_solver_result | std::views::transform([](auto const& result) -> BranchSolverOutputType {
+               if constexpr (std::same_as<BranchSolverOutputType,
+                                          BranchSolverOutput<decode_symmetry_v<BranchSolverOutputType>>>) {
+                   return BranchSolverOutputType{.s_f = result, .s_t = -result};
+               } else {
+                   return BranchSolverOutputType{.i_f = result, .i_t = -result};
+               }
+           }) |
+           std::ranges::to<std::vector>();
 }
 
 template <typename LinkSolver, main_model_state_c State, solver_output_type SolverOutput>

--- a/tests/cpp_unit_tests/main_core/test_topological_node_output.cpp
+++ b/tests/cpp_unit_tests/main_core/test_topological_node_output.cpp
@@ -524,12 +524,10 @@ TEST_CASE("Test topological node output") {
 
             auto const result = detail::solve_topological_nodes(std::ref(mock), state, math_output);
 
-            REQUIRE(mock.call_count == 2);
+            REQUIRE(mock.call_count == 1);
             CHECK(mock.recorded_edges[0] == links);
-            CHECK(mock.recorded_edges[1].empty());
             CHECK(mock.recorded_loads[0] ==
                   ComplexVector{DoubleComplex{}, -dummy_complex_value_sym(), dummy_complex_value_sym()});
-            CHECK(mock.recorded_loads[1] == ComplexVector{DoubleComplex{}});
 
             REQUIRE(result.size() == 2);
             CHECK(result[0].bus_injection ==
@@ -558,12 +556,10 @@ TEST_CASE("Test topological node output") {
 
             auto const result = detail::solve_topological_nodes(std::ref(mock), state, math_output);
 
-            REQUIRE(mock.call_count == 2);
+            REQUIRE(mock.call_count == 1);
             CHECK(mock.recorded_edges[0] == links);
-            CHECK(mock.recorded_edges[1].empty());
             CHECK(mock.recorded_loads[0] ==
                   ComplexVector{dummy_complex_value_sym(), -dummy_complex_value_sym(), DoubleComplex{}});
-            CHECK(mock.recorded_loads[1] == ComplexVector{DoubleComplex{}});
 
             REQUIRE(result.size() == 2);
             REQUIRE(result[0].link.size() == 2);


### PR DESCRIPTION
Fixes #1554 

Relates to #1555

There are potentially some other locations remaining where SmallVector can make a difference (in particular, topological node construction on the input side and the vectors internally in the link solver implementation), but for that, #1555 needs to be merged first. This fix is standalone. Instead, this PR fixes on the big fish.

Credits to @marhofmann for finding the issue.