### PR TITLE
Disable msvc reproducibility check temporarily 

### DIFF
--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        compiler: [msvc, clang-cl]
+        compiler: [clang-cl]
 
     env:
       PRESET: ci-${{ matrix.compiler }}-reproducible
@@ -96,7 +96,6 @@ jobs:
           uv tool install pgm-build-deps
           pgm-build-setup-ga-ci
 
-      - uses: ./.github/actions/enable-msvc
 
       - name: Build twice
         run: |


### PR DESCRIPTION
Our nightly build intermittently fails because of reproducible build with msvc does not succeed. 
Since clang-cl succeeds, there is atleast some way possible for windows users to get reproducible builds. 
Hence lets disable this check, fix reproduciblity and then re-enable it again