### PR TITLE
Fix: Restore Voltage Regulator warning regarding support for NR only

### DIFF
--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -1294,6 +1294,7 @@ voltage magnitude at the node follows `u_ref`.
 ```{warning}
 Voltage regulation is supported only by the [Newton-Raphson power flow](./calculations.md#newton-raphson-power-flow)
 method.
+```
 
 ```{note}
 If `q_min` and/or `q_max` are specified, the calculated reactive power is checked against these limits. If the required

--- a/docs/user_manual/components.md
+++ b/docs/user_manual/components.md
@@ -1291,6 +1291,7 @@ calculations, an active voltage regulator makes the connection node a voltage-co
 the regulated object remains specified by the load/generator input, while the reactive power is calculated so that the
 voltage magnitude at the node follows `u_ref`.
 
+```{warning}
 Voltage regulation is supported only by the [Newton-Raphson power flow](./calculations.md#newton-raphson-power-flow)
 method.
 


### PR DESCRIPTION
In PR #1452 a warning was unintentionally removed and the comment https://github.com/PowerGridModel/power-grid-model/pull/1452#discussion_r3504944692 remained unresolved.

In my opinion it should be a warning, but at-least it should be a note to make it more visible.