### PR TITLE
Merge links into nodes: fix pseudo branch registration order

### DIFF
--- a/power_grid_model_c/power_grid_model/include/power_grid_model/all_components.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/all_components.hpp
@@ -35,7 +35,7 @@
 
 namespace power_grid_model {
 
-using AllComponents = ComponentList<Node, Line, AsymLine, Link, GenericBranch, Transformer, ThreeWindingTransformer,
+using AllComponents = ComponentList<Node, Line, AsymLine, GenericBranch, Transformer, Link, ThreeWindingTransformer,
                                     Shunt, Source, SymGenerator, AsymGenerator, SymLoad, AsymLoad, SymPowerSensor,
                                     AsymPowerSensor, SymVoltageSensor, AsymVoltageSensor, SymCurrentSensor,
                                     AsymCurrentSensor, Fault, TransformerTapRegulator, VoltageRegulator>;

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_preparation.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/calculation_preparation.hpp
@@ -138,7 +138,8 @@ inline void rebuild_topology(typename ModelType::MainModelState& state, SolverPr
     // Determine the path based on whether link_node_idx is populated (new path) or empty (old path)
     // link_node_idx being non-empty means new path where links are separated (no node injection sensors)
     // link_node_idx being empty means old path where all edges treated as branches (has node injection sensors)
-    bool const has_node_injection_sensors = state.comp_topo->link_node_idx.empty();
+    bool const has_node_injection_sensors = state.comp_topo->link_node_idx.empty() &&
+                                            !std::ranges::empty(main_core::get_component_citer<Link>(state.components));
     ComponentConnections const comp_conn =
         main_core::construct_components_connections<ModelType>(state.components, has_node_injection_sensors);
 

--- a/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
+++ b/power_grid_model_c/power_grid_model/include/power_grid_model/main_core/state_queries.hpp
@@ -103,11 +103,12 @@ template <std::same_as<Link> Component, class ComponentContainer>
 constexpr auto comp_base_sequence_cbegin(MainModelState<ComponentContainer> const& state) {
     auto const& link_topo_ids = state.reduced_topology->topo_node_coup.coupling.user_links_to_topo_nodes;
     // TODO(jguo): cleanup v2 node single link registration path
-    if (std::ranges::ssize(link_topo_ids) == get_component_size<Link>(state.components)) {
-        // TODO(mgovers): cleanup v2: keep only this path: links are not branches
-        return link_topo_ids.cbegin();
+    if (std::ranges::empty(link_topo_ids)) {
+        return state.topo_comp_coup->branch.cbegin() + get_component_sequence_offset<Edge, Link>(state.components);
     }
-    return state.topo_comp_coup->branch.cbegin() + get_component_sequence_offset<Edge, Link>(state.components);
+    // TODO(mgovers): cleanup v2: keep only this path: links are not branches
+    assert(std::ranges::ssize(link_topo_ids) == get_component_size<Link>(state.components));
+    return link_topo_ids.cbegin();
 }
 
 template <std::derived_from<Branch3> Component, class ComponentContainer>


### PR DESCRIPTION
In the backwards-compatible code path, links are registered as pseudo-branches, similar to how three-winding transformers are registered as pseudo-branches. However, all pseudo-branches need to be registered strictly after all "regular" branches are registered. This was a bug in #1550 